### PR TITLE
Feature/fix doc

### DIFF
--- a/docs/source/getting_started/getting_started_with_corese-core.md
+++ b/docs/source/getting_started/getting_started_with_corese-core.md
@@ -77,6 +77,10 @@ graph.addEdge(edithPiafIRI, lastNameProperty, piafLiteral);
 This example shows how to load a graph from a file.
 
 ```java
+import fr.inria.corese.core.Graph ;
+import fr.inria.corese.core.load.Load;
+import fr.inria.corese.core.api.Loader;
+
 // Create a new empty Graph
 Graph graph = Graph.create();
 

--- a/docs/source/getting_started/getting_started_with_corese-core.md
+++ b/docs/source/getting_started/getting_started_with_corese-core.md
@@ -82,18 +82,18 @@ Graph graph = Graph.create();
 
 // Create loader and parse file
 Load loader = Load.create(graph);
-loader.parse("input_graph_file.ttl", Load.format.TURTLE_FORMAT);
+loader.parse("input_graph_file.ttl", Loader.format.TURTLE_FORMAT);
 ```
 
 Corese Loader supports the following formats:
 
-- RDF/XML (`Load.format.RDFXML_FORMAT`)
-- Turtle (`Load.format.TURTLE_FORMAT`)
-- TriG (`Load.format.TRIG_FORMAT`)
-- JSON-LD (`Load.format.JSONLD_FORMAT`)
-- N-Triples (`Load.format.NT_FORMAT`)
-- N-Quads (`Load.format.NQUADS_FORMAT`)
-- RDFa (`Load.format.RDFA_FORMAT`)
+- RDF/XML (`Loader.format.RDFXML_FORMAT`)
+- Turtle (`Loader.format.TURTLE_FORMAT`)
+- TriG (`Loader.format.TRIG_FORMAT`)
+- JSON-LD (`Loader.format.JSONLD_FORMAT`)
+- N-Triples (`Loader.format.NT_FORMAT`)
+- N-Quads (`Loader.format.NQUADS_FORMAT`)
+- RDFa (`Loader.format.RDFA_FORMAT`)
 
 ### **2.3. Export a Graph to a File**
 


### PR DESCRIPTION
Just a minor fix on the documentation. In the "Getting started" - " Load a Graph from a file" section, I found out while trying to do it, and also looking on the Java doc, that the `format` field belonged to the `Loader` class and not to the `Load` class.

I suggest two fixes on this specific part of the doc only
- Load.format to Loader.format
- also add the import for this case since there may be confusions otherwise
