### PR TITLE
statements and converter fixes and tests

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/api/base/model/AbstractStatement.java
+++ b/src/main/java/fr/inria/corese/core/next/api/base/model/AbstractStatement.java
@@ -1,0 +1,68 @@
+package fr.inria.corese.core.next.api.base.model;
+
+import fr.inria.corese.core.next.api.Statement;
+import java.util.Objects;
+
+/**
+ * An abstract implementation of the {@link Statement} interface.
+ * This class provides default implementations for the {@code equals}, {@code hashCode},
+ * and {@code toString} methods based on the subject, predicate, object, and context of the statement.
+ *
+ * <p>Any subclass of {@code AbstractStatement} should implement the methods from the
+ * {@code Statement} interface such as {@code getSubject}, {@code getPredicate}, {@code getObject},
+ * and {@code getContext} to represent a specific type of statement.</p>
+ *
+ * <p>This class ensures that statements are compared correctly, generate a proper hash code,
+ * and provide a meaningful string representation.</p>
+ */
+
+public abstract class AbstractStatement implements Statement {
+
+    /**
+     * Compares this statement to another object for equality.
+     * Two statements are considered equal if they have the same subject, predicate, object, and context.
+     *
+     * @param obj the object to compare this statement to.
+     * @return {@code true} if the statements are equal, otherwise {@code false}.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof Statement
+                && getObject().equals(((Statement) obj).getObject())
+                && getSubject().equals(((Statement) obj).getSubject())
+                && getPredicate().equals(((Statement) obj).getPredicate())
+                && Objects.equals(getContext(), ((Statement) obj).getContext());
+    }
+
+    /**
+     * Returns the hash code value for this statement.
+     * The hash code is computed based on the subject, predicate, object, and context of the statement.
+     *
+     * @return the hash code value for this statement.
+     */
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + (getSubject() == null ? 0 : getSubject().hashCode());
+        hash = 31 * hash + (getPredicate() == null ? 0 : getPredicate().hashCode());
+        hash = 31 * hash + (getObject() == null ? 0 : getObject().hashCode());
+        hash = 31 * hash + (getContext() == null ? 0 : getContext().hashCode());
+        return hash;
+    }
+
+    /**
+     * Returns a string representation of this statement.
+     * The string representation includes the subject, predicate, object, and context (if present).
+     *
+     * @return a string representation of this statement.
+     */
+    @Override
+    public String toString() {
+        return "("
+                + getSubject()
+                + ", " + getPredicate()
+                + ", " + getObject()
+                + (getContext() == null ? "" : ", " + getContext())
+                + ")";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseAdaptedValueFactory.java
+++ b/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseAdaptedValueFactory.java
@@ -4,6 +4,7 @@ import fr.inria.corese.core.next.api.*;
 import fr.inria.corese.core.next.api.base.model.literal.AbstractLiteral;
 import fr.inria.corese.core.next.impl.common.literal.XSD;
 import fr.inria.corese.core.next.api.literal.CoreDatatype;
+import fr.inria.corese.core.next.impl.exception.InternalException;
 import fr.inria.corese.core.next.impl.temp.literal.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -333,14 +334,52 @@ public class CoreseAdaptedValueFactory implements ValueFactory {
         return new CoreseDate(date);
     }
 
+    /**
+     * Creates a {@link Statement} with a subject, predicate, and object, and no context.
+     * This method is used to create a simple RDF-like statement where the context is not provided.
+     * @param subject the subject of the statement (cannot be null)
+     * @param predicate the predicate of the statement (cannot be null)
+     * @param object the object of the statement (cannot be null)
+     * @return a new {@link CoreseStatement} with the given subject, predicate, and object, and no context
+     * @throws InternalException if any of the parameters are {@code null}
+     */
     @Override
     public Statement createStatement(Resource subject, IRI predicate, Value object) {
-        throw new UnsupportedOperationException("Not supported yet.");
+
+        if (subject == null) {
+            throw new InternalException("Subject cannot be null");
+        }
+        if (predicate == null) {
+            throw new InternalException("Predicate cannot be null");
+        }
+        if (object == null) {
+            throw new InternalException("Object cannot be null");
+        }
+        return new CoreseStatement(subject, predicate, object, null);
     }
 
+    /**
+     * Creates a {@link Statement} with a subject, predicate, object, and context.
+     * This method is used to create an RDF-like statement with a specified context (graph).
+     * @param subject the subject of the statement (cannot be null)
+     * @param predicate the predicate of the statement (cannot be null)
+     * @param object the object of the statement (cannot be null)
+     * @param context the context (graph) of the statement (can be null)
+     * @return a new {@link CoreseStatement} with the given subject, predicate, object, and context
+     * @throws InternalException if any of the parameters are {@code null}
+     */
     @Override
     public Statement createStatement(Resource subject, IRI predicate, Value object, Resource context) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (subject == null) {
+            throw new InternalException("Subject cannot be null");
+        }
+        if (predicate == null) {
+            throw new InternalException("Predicate cannot be null");
+        }
+        if (object == null) {
+            throw new InternalException("Object cannot be null");
+        }
+        return new CoreseStatement(subject, predicate, object, context);
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseConverter.java
+++ b/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseConverter.java
@@ -1,0 +1,110 @@
+package fr.inria.corese.core.next.impl.temp;
+
+import fr.inria.corese.core.kgram.api.core.Node;
+import fr.inria.corese.core.next.api.IRI;
+import fr.inria.corese.core.next.api.Literal;
+import fr.inria.corese.core.next.api.Resource;
+import fr.inria.corese.core.next.api.Value;
+import fr.inria.corese.core.next.impl.exception.InternalException;
+import fr.inria.corese.core.next.impl.temp.literal.*;
+import fr.inria.corese.core.sparql.api.IDatatype;
+
+/**
+ * A utility class for converting between Corese-specific data types and next Corese API representations.
+ * This class provides methods to convert Corese nodes to next Corese API values and vice versa.
+ *
+ * <p>The class includes two main methods:
+ * <ul>
+ * <li>{@link #coreseNodeToRdf4jValue(Node)}: Converts a Corese {@link Node} to a next Corese API {@link Value}.</li>
+ * <li>{@link #convert(Value)}: Converts a next Corese API {@link Value} to a corresponding Corese {@link Node}.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>Additionally, the {@link #convert(IDatatype)} method handles conversions from various Corese data types
+ * (such as CoreseBoolean, CoreseDate, CoreseInteger, and CoreseLiteral) to RDF4J literals.</p>
+ */
+public class CoreseConverter {
+
+    static CoreseAdaptedValueFactory factory = new CoreseAdaptedValueFactory();
+
+    /**
+     * Converts a Corese {@link Node} to an next API {@link Value}.
+     * This method extracts the Corese datatype value and returns the corresponding next API value.
+     *
+     * @param corese_node the Corese {@link Node} to be converted (can be null)
+     * @return the corresponding next API {@link Value} (can be null if input is null)
+     */
+    public static Value coreseNodeToRdf4jValue(Node corese_node) {
+        if (corese_node == null) {
+            return null;
+        }
+        return convert(corese_node.getDatatypeValue());
+    }
+
+    /**
+     * Converts a Corese {@link IDatatype} to a next API {@link Value}.
+     *
+     * @param oldCoreseDatatype the Corese {@link IDatatype} to be converted
+     * @return the corresponding next API {@link Value}
+     * @throws InternalException if the provided datatype is not recognized
+     */
+    public static Value convert(IDatatype oldCoreseDatatype) {
+        if (oldCoreseDatatype.isURI()) {
+            return new CoreseIRI(oldCoreseDatatype.stringValue());
+        }
+        else {
+            String datatypeStringURI  = oldCoreseDatatype.getDatatypeURI();
+            IRI datatypeStringIRI = factory.createIRI(datatypeStringURI);
+            return factory.createLiteral(oldCoreseDatatype.getLabel(), datatypeStringIRI);
+        }
+    }
+
+    /**
+     * Converts a next API {@link Value} to a corresponding Corese {@link Node}.
+     *
+     * @param value the next API {@link Value} to be converted
+     * @return the corresponding Corese {@link Node}
+     * @throws InternalException if the provided value is not recognized
+     */
+    public static Node convert(Value value) {
+
+        if (value.isIRI()) {
+            CoreseIRI coreseIRI = new CoreseIRI(value.stringValue());
+            return coreseIRI.getCoreseNode();
+        } else if (value.isLiteral()) {
+            Literal literal = (Literal) value;
+
+            if (literal instanceof AbstractCoreseNumber) {
+                return ((AbstractCoreseNumber) literal).getCoreseNode();
+            } else if (literal instanceof CoreseBoolean) {
+                return ((CoreseBoolean) literal).getCoreseNode();
+            } else if (literal instanceof CoreseDate) {
+                return ((CoreseDate) literal).getCoreseNode();
+            } else if (literal instanceof CoreseDatetime) {
+                return ((CoreseDatetime) literal).getCoreseNode();
+            } else if (literal instanceof CoreseDecimal) {
+                return ((CoreseDecimal) literal).getCoreseNode();
+            } else if (literal instanceof CoreseInteger) {
+                return ((CoreseInteger) literal).getCoreseNode();
+            } else if (literal instanceof CoreseDuration) {
+                return ((CoreseDuration) literal).getCoreseNode();
+            } else if (literal instanceof CoreseLanguageTaggedStringLiteral) {
+                return ((CoreseLanguageTaggedStringLiteral) literal).getCoreseNode();
+            } else if (literal instanceof CoreseTime) {
+                return ((CoreseTime) literal).getCoreseNode();
+            } else {
+                CoreseTyped coreseTyped = new CoreseTyped(value.stringValue());
+                return coreseTyped.getCoreseNode();
+            }
+        } else if (value.isResource()) {
+            Resource resource = (Resource) value;
+            if (resource instanceof CoreseIRI) {
+                return ((CoreseIRI) resource).getCoreseNode();
+            } else {
+                throw new InternalException("Unexpected value: " + resource);
+            }
+        } else {
+            throw new InternalException("Unexpected value: " + value);
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseEdgeAdapter.java
+++ b/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseEdgeAdapter.java
@@ -1,0 +1,19 @@
+package fr.inria.corese.core.next.impl.temp;
+
+import fr.inria.corese.core.kgram.api.core.Edge;
+
+/**
+ * Interface that defines a wrapper for classes that represent Corese edges.
+ * This interface provides a method to retrieve the corresponding Corese {@link Edge} representation
+ * for the implementing class.
+ *
+ */
+public interface CoreseEdgeAdapter {
+
+    /**
+     * Retrieves the Corese {@link Edge} associated with the implementing class.
+     *
+     * @return the Corese {@link Edge} representation.
+     */
+    Edge getCoreseEdge();
+}

--- a/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseStatement.java
+++ b/src/main/java/fr/inria/corese/core/next/impl/temp/CoreseStatement.java
@@ -1,0 +1,120 @@
+package fr.inria.corese.core.next.impl.temp;
+
+import fr.inria.corese.core.edge.EdgeImpl;
+import fr.inria.corese.core.kgram.api.core.Edge;
+import fr.inria.corese.core.kgram.api.core.Node;
+import fr.inria.corese.core.next.api.IRI;
+import fr.inria.corese.core.next.api.Resource;
+import fr.inria.corese.core.next.api.Value;
+import fr.inria.corese.core.next.api.base.model.AbstractStatement;
+
+/**
+ * Represents a statement in Corese. A Corese statement consists of a subject, predicate, object,
+ * and an optional context. This class provides methods to access these components
+ *
+ */
+public class CoreseStatement extends AbstractStatement implements CoreseEdgeAdapter {
+
+    private final Edge edge;
+    private final Resource subject;
+    private final IRI predicate;
+    private final Value object;
+    private final Resource context;
+
+    /**
+     * Constructs a {@link CoreseStatement} from a subject, predicate, object, and context.
+     *
+     *
+     * @param subject the subject of the statement (non-null)
+     * @param predicate the predicate of the statement (non-null)
+     * @param object the object of the statement (non-null)
+     * @param context the context (or graph) of the statement (can be null)
+     */
+    CoreseStatement(Resource subject, IRI predicate, Value object, Resource context) {
+        this.subject = subject;
+        this.predicate = predicate;
+        this.object = object;
+        this.context = context;
+
+        Node subjectNode = CoreseConverter.convert(subject);
+        Node predicateNode = CoreseConverter.convert(predicate);
+        Node objectNode = CoreseConverter.convert(object);
+        Node contextNode = (context != null) ? CoreseConverter.convert(context): null;
+
+        EdgeImpl edgeImpl = EdgeImpl.create(contextNode, subjectNode, predicateNode, objectNode);
+        this.edge = edgeImpl;
+    }
+
+    /**
+     * Constructs a {@link CoreseStatement} from an existing {@link Edge}.
+     * This constructor extracts the subject, predicate, object, and context from the provided
+     * {@link Edge} and initializes the fields of this statement accordingly.
+     *
+     * @param edge the existing {@link Edge} object that represents the statement in the V4 Corese API (non-null)
+     */
+    public CoreseStatement(Edge edge) {
+        if (edge == null) {
+            throw new IllegalArgumentException("Edge cannot be null");
+        }
+
+        Resource subject_corese = (Resource) CoreseConverter.coreseNodeToRdf4jValue(edge.getSubjectValue());
+        IRI predicate_corese = (IRI) CoreseConverter.coreseNodeToRdf4jValue(edge.getPredicateValue());
+        Value object_corese = CoreseConverter.coreseNodeToRdf4jValue(edge.getObjectValue());
+        Resource context_corese = (Resource) CoreseConverter.coreseNodeToRdf4jValue(edge.getGraph());
+
+        this.subject = subject_corese;
+        this.predicate = predicate_corese;
+        this.object = object_corese;
+        this.context = context_corese;
+        this.edge = edge;
+    }
+
+    /**
+     * Returns the subject of the statement.
+     *
+     * @return the subject of the statement
+     */
+    @Override
+    public Resource getSubject() {
+        return this.subject;
+    }
+
+    /**
+     * Returns the predicate of the statement.
+     *
+     * @return the predicate of the statement
+     */
+    @Override
+    public IRI getPredicate() {
+        return this.predicate;
+    }
+
+    /**
+     * Returns the object of the statement.
+     *
+     * @return the object of the statement
+     */
+    @Override
+    public Value getObject() {
+        return this.object;
+    }
+
+    /**
+     * Returns the context (graph) of the statement.
+     *
+     * @return the context of the statement (may be null if not provided)
+     */
+    @Override
+    public Resource getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the underlying Corese {@link Edge} that represents this statement.
+     *
+     * @return the Corese edge object
+     */
+    public Edge getCoreseEdge() {
+        return this.edge;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/impl/temp/literal/CoreseBoolean.java
+++ b/src/main/java/fr/inria/corese/core/next/impl/temp/literal/CoreseBoolean.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.impl.temp.literal;
 
+import fr.inria.corese.core.kgram.api.core.Node;
 import fr.inria.corese.core.next.impl.common.literal.XSD;
 import fr.inria.corese.core.next.api.base.model.literal.AbstractLiteral;
 import fr.inria.corese.core.next.api.literal.CoreDatatype;
@@ -109,5 +110,9 @@ public class CoreseBoolean extends AbstractLiteral {
      */
     public static CoreseBoolean valueOf(boolean value) {
         return value ? TRUE : FALSE;
+    }
+
+    public Node getCoreseNode() {
+        return this.coreseObject;
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/impl/temp/CoreseAdaptedValueFactoryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/impl/temp/CoreseAdaptedValueFactoryTest.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.next.impl.temp;
 
 import fr.inria.corese.core.next.api.IRI;
 import fr.inria.corese.core.next.api.Literal;
+import fr.inria.corese.core.next.api.Resource;
 import fr.inria.corese.core.next.impl.common.literal.RDF;
 import fr.inria.corese.core.next.impl.common.literal.XSD;
 import fr.inria.corese.core.next.api.model.ValueFactoryTest;
@@ -20,12 +21,18 @@ public class CoreseAdaptedValueFactoryTest extends ValueFactoryTest {
     private String stringTestValue;
     private IRI xsdStringIRI;
 
+    private Resource subject;
+    private IRI predicate;
+    private Resource context;
+
     @Before
     @Override
     public void setUp() {
         this.valueFactory = new CoreseAdaptedValueFactory();
         stringTestValue = "String value";
         xsdStringIRI = XSD.STRING.getIRI();
+        subject = new CoreseIRI("http://corese.com/subject");
+        predicate = new CoreseIRI("http://corese.com/predicate");
     }
 
     @Test
@@ -93,5 +100,29 @@ public class CoreseAdaptedValueFactoryTest extends ValueFactoryTest {
         assertTrue(literal instanceof CoreseTyped);
         assertEquals(stringTestValue, literal.getLabel());
         assertEquals(XSD.STRING, literal.getCoreDatatype());
+    }
+
+    @Test
+    public void testCreateStatementWithoutContext() {
+        Literal literal = valueFactory.createLiteral(stringTestValue, xsdStringIRI, XSD.STRING);
+        CoreseStatement statement = (CoreseStatement) valueFactory.createStatement(subject, predicate, literal);
+        assertNotNull(statement);
+        assertEquals(subject, statement.getSubject());
+        assertEquals(predicate, statement.getPredicate());
+        assertEquals(literal, statement.getObject());
+        assertNull(statement.getContext());
+    }
+
+    @Test
+    public void testCreateStatementWithContext() {
+        Literal literal = valueFactory.createLiteral(stringTestValue, xsdStringIRI, XSD.STRING);
+
+        CoreseStatement statement = (CoreseStatement) valueFactory.createStatement(subject, predicate, literal, context);
+
+        assertNotNull(statement);
+        assertEquals(subject, statement.getSubject());
+        assertEquals(predicate, statement.getPredicate());
+        assertEquals(literal, statement.getObject());
+        assertEquals(context, statement.getContext());
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/impl/temp/CoreseStatementTest.java
+++ b/src/test/java/fr/inria/corese/core/next/impl/temp/CoreseStatementTest.java
@@ -1,0 +1,83 @@
+package fr.inria.corese.core.next.impl.temp;
+
+import fr.inria.corese.core.NodeImpl;
+import fr.inria.corese.core.edge.EdgeImpl;
+import fr.inria.corese.core.kgram.api.core.Edge;
+import fr.inria.corese.core.kgram.api.core.Node;
+import fr.inria.corese.core.next.api.IRI;
+import fr.inria.corese.core.next.api.Resource;
+import fr.inria.corese.core.next.api.Value;
+import fr.inria.corese.core.next.impl.temp.literal.CoreseInteger;
+import fr.inria.corese.core.sparql.datatype.DatatypeMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CoreseStatementTest {
+    private Resource subject;
+    private IRI predicate;
+    private Value object;
+    private Resource context;
+    private Edge edge;
+    private Node graphNode;
+    private Node predicateNode;
+    private Node subjectNode;
+    private Node objectNode;
+
+    @Before
+    public void setUp() {
+        subject = new CoreseIRI("http://corese.com/subject");
+        predicate = new CoreseIRI("http://corese.com/predicate");
+        object = new CoreseInteger(1);
+        context = new CoreseIRI("http://corese.com/context");
+
+        graphNode = NodeImpl.create(DatatypeMap.createResource("http://corese.com/context"));
+        predicateNode = NodeImpl.create(DatatypeMap.createResource("http://corese.com/predicate"));
+        subjectNode = NodeImpl.create(DatatypeMap.createResource("http://corese.com/subject"));
+        objectNode = NodeImpl.create(DatatypeMap.create(1));
+        edge = EdgeImpl.create(graphNode, subjectNode, predicateNode, objectNode);
+    }
+
+    @Test
+    public void testCoreseStatementWithContext() {
+        CoreseStatement statement = new CoreseStatement(subject, predicate, object, context);
+
+        assertEquals(subject, statement.getSubject());
+        assertEquals(predicate, statement.getPredicate());
+        assertEquals(object, statement.getObject());
+        assertEquals(context, statement.getContext());
+    }
+
+    @Test
+    public void testCoreseStatementWithoutContext() {
+        CoreseStatement statement = new CoreseStatement(subject, predicate, object, null);
+
+        assertEquals(subject, statement.getSubject());
+        assertEquals(predicate, statement.getPredicate());
+        assertEquals(object, statement.getObject());
+        assertNull(statement.getContext());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCoreseStatementFromEdgeWithNullEdge() {
+        new CoreseStatement(null);
+    }
+
+    @Test
+    public void testCoreseStatementFromEdge() {
+        CoreseStatement statement = new CoreseStatement(edge);
+
+        assertEquals(subject, statement.getSubject());
+        assertEquals(predicate, statement.getPredicate());
+        assertEquals(object.stringValue(), statement.getObject().stringValue());
+        assertEquals(context, statement.getContext());
+    }
+
+    @Test
+    public void testGetCoreseEdge() {
+        CoreseStatement statement = new CoreseStatement(subject, predicate, object, context);
+        assertNotNull(statement.getCoreseEdge());
+    }
+}
+


### PR DESCRIPTION
# Changes Summary:

## Added the getCoreseNode method to CoreseBoolean:

Added a getCoreseNode() method to CoreseBoolean to return the corresponding Corese node for CoreseBoolean instances, ensuring consistency with the overall framework.

## Added the createStatement method to CoreseAdaptedValueFactory:

The method is now available to create statements from the new API, simplifying the creation of statements (with or without a context) from the provided subject, predicate, and object values.

## Added methods to convert Edge from the old API to Statement in the new API (and vice versa):

Added conversion methods to translate old API Edge objects into the new Statement structure (and vice versa). 

## Next Step: Add BlankNode Support to the convert Method