### PR TITLE
92 redesign the property class to have a config management based on lightbend config

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/data/impl/common/DataConfigurationProperties.java
+++ b/src/main/java/fr/inria/corese/core/next/data/impl/common/DataConfigurationProperties.java
@@ -1,0 +1,40 @@
+package fr.inria.corese.core.next.data.impl.common;
+
+import fr.inria.corese.core.next.util.ConfigurationProperty;
+
+import java.util.Optional;
+
+public enum DataConfigurationProperties implements ConfigurationProperty {
+    DEFAULT_BASE_URI("core.default-uri", true);
+
+    private final String name;
+    private final Optional<String> defaultValue;
+    private final boolean optional;
+
+    DataConfigurationProperties(String name, boolean optional) {
+        this.name = name;
+        this.defaultValue = Optional.empty();
+        this.optional = optional;
+    }
+
+    DataConfigurationProperties(String name, String defaultValue, boolean optional) {
+        this.name = name;
+        this.defaultValue = Optional.of(defaultValue);
+        this.optional = optional;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Optional<String> getDefaultValue() {
+        return this.defaultValue;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return this.optional;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/data/impl/common/DataConfigurationProperties.java
+++ b/src/main/java/fr/inria/corese/core/next/data/impl/common/DataConfigurationProperties.java
@@ -1,26 +1,53 @@
 package fr.inria.corese.core.next.data.impl.common;
 
 import fr.inria.corese.core.next.util.ConfigurationProperty;
+import fr.inria.corese.core.next.util.Properties;
+import fr.inria.corese.core.next.util.exception.ConfigurationException;
 
 import java.util.Optional;
 
+/**
+ * Configuration properties for the high-level data management API of Corese
+ */
 public enum DataConfigurationProperties implements ConfigurationProperty {
-    DEFAULT_BASE_URI("core.default-uri", true);
+    DEFAULT_BASE_URI("core.default-uri", "https://ns.inria.fr/corese/");
 
     private final String name;
-    private final Optional<String> defaultValue;
+    private final String defaultValue;
     private final boolean optional;
 
-    DataConfigurationProperties(String name, boolean optional) {
-        this.name = name;
-        this.defaultValue = Optional.empty();
-        this.optional = optional;
-    }
-
+    /**
+     * Main constructor.
+     * @param name The path of the property in the configuration file (e.g. "core.default-uri")
+     * @param defaultValue The default value of the property
+     * @param optional Flag indicating if the property has to be present in the configuration file, or not
+     * @throws ConfigurationException if the property is not optional and not defined in the configuration file
+     */
     DataConfigurationProperties(String name, String defaultValue, boolean optional) {
         this.name = name;
-        this.defaultValue = Optional.of(defaultValue);
+        this.defaultValue = defaultValue;
         this.optional = optional;
+        if(! this.optional && ! Properties.instance().propertyValueExists(this)) {
+            throw new ConfigurationException(this.name + " data configuration is not present in the configuration file");
+        }
+    }
+
+    /**
+     * Constructor without default value
+     * @param name The path of the property in the configuration file (e.g. "core.default-uri")
+     * @param optional Flag indicating if the property has to be present in the configuration file, or not
+     */
+    DataConfigurationProperties(String name, boolean optional) {
+        this(name, null, optional);
+    }
+
+    /**
+     * Constructor with a default value. A property with a default value is expected to be optional.
+     * @param name The path of the property in the configuration file (e.g. "core.default-uri")
+     * @param defaultValue String representation of the default value
+     */
+    DataConfigurationProperties(String name, String defaultValue) {
+        this(name, defaultValue, true);
     }
 
     @Override
@@ -30,7 +57,7 @@ public enum DataConfigurationProperties implements ConfigurationProperty {
 
     @Override
     public Optional<String> getDefaultValue() {
-        return this.defaultValue;
+        return Optional.ofNullable(this.defaultValue);
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/data/impl/io/common/IOConstants.java
+++ b/src/main/java/fr/inria/corese/core/next/data/impl/io/common/IOConstants.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.data.impl.io.common;
 
+import fr.inria.corese.core.next.data.impl.common.DataConfigurationProperties;
+import fr.inria.corese.core.next.util.Properties;
 import fr.inria.corese.core.util.Property;
 
 /**
@@ -63,10 +65,6 @@ public class IOConstants {
      * @return the default base URI from configuration, or null if not set
      */
     public static String getDefaultBaseURI() {
-        String configuredValue = Property.getStringValue(Property.Value.DEFAULT_BASE_URI);
-        if (configuredValue == null || configuredValue.isEmpty()) {
-            return "http://example.org/";
-        }
-        return configuredValue;
+        return Properties.instance().getPropertyValue(DataConfigurationProperties.DEFAULT_BASE_URI).get();
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/util/ConfigurationProperty.java
+++ b/src/main/java/fr/inria/corese/core/next/util/ConfigurationProperty.java
@@ -1,0 +1,14 @@
+package fr.inria.corese.core.next.util;
+
+import java.util.Optional;
+
+/**
+ * Interface to be inherited by all enum classes defining configuration properties.
+ * This is done to ensure checks and defaults properties
+ */
+public interface ConfigurationProperty {
+
+    String getName();
+    Optional<String> getDefaultValue();
+    boolean isOptional();
+}

--- a/src/main/java/fr/inria/corese/core/next/util/ConfigurationProperty.java
+++ b/src/main/java/fr/inria/corese/core/next/util/ConfigurationProperty.java
@@ -1,14 +1,42 @@
 package fr.inria.corese.core.next.util;
 
+import fr.inria.corese.core.next.util.exception.ConfigurationException;
+
 import java.util.Optional;
 
 /**
  * Interface to be inherited by all enum classes defining configuration properties.
- * This is done to ensure checks and defaults properties
+ * it is recommended that the enum implementing this interface use {@link Properties.propertyValueExists() } in their
+ * constructor to throw an exception at class loading for any undefined non-optional property.
  */
 public interface ConfigurationProperty {
 
+    /**
+     * @return The path of the property in the configuration file
+     */
     String getName();
+
+    /**
+     * @return The string value representation of the property if it exists in the configuration file
+     * @throws fr.inria.corese.core.next.util.exception.ConfigurationException If a non-optional property has no value
+     */
+    default Optional<String> getValue() {
+        if(Properties.instance().propertyValueExists(this)) {
+            return Properties.instance().getPropertyValue(this);
+        } else if(this.isOptional()) {
+            return this.getDefaultValue();
+        } else {
+            throw new ConfigurationException("Non-optional property " + this.getName() + " has no value");
+        }
+    }
+
+    /**
+     * @return The string value representation of the default value if there is one
+     */
     Optional<String> getDefaultValue();
+
+    /**
+     * @return A flag indicating in the value has to be defined in the configuration file or not
+     */
     boolean isOptional();
 }

--- a/src/main/java/fr/inria/corese/core/next/util/Properties.java
+++ b/src/main/java/fr/inria/corese/core/next/util/Properties.java
@@ -23,23 +23,27 @@ public class Properties {
     }
 
     public static Properties instance() {
-        if(INSTANCE == null) {
+        if (INSTANCE == null) {
             INSTANCE = new Properties();
         }
         return INSTANCE;
     }
 
     public Optional<String> getPropertyValue(ConfigurationProperty property) {
-        if(this.config.hasPath(property.getName())) {
+        if (propertyValueExists(property)) {
             return Optional.of(this.config.getString(property.getName()));
         } else if (property.isOptional()) {
-            if(property.isOptional() && property.getDefaultValue().isPresent()) {
+            if (property.getDefaultValue().isPresent()) {
                 return property.getDefaultValue();
             } else {
                 return Optional.empty();
             }
-            } else {
-                throw new ConfigurationException("Undefined configuration " + property.getName());
-            }
+        } else {
+            throw new ConfigurationException("Undefined configuration " + property.getName());
+        }
+    }
+
+    public boolean propertyValueExists(ConfigurationProperty property) {
+        return this.config.hasPath(property.getName());
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/util/Properties.java
+++ b/src/main/java/fr/inria/corese/core/next/util/Properties.java
@@ -1,0 +1,45 @@
+package fr.inria.corese.core.next.util;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import fr.inria.corese.core.next.util.exception.ConfigurationException;
+
+import java.util.Optional;
+
+public class Properties {
+
+    private static final String CONFIG_FILE = "application.conf";
+
+    private final Config config;
+    private static Properties INSTANCE = null;
+
+    private Properties() {
+        try {
+            this.config = ConfigFactory.load(CONFIG_FILE);
+        } catch (ConfigException e) {
+            throw new ConfigurationException("Error during configuration loading", e);
+        }
+    }
+
+    public static Properties instance() {
+        if(INSTANCE == null) {
+            INSTANCE = new Properties();
+        }
+        return INSTANCE;
+    }
+
+    public Optional<String> getPropertyValue(ConfigurationProperty property) {
+        if(this.config.hasPath(property.getName())) {
+            return Optional.of(this.config.getString(property.getName()));
+        } else if (property.isOptional()) {
+            if(property.isOptional() && property.getDefaultValue().isPresent()) {
+                return property.getDefaultValue();
+            } else {
+                return Optional.empty();
+            }
+            } else {
+                throw new ConfigurationException("Undefined configuration " + property.getName());
+            }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/util/exception/ConfigurationException.java
+++ b/src/main/java/fr/inria/corese/core/next/util/exception/ConfigurationException.java
@@ -1,0 +1,25 @@
+package fr.inria.corese.core.next.util.exception;
+
+import fr.inria.corese.core.next.data.api.base.exception.CoreseException;
+
+/**
+ * Class for any exception related to the configuration of Corese.
+ */
+public class ConfigurationException extends CoreseException {
+
+    public ConfigurationException() {
+        super();
+    }
+
+    public ConfigurationException(String msg) {
+        super(msg);
+    }
+
+    public ConfigurationException(Throwable t) {
+        super(t);
+    }
+
+    public ConfigurationException(String msg, Throwable t) {
+        super(msg, t);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/util/Property.java
+++ b/src/main/java/fr/inria/corese/core/util/Property.java
@@ -62,8 +62,6 @@ import static fr.inria.corese.core.util.Property.Value.*;
  */
 public class Property {
 
-    public static final String STAR = "*";
-    public static final String RDF_XML = "rdf+xml";
     public static final String TURTLE = "turtle";
     public static final String TRIG = "trig";
     public static final String JSON = "json";

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 core {
   log.level = "INFO"
   log.level = ${?CORESE_LOG_LEVEL}
+  default-uri = "http://example.com"
 }

--- a/src/test/java/fr/inria/corese/core/next/util/PropertiesTest.java
+++ b/src/test/java/fr/inria/corese/core/next/util/PropertiesTest.java
@@ -1,0 +1,80 @@
+package fr.inria.corese.core.next.util;
+
+import fr.inria.corese.core.next.util.exception.ConfigurationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PropertiesTest {
+
+    enum MockProperties implements ConfigurationProperty {
+        FOOBAR("foo.bar", null, false),
+        FOOFOOBAR("foo.foo.bar", null, false),
+        FOOFOOBARBAR("foo.foo.bar.bar", null, true),
+        INTPROP("foo.intprop", "0", false),
+        INTOPTPROP("foo.intoptprop", "0", true);
+
+        private String name;
+        private String defaultValue;
+        private boolean optional;
+
+        MockProperties(String name, String defaultValue, boolean optional) {
+            this.name = name;
+            this.defaultValue = defaultValue;
+            this.optional = optional;
+        }
+
+        @Override
+        public String getName() {
+            return this.name;
+        }
+
+        @Override
+        public Optional<String> getDefaultValue() {
+            return Optional.ofNullable(this.defaultValue);
+        }
+
+        @Override
+        public boolean isOptional() {
+            return this.optional;
+        }
+    }
+
+    @Test
+    @DisplayName("Properties returns the value of a non-optional property")
+    void getPropertyValue() {
+        assertEquals("foobar", MockProperties.FOOBAR.getValue().get());
+    }
+
+    @Test
+    @DisplayName("Properties returns the value of a non-optional int property")
+    void getPropertyIntValue() {
+        assertEquals(4, Integer.valueOf(MockProperties.INTPROP.getValue().get()));
+    }
+
+    @Test
+    @DisplayName("Properties returns the default value of an optional int property")
+    void getPropertyDefaultIntValue() {
+        assertEquals(0, Integer.valueOf(MockProperties.INTOPTPROP.getValue().get()));
+    }
+
+    @Test
+    @DisplayName("Properties throws an exception when the value of a non-existing non-optional property is accessed")
+    void throwExceptionNonExistentProperty() {
+        assertThrows(ConfigurationException.class, () -> {
+           MockProperties.FOOFOOBAR.getValue();
+        });
+    }
+
+    @Test
+    @DisplayName("Properties does not throw an exception if the value of an non-existent optional property is accessed")
+    void throwDoNotThrowNonExistentNonOptionalProperty() {
+        assertDoesNotThrow(() -> {
+            MockProperties.FOOFOOBARBAR.getValue();
+        });
+    }
+
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+foo {
+  bar = "foobar"
+  intprop = 4
+}


### PR DESCRIPTION
New configuration mechanism based on the Lightbend library.

Main points:
- `fr.inria.corese.core.next.util.Properties` in a singleton in charge of loading the configuration file and giving access to its values to "registered properties"
- "Registered properties" refer to the values of enums that implement `fr.inria.corese.core.next.util.ConfigurationProperty`
    - See `fr.inria.corese.core.next.data.impl.common.DataConfigurationProperties` for an example of implementation
- Each package can define its own independent set of configuration properties
    
The idea here is to check the presence of the config properties at class loading by using a check in the constructor of each config property enum, as done in `fr.inria.corese.core.next.data.impl.common.DataConfigurationProperties`.
Independent of that, an exception is thrown when accessing a non-optional property that is not present in the configuration file.


The only configuration property used in `next` I could find is the default URI.