### PR TITLE
Query index dependency

### DIFF
--- a/src/main/java/fr/inria/corese/core/query/ProducerImpl.java
+++ b/src/main/java/fr/inria/corese/core/query/ProducerImpl.java
@@ -928,10 +928,7 @@ public class ProducerImpl
 
     @Override
     public Edge copy(Edge ent) {
-        if (EdgeManagerIndexer.test) {
-            return getGraph().getEdgeFactory().copy(ent);
-        }
-        return ent;
+        return getGraph().getEdgeFactory().copy(ent);
     }
 
     @Override


### PR DESCRIPTION
Removed a foreign attribute access that was always a constant (`true`)
