### PR TITLE
Optional parsing with test

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -43,6 +43,9 @@ public final class SparqlAstBuilder {
     /** Stack of current BGP triples (TriplesBlock). Nested blocks are rare but stack keeps it safe. */
     private final Deque<List<TriplePatternAst>> bgpStack = new ArrayDeque<>();
 
+    /** At enterOptional(), we push groupStack.size(). At exitGroup(), if groupStack.size() equals peek, we wrap in OptionalAst. */
+    private final Deque<Integer> optionalGroupDepths = new ArrayDeque<>();
+
     /** Top-level WHERE clause, set when the root group is closed in exitGroup(). */
     private GroupGraphPatternAst whereClause;
 
@@ -103,15 +106,19 @@ public final class SparqlAstBuilder {
 
     /**
      * Exit a { ... } groupGraphPattern.
-     * Pops the current group, wraps it in {@link GroupGraphPatternAst}; if there is a parent group,
-     * adds it there; otherwise stores it as the top-level WHERE clause for {@link #getResult()}.
+     * Pops the current group, wraps it in {@link GroupGraphPatternAst}. If we had entered OPTIONAL
+     * and the parent group depth matches {@link #optionalGroupDepths}, wraps in {@link OptionalAst} and adds to parent;
+     * otherwise adds the group to parent or sets as top-level WHERE.
      * Must not be called while a TriplesBlock is still open (no pending enterBgp without exitBgp).
      */
     public void exitGroup() {
         ensureNoOpenBgp("exitGroup() called while a TriplesBlock/BGP is still open");
         List<PatternAst> popped = groupStack.pop();
         GroupGraphPatternAst group = new GroupGraphPatternAst(popped);
-        if (groupStack.isEmpty()) {
+        if (!optionalGroupDepths.isEmpty() && groupStack.size() == optionalGroupDepths.peek()) {
+            optionalGroupDepths.pop();
+            currentGroup().add(new OptionalAst(group));
+        } else if (groupStack.isEmpty()) {
             whereClause = group;
         } else {
             currentGroup().add(group);
@@ -147,6 +154,19 @@ public final class SparqlAstBuilder {
         }
         bgpStack.peek().add(new TriplePatternAst(s, p, o));
     }
+
+    /**
+     * Enter OPTIONAL scope. Records current group stack size so that when we exitGroup() and the stack
+     * is back to that size, we wrap the popped group in {@link OptionalAst}.
+     */
+    public void enterOptional() {
+        optionalGroupDepths.push(groupStack.size());
+    }
+
+    /**
+     * Exit OPTIONAL scope. No-op: the optional content was already wrapped in {@link OptionalAst} in {@link #exitGroup()}.
+     */
+    public void exitOptional() {}
 
     // --- Result ---
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
@@ -61,4 +61,15 @@ public final class SparqlListener extends SparqlParserBaseListener {
     public void exitTriplesSameSubject(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.TriplesSameSubjectContext ctx) {
         for (var d : delegates) d.exitTriplesSameSubject(ctx);
     }
+
+    // ---------- OPTIONAL ----------
+    @Override
+    public void enterOptionalGraphPattern(SparqlParser.OptionalGraphPatternContext ctx) {
+        for (var d : delegates) d.enterOptionalGraphPattern(ctx);
+    }
+
+    @Override
+    public void exitOptionalGraphPattern(SparqlParser.OptionalGraphPatternContext ctx) {
+        for (var d : delegates) d.exitOptionalGraphPattern(ctx);
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/BgpFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/BgpFeature.java
@@ -8,12 +8,13 @@ import java.util.List;
 
 
 /**
- * SPARQL 1.0 feature: build Triple patterns + BGPs
+ * SPARQL 1.0 feature: build Triple patterns + BGPs + OPTIONAL
  *
  * Grammar hooks used:
  * - GroupGraphPattern: { ... }  -> builder.enterGroup()/exitGroup()
  * - TriplesBlock: BGP block      -> builder.enterBgp()/exitBgp()
  * - TriplesSameSubject: produce actual triples -> builder.addTriple(s,p,o)
+ * - OptionalGraphPattern: OPTIONAL { ... } -> builder.enterOptional()/exitOptional()
  */
 public class BgpFeature extends AbstractSparqlFeature {
 
@@ -33,6 +34,17 @@ public class BgpFeature extends AbstractSparqlFeature {
     @Override
     public void exitGroupGraphPattern(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.GroupGraphPatternContext ctx) {
         builder.exitGroup();
+    }
+
+    // -------- OPTIONAL { ... } --------
+    @Override
+    public void enterOptionalGraphPattern(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.OptionalGraphPatternContext ctx) {
+        builder.enterOptional();
+    }
+
+    @Override
+    public void exitOptionalGraphPattern(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.OptionalGraphPatternContext ctx) {
+        builder.exitOptional();
     }
 
     // -------- BGP (TriplesBlock) --------

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OptionalAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OptionalAst.java
@@ -1,0 +1,8 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+/**
+ * Optional can contain BGP, FILTER, UNION
+ *
+ * @param ast PatternAst
+ */
+public record OptionalAst(PatternAst ast) implements PatternAst {}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
@@ -3,5 +3,5 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 /**
  * Element of a group graph pattern (BGP, optional, union, etc.).
  */
-public sealed interface PatternAst permits BgpAst, GroupGraphPatternAst {
+public sealed interface PatternAst permits BgpAst, GroupGraphPatternAst, OptionalAst {
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserOptionalTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserOptionalTest.java
@@ -1,0 +1,100 @@
+package fr.inria.corese.core.next.query.impl.parser;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SparqlParserOptionalTest extends AbstractSparqlParserFeatureTest {
+
+    @Test
+    @DisplayName("Should parse a basic SELECT With Optional triples")
+    public void shouldParseBasicSelectWithOptionalTest() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT ?child ?childLabel ?genderLabel ?birth_date ?date_of_death
+                 WHERE
+                 {
+                   ?child wdt:P22 wd:Q76.
+                   OPTIONAL{ ?child wdt:P21 ?gender. }
+                   OPTIONAL{ ?child wdt:P569 ?birth_date. }
+                   OPTIONAL{ ?child wdt:P570 ?date_of_death. }
+                 }
+                """);
+
+        assertNotNull(ast);
+        assertInstanceOf(QueryAst.class, ast);
+
+        SelectQueryAst select = (SelectQueryAst) ast;
+
+        GroupGraphPatternAst where = select.whereClause();
+
+        assertEquals(4, where.patterns().size());
+
+        assertInstanceOf(BgpAst.class, where.patterns().get(0));
+        assertInstanceOf(OptionalAst.class, where.patterns().get(1));
+        assertInstanceOf(OptionalAst.class, where.patterns().get(2));
+        assertInstanceOf(OptionalAst.class, where.patterns().get(3));
+
+
+
+    }
+
+    @Test
+    @DisplayName("Should parse a basic SELECT With Optional Block")
+    public void shouldParseBasicSelectWithOptionalBlockTest() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT ?child ?childLabel ?genderLabel ?birth_date ?date_of_death
+                WHERE
+                {
+                  ?child wdt:P22 wd:Q76.
+                  OPTIONAL{ ?child wdt:P21 ?gender.          
+                            ?child wdt:P569 ?birth_date.
+                            ?child wdt:P570 ?date_of_death.
+                          }
+                }
+                """);
+
+        assertNotNull(ast);
+        assertInstanceOf(QueryAst.class, ast);
+
+        SelectQueryAst select = (SelectQueryAst) ast;
+
+        GroupGraphPatternAst where = select.whereClause();
+
+        assertEquals(2, where.patterns().size());
+
+        assertInstanceOf(BgpAst.class, where.patterns().get(0));
+        assertInstanceOf(OptionalAst.class, where.patterns().get(1));
+    }
+
+    @Test
+    @DisplayName("Should parse a basic SELECT With nested Optional triples")
+    void shouldParseOptionalPattern() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+        SELECT ?s ?name WHERE {
+            ?s a foaf:Person .
+            OPTIONAL { OPTIONAL { ?s foaf:name ?name } }
+        }
+    """);
+
+        SelectQueryAst select = (SelectQueryAst) ast;
+
+        GroupGraphPatternAst where = select.whereClause();
+
+        assertEquals(2, where.patterns().size());
+
+        assertInstanceOf(BgpAst.class, where.patterns().get(0));
+        assertInstanceOf(OptionalAst.class, where.patterns().get(1));
+    }
+
+}


### PR DESCRIPTION
We add the sparql optional parser. It should also parse nested Optional.

we add 
private final Deque<Integer> optionalGroupDepths = new ArrayDeque<>(); to help us know when we can wrap a group in a OptionalAst.