### PR TITLE
[SPARQL 1.0] Implement #380 and #382 in next parser

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryDiagnostic.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryDiagnostic.java
@@ -1,0 +1,62 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+import java.util.Objects;
+
+/**
+ * Public diagnostic model for query validation.
+ *
+ * <p>This type is intended to unify syntax and semantic diagnostics behind a
+ * stable contract consumable by external tools.</p>
+ *
+ * <p>Line numbers follow the parser conventions already used in the query
+ * package: line numbers are 1-based when known, columns are 0-based when
+ * known, and both are set to {@code -1} when unavailable.</p>
+ */
+public record QueryDiagnostic(
+        Kind kind,
+        Severity severity,
+        String message,
+        int line,
+        int column,
+        String offendingText,
+        String source
+) {
+
+    /** High-level diagnostic category. */
+    public enum Kind {
+        LEXER_ERROR,
+        SYNTAX_ERROR,
+        SEMANTIC_ERROR
+    }
+
+    /** Diagnostic severity level. */
+    public enum Severity {
+        INFO,
+        WARNING,
+        ERROR
+    }
+
+    public QueryDiagnostic {
+        Objects.requireNonNull(kind, "QueryDiagnostic.kind must not be null");
+        Objects.requireNonNull(severity, "QueryDiagnostic.severity must not be null");
+        Objects.requireNonNull(message, "QueryDiagnostic.message must not be null");
+        if (line < -1) {
+            throw new IllegalArgumentException("line must be >= -1");
+        }
+        if (column < -1) {
+            throw new IllegalArgumentException("column must be >= -1");
+        }
+    }
+
+    /**
+     * Formats this diagnostic as a compact single-line message.
+     */
+    public String format() {
+        String where = line >= 1 ? "line " + line + ":" + column + " " : "";
+        String off = offendingText != null && !offendingText.isBlank()
+                ? " (offending: " + offendingText + ")"
+                : "";
+        String src = source != null && !source.isBlank() ? " [" + source + "]" : "";
+        return where + message + off + src;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryTextValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryTextValidator.java
@@ -1,0 +1,36 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * Public validation entry point for query text.
+ *
+ * <p>Current SPARQL semantic coverage is intentionally limited to the
+ * features already represented by the {@code next} AST and semantic rules.
+ * Today this mainly covers syntax diagnostics plus implemented scope checks
+ * such as SELECT projection visibility and ORDER BY visibility for
+ * SELECT/CONSTRUCT/DESCRIBE.</p>
+ *
+ * <p>Validation is intended to behave like a linter: malformed or semantically
+ * invalid queries should be reported through {@link QueryDiagnostic}
+ * instances collected in the returned {@link QueryValidationResult}, rather
+ * than through query-invalidity exceptions. Technical failures unrelated to the
+ * query text itself, such as I/O failures while reading the input, may still
+ * surface as exceptions.</p>
+ */
+public interface QueryTextValidator extends QueryValidator<String> {
+
+    QueryValidationResult validate(InputStream in);
+
+    QueryValidationResult validate(InputStream in, String baseIRI);
+
+    QueryValidationResult validate(Reader reader);
+
+    QueryValidationResult validate(Reader reader, String baseIRI);
+
+    @Override
+    QueryValidationResult validate(String queryString);
+
+    QueryValidationResult validate(String queryString, String baseIRI);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidationResult.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidationResult.java
@@ -1,0 +1,23 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+import java.util.List;
+
+/**
+ * Aggregated validation result for a query.
+ *
+ * <p>A result is considered valid when it contains no diagnostic with severity
+ * {@link QueryDiagnostic.Severity#ERROR}. Informational or warning diagnostics
+ * may still be present on a valid result.</p>
+ */
+public record QueryValidationResult(List<QueryDiagnostic> diagnostics) {
+
+    public QueryValidationResult {
+        diagnostics = diagnostics != null ? List.copyOf(diagnostics) : List.of();
+    }
+
+    /** Returns {@code true} when no error diagnostic was reported. */
+    public boolean isValid() {
+        return diagnostics.stream()
+                .noneMatch(diagnostic -> diagnostic.severity() == QueryDiagnostic.Severity.ERROR);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidator.java
@@ -1,0 +1,18 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+/**
+ * Validates a query model and returns structured diagnostics.
+ *
+ * @param <T> validated input type
+ */
+public interface QueryValidator<T> {
+
+    /**
+     * Validates an input and returns all collected diagnostics.
+     *
+     * <p>Implementations should prefer returning diagnostics over throwing when
+     * the input is malformed or semantically invalid. Runtime failures unrelated
+     * to validation may still surface as exceptions.</p>
+     */
+    QueryValidationResult validate(T input);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidators.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/validation/QueryValidators.java
@@ -1,0 +1,17 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
+
+/**
+ * Public factories for query validators.
+ */
+public final class QueryValidators {
+
+    private QueryValidators() {
+    }
+
+    /** Returns a validator for SPARQL query text. */
+    public static QueryTextValidator sparql() {
+        return new SparqlParser();
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -4,7 +4,6 @@ import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.impl.parser.antlr.SparqlParser;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -123,11 +122,6 @@ public final class SparqlAstBuilder {
      * Template AST after {@link #exitConstructTemplate()}; consumed in {@link #getResult()}.
      */
     private ConstructTemplateAst constructTemplate;
-
-    /**
-     * Helper used to compute visible and referenced variables.
-     */
-    private final VariableScopeAnalyzer variableScopeAnalyzer = new VariableScopeAnalyzer();
 
     /**
      * Effective base URI after prologue (parser options, then possibly {@code BASE}).
@@ -446,7 +440,6 @@ public final class SparqlAstBuilder {
      * Builds the AST for SELECT queries.
      */
     private SelectQueryAst buildSelectQueryAst(DatasetClauseAst datasetClauseAst, QueryPrologueAst prologue) {
-        validateSelectQueryScope();
         return new SelectQueryAst(projection, datasetClauseAst, whereClause, buildSolutionModifier(), prologue);
     }
 
@@ -454,96 +447,19 @@ public final class SparqlAstBuilder {
      * Builds the AST for DESCRIBE queries.
      */
     private DescribeQueryAst buildDescribeQueryAst(DatasetClauseAst datasetClauseAst, QueryPrologueAst prologue) {
-        // TODO #306: validate variable scope for DESCRIBE modifiers when DescribeQueryAst carries them.
-        return new DescribeQueryAst(datasetClauseAst, describeResources, whereClause, prologue);
+        return new DescribeQueryAst(datasetClauseAst, describeResources, whereClause, buildSolutionModifier(), prologue);
     }
 
     /**
      * Builds the AST for CONSTRUCT queries.
      */
     private ConstructQueryAst buildConstructQueryAst(DatasetClauseAst datasetClauseAst, QueryPrologueAst prologue) {
-        // TODO #306: validate variable scope for CONSTRUCT modifiers when ConstructQueryAst carries them.
         return new ConstructQueryAst(
                 constructTemplate != null ? constructTemplate : new ConstructTemplateAst(List.of()),
                 datasetClauseAst,
                 whereClause,
                 buildSolutionModifier(),
                 prologue);
-    }
-
-    /**
-     * Validates SELECT projection and ORDER BY variables against the WHERE clause scope.
-     */
-    private void validateSelectQueryScope() {
-        // TODO #306: extend this validation to GROUP BY when it is supported by the next parser.
-        Set<String> visibleVariables = variableScopeAnalyzer.collectVisibleVariables(whereClause);
-
-        // SELECT * still needs ORDER BY validation.
-        if (!projection.selectAll()) {
-            validateProjectionVariables(visibleVariables);
-        }
-
-        validateOrderVariables(collectOrderByAvailableVariables(visibleVariables));
-    }
-
-    /**
-     * Validates explicit projection variables against the WHERE clause scope.
-     *
-     * @param visibleVariables variable names visible from the WHERE clause
-     */
-    private void validateProjectionVariables(Set<String> visibleVariables) {
-        for (VarAst projectedVar : projection.variables()) {
-            if (!visibleVariables.contains(projectedVar.name())) {
-                throw new QueryValidationException(buildOutOfScopeVariableMessage(
-                        projectedVar.name(),
-                        "SELECT projection"));
-            }
-        }
-    }
-
-    /**
-     * Collects variables that may be referenced from ORDER BY.
-     *
-     * <p>SPARQL applies ORDER BY before the final projection step. In the current next parser,
-     * explicit projection variables are already validated against the WHERE clause, so adding
-     * them here mainly keeps the availability rule explicit while staying within the current
-     * SPARQL 1.0 feature set.
-     *
-     * @param visibleVariables variable names visible from the WHERE clause
-     * @return variable names available to ORDER BY validation
-     */
-    private Set<String> collectOrderByAvailableVariables(Set<String> visibleVariables) {
-        Set<String> availableVariables = new LinkedHashSet<>(visibleVariables);
-        if (!projection.selectAll()) {
-            for (VarAst projectedVar : projection.variables()) {
-                availableVariables.add(projectedVar.name());
-            }
-        }
-        return availableVariables;
-    }
-
-    /**
-     * Validates ORDER BY variables against the variables available at ORDER BY time.
-     *
-     * @param availableOrderVariables variable names available to ORDER BY
-     */
-    private void validateOrderVariables(Set<String> availableOrderVariables) {
-        for (OrderConditionAst orderCondition : orderConditions) {
-            Set<String> referencedVariables = variableScopeAnalyzer
-                    .collectReferencedVariables(orderCondition.expression());
-
-            for (String variableName : referencedVariables) {
-                if (!availableOrderVariables.contains(variableName)) {
-                    throw new QueryValidationException(buildOutOfScopeVariableMessage(
-                            variableName,
-                            "ORDER BY"));
-                }
-            }
-        }
-    }
-
-    private String buildOutOfScopeVariableMessage(String variableName, String clause) {
-        return "Variable ?" + variableName + " used in " + clause + " is not visible in WHERE clause";
     }
 
     /**
@@ -602,7 +518,7 @@ public final class SparqlAstBuilder {
     }
 
     /**
-     * Builds the solution modifier (DISTINCT, REDUCED, ORDER BY, LIMIT, OFFSET) for SELECT.
+     * Builds the parsed solution modifier (DISTINCT, REDUCED, ORDER BY, LIMIT, OFFSET).
      */
     private SolutionModifierAst buildSolutionModifier() {
         return new SolutionModifierAst(distinct, reduced, this.orderConditions, limit, offset);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
@@ -1,35 +1,36 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
-import fr.inria.corese.core.next.query.impl.parser.listener.*;
-import org.antlr.v4.runtime.BailErrorStrategy;
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.DefaultErrorStrategy;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
-import fr.inria.corese.core.next.data.impl.io.parser.util.ParserConstants;
-import fr.inria.corese.core.next.impl.parser.antlr.SparqlLexer;
 import fr.inria.corese.core.next.query.api.base.io.AbstractQueryParser;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.api.io.parser.QueryOptions;
 import fr.inria.corese.core.next.query.api.sparql.options.BaseIRIOptions;
+import fr.inria.corese.core.next.query.api.validation.QueryTextValidator;
+import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 
-public class SparqlParser extends AbstractQueryParser {
+/**
+ * SPARQL parser exposing both AST parsing and non-throwing validation entry points.
+ *
+ * <p>{@code parse(...)} keeps the traditional parser contract: syntax and
+ * semantic query errors are reported with exceptions and a valid query returns
+ * a {@link QueryAst}. By contrast, {@code validate(...)} is intended for
+ * linter-style usage and reports query problems through
+ * {@link QueryValidationResult} diagnostics. Both families may still throw on
+ * technical failures unrelated to the query validity itself.</p>
+ */
+public class SparqlParser extends AbstractQueryParser implements QueryTextValidator {
+
+    private final SparqlQueryAnalyzer analyzer = new SparqlQueryAnalyzer();
 
     public SparqlParser() {
         this(new SparqlParserOptions.Builder().build());
@@ -59,75 +60,10 @@ public class SparqlParser extends AbstractQueryParser {
 
     @Override
     public QueryAst parse(Reader reader, String baseIRI) {
-        SparqlParserOptions config = getEffectiveConfig();
-        SparqlParserOptions sparqlParserOptions = new SparqlParserOptions.Builder()
-                .baseIRI(baseIRI != null ? baseIRI : ParserConstants.getDefaultBaseURI())
-                .failFast(config.isFailFast())
-                .collectErrors(config.isCollectErrors())
-                .build();
-
         try {
-            CharStream charStream = CharStreams.fromReader(reader);
-            SparqlLexer lexer = new SparqlLexer(charStream);
-
-            SparqlErrorListener errorListener = new SparqlErrorListener(sparqlParserOptions);
-
-            lexer.removeErrorListeners();
-            lexer.addErrorListener(errorListener);
-
-            CommonTokenStream tokens = new CommonTokenStream(lexer);
-            fr.inria.corese.core.next.impl.parser.antlr.SparqlParser parser = new fr.inria.corese.core.next.impl.parser.antlr.SparqlParser(tokens);
-
-            parser.removeErrorListeners();
-            parser.addErrorListener(errorListener);
-
-            if (sparqlParserOptions.isFailFast()) {
-                parser.setErrorHandler(new BailErrorStrategy());
-            } else {
-                parser.setErrorHandler(new DefaultErrorStrategy());
-            }
-
-            ParseTreeWalker walker = new ParseTreeWalker();
-
-            ParseTree tree;
-
-            try {
-                tree = parser.query();
-                if (errorListener.hasErrors()) {
-                    String errorMsg = errorListener.getErrorMessage();
-                    if (errorMsg == null || errorMsg.trim().isEmpty()) {
-                        errorMsg = "Unknown syntax error detected";
-                    }
-                    throw new QuerySyntaxException("Syntax error in SPARQL query: " + errorMsg);
-                }
-            } catch (RecognitionException e) {
-                throw new QuerySyntaxException("Recognition error in SPARQL query: " + e.getMessage(), e);
-            } catch (ParseCancellationException e) {
-                throw toQuerySyntaxException(e, errorListener);
-            }
-
-            SparqlAstBuilder builder = new SparqlAstBuilder(sparqlParserOptions);
-
-            SparqlListener listener = new SparqlListener(List.of(
-                    new BgpFeature(builder),
-                    new AskQueryFeature(builder),
-                    new SelectQueryFeature(builder),
-                    new ConstructQueryFeature(builder),
-                    new SolutionModifierFeature(builder),
-                    new FilterFeature(builder),
-                    new UnionFeature(builder),
-                    new DescribeQueryFeature(builder),
-                    new DatasetClauseFeature(builder),
-                    new PrologueFeature(builder)
-            ));
-
-            walker.walk(listener, tree);
-
-            return builder.getResult();
+            return analyzer.parse(reader, baseIRI, getEffectiveConfig());
         } catch (QuerySyntaxException | QueryValidationException | QueryEvaluationException e) {
             throw e;
-        } catch (IOException e) {
-            throw new QueryEvaluationException("Failed to parse SPARQL query: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new QuerySyntaxException("Unexpected error during SPARQL parsing: " + e.getMessage(), e);
         }
@@ -141,6 +77,40 @@ public class SparqlParser extends AbstractQueryParser {
     @Override
     public QueryAst parse(String queryString, String baseIRI) {
         return parse(new StringReader(queryString), baseIRI);
+    }
+
+    @Override
+    public QueryValidationResult validate(InputStream in) {
+        String baseIri = IOConstants.getDefaultBaseURI();
+        if (getConfig() instanceof BaseIRIOptions baseIRIOptions) {
+            baseIri = baseIRIOptions.getBaseIRI();
+        }
+        return validate(new java.io.InputStreamReader(in, StandardCharsets.UTF_8), baseIri);
+    }
+
+    @Override
+    public QueryValidationResult validate(InputStream in, String baseIRI) {
+        return validate(new java.io.InputStreamReader(in, StandardCharsets.UTF_8), baseIRI);
+    }
+
+    @Override
+    public QueryValidationResult validate(Reader reader) {
+        return validate(reader, getBaseIRIFromConfig());
+    }
+
+    @Override
+    public QueryValidationResult validate(Reader reader, String baseIRI) {
+        return analyzer.validate(reader, baseIRI, getEffectiveConfig());
+    }
+
+    @Override
+    public QueryValidationResult validate(String queryString) {
+        return validate(new StringReader(queryString), getBaseIRIFromConfig());
+    }
+
+    @Override
+    public QueryValidationResult validate(String queryString, String baseIRI) {
+        return validate(new StringReader(queryString), baseIRI);
     }
 
     private String getBaseIRIFromConfig() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -14,6 +15,7 @@ import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.api.io.parser.QueryOptions;
 import fr.inria.corese.core.next.query.api.sparql.options.BaseIRIOptions;
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.api.validation.QueryTextValidator;
 import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
@@ -61,9 +63,28 @@ public class SparqlParser extends AbstractQueryParser implements QueryTextValida
     @Override
     public QueryAst parse(Reader reader, String baseIRI) {
         try {
-            return analyzer.parse(reader, baseIRI, getEffectiveConfig());
+            SparqlQueryAnalyzer.AnalysisResult analysisResult = analyzer.analyze(
+                    reader,
+                    buildEffectiveOptions(baseIRI, false));
+
+            if (!analysisResult.validationResult().isValid()) {
+                QueryDiagnostic firstError = firstErrorDiagnostic(analysisResult.validationResult());
+
+                if (firstError.kind() == QueryDiagnostic.Kind.SEMANTIC_ERROR) {
+                    throw new QueryValidationException(firstError.message());
+                }
+                throw buildSyntaxException(analysisResult.validationResult());
+            }
+
+            if (analysisResult.ast() == null) {
+                throw new QueryEvaluationException("SPARQL analysis completed without producing an AST");
+            }
+
+            return analysisResult.ast();
         } catch (QuerySyntaxException | QueryValidationException | QueryEvaluationException e) {
             throw e;
+        } catch (IOException e) {
+            throw new QueryEvaluationException("Failed to parse SPARQL query: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new QuerySyntaxException("Unexpected error during SPARQL parsing: " + e.getMessage(), e);
         }
@@ -100,7 +121,11 @@ public class SparqlParser extends AbstractQueryParser implements QueryTextValida
 
     @Override
     public QueryValidationResult validate(Reader reader, String baseIRI) {
-        return analyzer.validate(reader, baseIRI, getEffectiveConfig());
+        try {
+            return analyzer.analyze(reader, buildEffectiveOptions(baseIRI, true)).validationResult();
+        } catch (IOException e) {
+            throw new QueryEvaluationException("Failed to validate SPARQL query: " + e.getMessage(), e);
+        }
     }
 
     @Override
@@ -116,6 +141,38 @@ public class SparqlParser extends AbstractQueryParser implements QueryTextValida
     private String getBaseIRIFromConfig() {
         SparqlParserOptions opts = getEffectiveConfig();
         return opts.getBaseIRI();
+    }
+
+    private SparqlParserOptions buildEffectiveOptions(String baseIRI, boolean validationMode) {
+        SparqlParserOptions config = getEffectiveConfig();
+        String effectiveBaseIRI = baseIRI != null ? baseIRI : IOConstants.getDefaultBaseURI();
+        return new SparqlParserOptions.Builder()
+                .baseIRI(effectiveBaseIRI)
+                .strictMode(config.isStrictMode())
+                .failFast(!validationMode && config.isFailFast())
+                .collectErrors(validationMode || config.isCollectErrors())
+                .build();
+    }
+
+    private QueryDiagnostic firstErrorDiagnostic(QueryValidationResult validationResult) {
+        return validationResult.diagnostics().stream()
+                .filter(diagnostic -> diagnostic.severity() == QueryDiagnostic.Severity.ERROR)
+                .findFirst()
+                .orElse(validationResult.diagnostics().getFirst());
+    }
+
+    private QuerySyntaxException buildSyntaxException(QueryValidationResult validationResult) {
+        QueryDiagnostic firstDiagnostic = validationResult.diagnostics().getFirst();
+        String formattedDiagnostics = validationResult.diagnostics().stream()
+                .map(QueryDiagnostic::format)
+                .reduce((left, right) -> left + "; " + right)
+                .orElse("Unknown syntax error detected");
+
+        String message = "Syntax error in SPARQL query: " + formattedDiagnostics;
+        if (firstDiagnostic.line() >= 1 && firstDiagnostic.column() >= 0) {
+            return new QuerySyntaxException(message, firstDiagnostic.line(), firstDiagnostic.column());
+        }
+        return new QuerySyntaxException(message);
     }
 
     /**

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
@@ -1,0 +1,249 @@
+package fr.inria.corese.core.next.query.impl.parser;
+
+import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
+import fr.inria.corese.core.next.impl.parser.antlr.SparqlLexer;
+import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
+import fr.inria.corese.core.next.query.api.sparql.options.SparqlAstError;
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
+import fr.inria.corese.core.next.query.impl.parser.listener.AskQueryFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.BgpFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.ConstructQueryFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.DatasetClauseFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.DescribeQueryFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.FilterFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.PrologueFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.SelectQueryFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.SolutionModifierFeature;
+import fr.inria.corese.core.next.query.impl.parser.listener.UnionFeature;
+import fr.inria.corese.core.next.query.impl.parser.semantic.validator.SparqlQuerySemanticValidator;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DefaultErrorStrategy;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+/** Shared SPARQL analysis pipeline used by both parsing and validation entry points. */
+final class SparqlQueryAnalyzer {
+
+    private final SparqlQuerySemanticValidator semanticValidator = new SparqlQuerySemanticValidator();
+
+    /**
+     * Parses a SPARQL query and keeps the historical parser contract:
+     * syntax problems raise {@link QuerySyntaxException}, semantic problems
+     * raise {@link QueryValidationException}.
+     */
+    QueryAst parse(Reader reader, String baseIRI, SparqlParserOptions config) {
+        AnalysisResult analysisResult = analyze(reader, baseIRI, config, false);
+        if (!analysisResult.validationResult().isValid()) {
+            QueryDiagnostic firstError = firstErrorDiagnostic(analysisResult.validationResult());
+
+            if (firstError.kind() == QueryDiagnostic.Kind.SEMANTIC_ERROR) {
+                throw new QueryValidationException(firstError.message());
+            }
+            throw buildSyntaxException(analysisResult.validationResult());
+        }
+
+        if (analysisResult.ast() == null) {
+            throw new QueryEvaluationException("SPARQL analysis completed without producing an AST");
+        }
+
+        return analysisResult.ast();
+    }
+
+    /**
+     * Validates a SPARQL query and returns structured diagnostics instead of
+     * throwing on syntax or semantic issues.
+     */
+    QueryValidationResult validate(Reader reader, String baseIRI, SparqlParserOptions config) {
+        return analyze(reader, baseIRI, config, true).validationResult();
+    }
+
+    private AnalysisResult analyze(
+            Reader reader,
+            String baseIRI,
+            SparqlParserOptions config,
+            boolean validationMode
+    ) {
+        SparqlParserOptions effectiveOptions = buildEffectiveOptions(baseIRI, config, validationMode);
+        SyntaxAnalysis syntaxAnalysis = analyzeSyntax(reader, effectiveOptions);
+
+        if (!syntaxAnalysis.validationResult().isValid()) {
+            return new AnalysisResult(null, syntaxAnalysis.validationResult());
+        }
+
+        try {
+            QueryAst ast = buildAst(syntaxAnalysis.parseTree(), effectiveOptions);
+            QueryValidationResult semanticValidation = semanticValidator.validate(ast);
+            return new AnalysisResult(ast, semanticValidation);
+        } catch (QuerySyntaxException e) {
+            return new AnalysisResult(null, new QueryValidationResult(List.of(toSyntaxDiagnostic(e))));
+        }
+    }
+
+    private SparqlParserOptions buildEffectiveOptions(
+            String baseIRI,
+            SparqlParserOptions config,
+            boolean validationMode
+    ) {
+        String effectiveBaseIRI = baseIRI != null ? baseIRI : IOConstants.getDefaultBaseURI();
+        return new SparqlParserOptions.Builder()
+                .baseIRI(effectiveBaseIRI)
+                .strictMode(config.isStrictMode())
+                .failFast(!validationMode && config.isFailFast())
+                .collectErrors(validationMode || config.isCollectErrors())
+                .build();
+    }
+
+    private SyntaxAnalysis analyzeSyntax(Reader reader, SparqlParserOptions options) {
+        SparqlErrorListener errorListener = null;
+        try {
+            CharStream charStream = CharStreams.fromReader(reader);
+            SparqlLexer lexer = new SparqlLexer(charStream);
+
+            errorListener = new SparqlErrorListener(options);
+
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(errorListener);
+
+            CommonTokenStream tokens = new CommonTokenStream(lexer);
+            fr.inria.corese.core.next.impl.parser.antlr.SparqlParser parser =
+                    new fr.inria.corese.core.next.impl.parser.antlr.SparqlParser(tokens);
+
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+
+            if (options.isFailFast()) {
+                parser.setErrorHandler(new BailErrorStrategy());
+            } else {
+                parser.setErrorHandler(new DefaultErrorStrategy());
+            }
+
+            ParseTree tree = parser.query();
+            if (errorListener.hasErrors()) {
+                return new SyntaxAnalysis(
+                        null,
+                        new QueryValidationResult(mapSyntaxDiagnostics(errorListener.getDiagnostics())));
+            }
+
+            return new SyntaxAnalysis(tree, new QueryValidationResult(List.of()));
+        } catch (RecognitionException e) {
+            return new SyntaxAnalysis(null, new QueryValidationResult(List.of(
+                    new QueryDiagnostic(
+                            QueryDiagnostic.Kind.SYNTAX_ERROR,
+                            QueryDiagnostic.Severity.ERROR,
+                            "Recognition error in SPARQL query: " + e.getMessage(),
+                            -1,
+                            -1,
+                            null,
+                            e.getClass().getSimpleName()))));
+        } catch (ParseCancellationException e) {
+            QuerySyntaxException syntaxException = SparqlParser.toQuerySyntaxException(e, errorListener);
+            return new SyntaxAnalysis(null, new QueryValidationResult(List.of(toSyntaxDiagnostic(syntaxException))));
+        } catch (QuerySyntaxException e) {
+            return new SyntaxAnalysis(null, new QueryValidationResult(List.of(toSyntaxDiagnostic(e))));
+        } catch (IOException e) {
+            throw new QueryEvaluationException("Failed to validate SPARQL query: " + e.getMessage(), e);
+        }
+    }
+
+    private QueryAst buildAst(ParseTree tree, SparqlParserOptions options) {
+        SparqlAstBuilder builder = new SparqlAstBuilder(options);
+
+        SparqlListener listener = new SparqlListener(List.of(
+                new BgpFeature(builder),
+                new AskQueryFeature(builder),
+                new SelectQueryFeature(builder),
+                new ConstructQueryFeature(builder),
+                new SolutionModifierFeature(builder),
+                new FilterFeature(builder),
+                new UnionFeature(builder),
+                new DescribeQueryFeature(builder),
+                new DatasetClauseFeature(builder),
+                new PrologueFeature(builder)
+        ));
+
+        ParseTreeWalker walker = new ParseTreeWalker();
+        walker.walk(listener, tree);
+        return builder.getResult();
+    }
+
+    private List<QueryDiagnostic> mapSyntaxDiagnostics(List<SparqlAstError> diagnostics) {
+        return diagnostics.stream()
+                .map(SparqlQueryAnalyzer::toQueryDiagnostic)
+                .toList();
+    }
+
+    static QueryDiagnostic toQueryDiagnostic(SparqlAstError diagnostic) {
+        QueryDiagnostic.Kind kind = switch (diagnostic.kind()) {
+            case LEXER_ERROR -> QueryDiagnostic.Kind.LEXER_ERROR;
+            case SYNTAX_ERROR -> QueryDiagnostic.Kind.SYNTAX_ERROR;
+            case STRICT_MODE_ERROR -> QueryDiagnostic.Kind.SEMANTIC_ERROR;
+        };
+
+        QueryDiagnostic.Severity severity = switch (diagnostic.severity()) {
+            case INFO -> QueryDiagnostic.Severity.INFO;
+            case WARNING -> QueryDiagnostic.Severity.WARNING;
+            case ERROR -> QueryDiagnostic.Severity.ERROR;
+        };
+
+        return new QueryDiagnostic(
+                kind,
+                severity,
+                diagnostic.message(),
+                diagnostic.line(),
+                diagnostic.column(),
+                diagnostic.offendingText(),
+                diagnostic.source());
+    }
+
+    private QueryDiagnostic toSyntaxDiagnostic(QuerySyntaxException exception) {
+        return new QueryDiagnostic(
+                QueryDiagnostic.Kind.SYNTAX_ERROR,
+                QueryDiagnostic.Severity.ERROR,
+                exception.getMessage(),
+                exception.getLine(),
+                exception.getColumn(),
+                null,
+                exception.getClass().getSimpleName());
+    }
+
+    private QueryDiagnostic firstErrorDiagnostic(QueryValidationResult validationResult) {
+        return validationResult.diagnostics().stream()
+                .filter(diagnostic -> diagnostic.severity() == QueryDiagnostic.Severity.ERROR)
+                .findFirst()
+                .orElse(validationResult.diagnostics().getFirst());
+    }
+
+    private QuerySyntaxException buildSyntaxException(QueryValidationResult validationResult) {
+        List<QueryDiagnostic> diagnostics = validationResult.diagnostics();
+        QueryDiagnostic firstDiagnostic = diagnostics.getFirst();
+        String formattedDiagnostics = diagnostics.stream()
+                .map(QueryDiagnostic::format)
+                .reduce((left, right) -> left + "; " + right)
+                .orElse("Unknown syntax error detected");
+
+        String message = "Syntax error in SPARQL query: " + formattedDiagnostics;
+        if (firstDiagnostic.line() >= 1 && firstDiagnostic.column() >= 0) {
+            return new QuerySyntaxException(message, firstDiagnostic.line(), firstDiagnostic.column());
+        }
+        return new QuerySyntaxException(message);
+    }
+
+    private record SyntaxAnalysis(ParseTree parseTree, QueryValidationResult validationResult) {
+    }
+
+    private record AnalysisResult(QueryAst ast, QueryValidationResult validationResult) {
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
@@ -1,10 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
-import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
 import fr.inria.corese.core.next.impl.parser.antlr.SparqlLexer;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.api.sparql.options.SparqlAstError;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
@@ -34,57 +31,23 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
 
-/** Shared SPARQL analysis pipeline used by both parsing and validation entry points. */
+/**
+ * Performs SPARQL syntax, AST, and semantic analysis and returns the
+ * collected result to the caller.
+ */
 final class SparqlQueryAnalyzer {
 
     private final SparqlQuerySemanticValidator semanticValidator = new SparqlQuerySemanticValidator();
 
-    /**
-     * Parses a SPARQL query and keeps the historical parser contract:
-     * syntax problems raise {@link QuerySyntaxException}, semantic problems
-     * raise {@link QueryValidationException}.
-     */
-    QueryAst parse(Reader reader, String baseIRI, SparqlParserOptions config) {
-        AnalysisResult analysisResult = analyze(reader, baseIRI, config, false);
-        if (!analysisResult.validationResult().isValid()) {
-            QueryDiagnostic firstError = firstErrorDiagnostic(analysisResult.validationResult());
-
-            if (firstError.kind() == QueryDiagnostic.Kind.SEMANTIC_ERROR) {
-                throw new QueryValidationException(firstError.message());
-            }
-            throw buildSyntaxException(analysisResult.validationResult());
-        }
-
-        if (analysisResult.ast() == null) {
-            throw new QueryEvaluationException("SPARQL analysis completed without producing an AST");
-        }
-
-        return analysisResult.ast();
-    }
-
-    /**
-     * Validates a SPARQL query and returns structured diagnostics instead of
-     * throwing on syntax or semantic issues.
-     */
-    QueryValidationResult validate(Reader reader, String baseIRI, SparqlParserOptions config) {
-        return analyze(reader, baseIRI, config, true).validationResult();
-    }
-
-    private AnalysisResult analyze(
-            Reader reader,
-            String baseIRI,
-            SparqlParserOptions config,
-            boolean validationMode
-    ) {
-        SparqlParserOptions effectiveOptions = buildEffectiveOptions(baseIRI, config, validationMode);
-        SyntaxAnalysis syntaxAnalysis = analyzeSyntax(reader, effectiveOptions);
+    AnalysisResult analyze(Reader reader, SparqlParserOptions options) throws IOException {
+        SyntaxAnalysis syntaxAnalysis = analyzeSyntax(reader, options);
 
         if (!syntaxAnalysis.validationResult().isValid()) {
             return new AnalysisResult(null, syntaxAnalysis.validationResult());
         }
 
         try {
-            QueryAst ast = buildAst(syntaxAnalysis.parseTree(), effectiveOptions);
+            QueryAst ast = buildAst(syntaxAnalysis.parseTree(), options);
             QueryValidationResult semanticValidation = semanticValidator.validate(ast);
             return new AnalysisResult(ast, semanticValidation);
         } catch (QuerySyntaxException e) {
@@ -92,21 +55,7 @@ final class SparqlQueryAnalyzer {
         }
     }
 
-    private SparqlParserOptions buildEffectiveOptions(
-            String baseIRI,
-            SparqlParserOptions config,
-            boolean validationMode
-    ) {
-        String effectiveBaseIRI = baseIRI != null ? baseIRI : IOConstants.getDefaultBaseURI();
-        return new SparqlParserOptions.Builder()
-                .baseIRI(effectiveBaseIRI)
-                .strictMode(config.isStrictMode())
-                .failFast(!validationMode && config.isFailFast())
-                .collectErrors(validationMode || config.isCollectErrors())
-                .build();
-    }
-
-    private SyntaxAnalysis analyzeSyntax(Reader reader, SparqlParserOptions options) {
+    private SyntaxAnalysis analyzeSyntax(Reader reader, SparqlParserOptions options) throws IOException {
         SparqlErrorListener errorListener = null;
         try {
             CharStream charStream = CharStreams.fromReader(reader);
@@ -153,8 +102,6 @@ final class SparqlQueryAnalyzer {
             return new SyntaxAnalysis(null, new QueryValidationResult(List.of(toSyntaxDiagnostic(syntaxException))));
         } catch (QuerySyntaxException e) {
             return new SyntaxAnalysis(null, new QueryValidationResult(List.of(toSyntaxDiagnostic(e))));
-        } catch (IOException e) {
-            throw new QueryEvaluationException("Failed to validate SPARQL query: " + e.getMessage(), e);
         }
     }
 
@@ -219,31 +166,9 @@ final class SparqlQueryAnalyzer {
                 exception.getClass().getSimpleName());
     }
 
-    private QueryDiagnostic firstErrorDiagnostic(QueryValidationResult validationResult) {
-        return validationResult.diagnostics().stream()
-                .filter(diagnostic -> diagnostic.severity() == QueryDiagnostic.Severity.ERROR)
-                .findFirst()
-                .orElse(validationResult.diagnostics().getFirst());
-    }
-
-    private QuerySyntaxException buildSyntaxException(QueryValidationResult validationResult) {
-        List<QueryDiagnostic> diagnostics = validationResult.diagnostics();
-        QueryDiagnostic firstDiagnostic = diagnostics.getFirst();
-        String formattedDiagnostics = diagnostics.stream()
-                .map(QueryDiagnostic::format)
-                .reduce((left, right) -> left + "; " + right)
-                .orElse("Unknown syntax error detected");
-
-        String message = "Syntax error in SPARQL query: " + formattedDiagnostics;
-        if (firstDiagnostic.line() >= 1 && firstDiagnostic.column() >= 0) {
-            return new QuerySyntaxException(message, firstDiagnostic.line(), firstDiagnostic.column());
-        }
-        return new QuerySyntaxException(message);
-    }
-
     private record SyntaxAnalysis(ParseTree parseTree, QueryValidationResult validationResult) {
     }
 
-    private record AnalysisResult(QueryAst ast, QueryValidationResult validationResult) {
+    record AnalysisResult(QueryAst ast, QueryValidationResult validationResult) {
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OrderByScopeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OrderByScopeValidationRule.java
@@ -1,0 +1,113 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VariableScopeAnalyzer;
+import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.DescribeQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.OrderConditionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ProjectionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SolutionModifierAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates that variables referenced from ORDER BY are visible from the
+ * WHERE clause scope.
+ */
+public final class OrderByScopeValidationRule implements SemanticValidationRule {
+
+    private static final String DIAGNOSTIC_SOURCE = "OrderByScopeValidationRule";
+
+    private final VariableScopeAnalyzer variableScopeAnalyzer = new VariableScopeAnalyzer();
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        return switch (queryAst) {
+            case SelectQueryAst selectQueryAst -> validateSelectQuery(selectQueryAst);
+            case ConstructQueryAst constructQueryAst -> validateOrderByOnly(
+                    constructQueryAst.whereClause(),
+                    constructQueryAst.solutionModifier());
+            case DescribeQueryAst describeQueryAst -> validateOrderByOnly(
+                    describeQueryAst.whereClause(),
+                    describeQueryAst.solutionModifier());
+            // TODO: handle ASK solution modifiers with SPARQL 1.1 support.
+            case AskQueryAst ignored -> List.of();
+        };
+    }
+
+    private List<QueryDiagnostic> validateSelectQuery(SelectQueryAst queryAst) {
+        Set<String> visibleVariables = variableScopeAnalyzer.collectVisibleVariables(queryAst.whereClause());
+        List<QueryDiagnostic> diagnostics = new ArrayList<>();
+        validateOrderVariables(
+                collectOrderByAvailableVariables(queryAst.projection(), visibleVariables),
+                queryAst.solutionModifier(),
+                diagnostics);
+        return List.copyOf(diagnostics);
+    }
+
+    private List<QueryDiagnostic> validateOrderByOnly(
+            GroupGraphPatternAst whereClause,
+            SolutionModifierAst solutionModifier
+    ) {
+        List<QueryDiagnostic> diagnostics = new ArrayList<>();
+        Set<String> visibleVariables = variableScopeAnalyzer.collectVisibleVariables(whereClause);
+        validateOrderVariables(visibleVariables, solutionModifier, diagnostics);
+        return List.copyOf(diagnostics);
+    }
+
+    /**
+     * ORDER BY is applied before the final projection step. For the current
+     * feature set, the variables visible from the WHERE clause remain the source
+     * of truth, and explicit projection variables are added to keep the rule
+     * ready for SELECT-specific extensions.
+     */
+    private Set<String> collectOrderByAvailableVariables(
+            ProjectionAst projection,
+            Set<String> visibleVariables
+    ) {
+        Set<String> availableVariables = new LinkedHashSet<>(visibleVariables);
+        // TODO: handle SELECT aliases, GROUP BY, and HAVING with SPARQL 1.1 support.
+        if (!projection.selectAll()) {
+            for (VarAst projectedVar : projection.variables()) {
+                availableVariables.add(projectedVar.name());
+            }
+        }
+        return availableVariables;
+    }
+
+    private void validateOrderVariables(
+            Set<String> availableOrderVariables,
+            SolutionModifierAst solutionModifier,
+            List<QueryDiagnostic> diagnostics
+    ) {
+        for (OrderConditionAst orderCondition : solutionModifier.orderBy()) {
+            Set<String> referencedVariables = variableScopeAnalyzer
+                    .collectReferencedVariables(orderCondition.expression());
+
+            for (String variableName : referencedVariables) {
+                if (!availableOrderVariables.contains(variableName)) {
+                    diagnostics.add(buildOutOfScopeDiagnostic(variableName, "ORDER BY"));
+                }
+            }
+        }
+    }
+
+    private QueryDiagnostic buildOutOfScopeDiagnostic(String variableName, String clause) {
+        return new QueryDiagnostic(
+                QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                QueryDiagnostic.Severity.ERROR,
+                "Variable ?" + variableName + " used in " + clause + " is not visible in WHERE clause",
+                -1,
+                -1,
+                "?" + variableName,
+                DIAGNOSTIC_SOURCE);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/SelectProjectionScopeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/SelectProjectionScopeValidationRule.java
@@ -1,0 +1,62 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VariableScopeAnalyzer;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ProjectionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates that explicitly projected SELECT variables are visible from the
+ * WHERE clause scope.
+ */
+public final class SelectProjectionScopeValidationRule implements SemanticValidationRule {
+
+    private static final String DIAGNOSTIC_SOURCE = "SelectProjectionScopeValidationRule";
+
+    private final VariableScopeAnalyzer variableScopeAnalyzer = new VariableScopeAnalyzer();
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        if (!(queryAst instanceof SelectQueryAst selectQueryAst)) {
+            return List.of();
+        }
+        if (selectQueryAst.projection().selectAll()) {
+            return List.of();
+        }
+
+        Set<String> visibleVariables = variableScopeAnalyzer.collectVisibleVariables(selectQueryAst.whereClause());
+        List<QueryDiagnostic> diagnostics = new ArrayList<>();
+        validateProjectionVariables(selectQueryAst.projection(), visibleVariables, diagnostics);
+        return List.copyOf(diagnostics);
+    }
+
+    private void validateProjectionVariables(
+            ProjectionAst projection,
+            Set<String> visibleVariables,
+            List<QueryDiagnostic> diagnostics
+    ) {
+        // TODO: handle SELECT (expr AS ?var) with SPARQL 1.1 support.
+        for (VarAst projectedVar : projection.variables()) {
+            if (!visibleVariables.contains(projectedVar.name())) {
+                diagnostics.add(buildOutOfScopeDiagnostic(projectedVar.name(), "SELECT projection"));
+            }
+        }
+    }
+
+    private QueryDiagnostic buildOutOfScopeDiagnostic(String variableName, String clause) {
+        return new QueryDiagnostic(
+                QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                QueryDiagnostic.Severity.ERROR,
+                "Variable ?" + variableName + " used in " + clause + " is not visible in WHERE clause",
+                -1,
+                -1,
+                "?" + variableName,
+                DIAGNOSTIC_SOURCE);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/SemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/SemanticValidationRule.java
@@ -1,0 +1,14 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+
+import java.util.List;
+
+/**
+ * Internal semantic validation rule applied to a parsed query AST.
+ */
+public interface SemanticValidationRule {
+
+    List<QueryDiagnostic> validate(QueryAst queryAst);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
@@ -1,4 +1,4 @@
-package fr.inria.corese.core.next.query.impl.parser;
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
 
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
@@ -1,0 +1,45 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.validator;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
+import fr.inria.corese.core.next.query.api.validation.QueryValidator;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.OrderByScopeValidationRule;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SelectProjectionScopeValidationRule;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SemanticValidationRule;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Internal semantic validator for SPARQL query ASTs produced by the
+ * {@code next} parser.
+ */
+public final class SparqlQuerySemanticValidator implements QueryValidator<QueryAst> {
+
+    private final List<SemanticValidationRule> rules;
+
+    public SparqlQuerySemanticValidator() {
+        this(List.of(
+                new SelectProjectionScopeValidationRule(),
+                new OrderByScopeValidationRule()));
+    }
+
+    /** Package-private for tests or future composition of rule sets. */
+    SparqlQuerySemanticValidator(List<SemanticValidationRule> rules) {
+        this.rules = List.copyOf(rules);
+    }
+
+    @Override
+    public QueryValidationResult validate(QueryAst input) {
+        if (input == null) {
+            return new QueryValidationResult(List.of());
+        }
+
+        List<QueryDiagnostic> diagnostics = new ArrayList<>();
+        for (SemanticValidationRule rule : rules) {
+            diagnostics.addAll(rule.validate(input));
+        }
+        return new QueryValidationResult(diagnostics);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
@@ -21,7 +21,13 @@ import java.util.List;
  * }
  * }</pre>
  */
-public record DescribeQueryAst(DatasetClauseAst datasetClause, List<TermAst> described, GroupGraphPatternAst whereClause, QueryPrologueAst prologue) implements QueryAst {
+public record DescribeQueryAst(
+        DatasetClauseAst datasetClause,
+        List<TermAst> described,
+        GroupGraphPatternAst whereClause,
+        SolutionModifierAst solutionModifier,
+        QueryPrologueAst prologue
+) implements QueryAst {
     public DescribeQueryAst {
         described = described != null ? List.copyOf(described) : List.of();
         if (whereClause == null) {
@@ -29,6 +35,9 @@ public record DescribeQueryAst(DatasetClauseAst datasetClause, List<TermAst> des
         }
         if(datasetClause == null) {
             datasetClause = DatasetClauseAst.none();
+        }
+        if (solutionModifier == null) {
+            solutionModifier = SolutionModifierAst.empty();
         }
         if(prologue == null) {
             prologue = QueryPrologueAst.empty();
@@ -38,8 +47,20 @@ public record DescribeQueryAst(DatasetClauseAst datasetClause, List<TermAst> des
     /**
      * constructor with default prefix handler
      */
+    public DescribeQueryAst(
+            DatasetClauseAst datasetClause,
+            List<TermAst> described,
+            GroupGraphPatternAst whereClause,
+            SolutionModifierAst solutionModifier
+    ) {
+        this(datasetClause, described, whereClause, solutionModifier, null);
+    }
+
+    /**
+     * constructor with default prefix handler and default solution modifier
+     */
     public DescribeQueryAst(DatasetClauseAst datasetClause, List<TermAst> described, GroupGraphPatternAst whereClause) {
-        this(datasetClause, described, whereClause, null);
+        this(datasetClause, described, whereClause, null, null);
     }
 
     /**

--- a/src/test/java/fr/inria/corese/core/next/query/api/validation/QueryValidationResultTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/api/validation/QueryValidationResultTest.java
@@ -1,0 +1,71 @@
+package fr.inria.corese.core.next.query.api.validation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryValidationResultTest {
+
+    @Test
+    void isValidWhenNoDiagnosticsArePresent() {
+        QueryValidationResult result = new QueryValidationResult(List.of());
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void isValidWhenOnlyInfoDiagnosticsArePresent() {
+        QueryValidationResult result = new QueryValidationResult(List.of(
+                new QueryDiagnostic(
+                        QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                        QueryDiagnostic.Severity.INFO,
+                        "Informational diagnostic",
+                        -1,
+                        -1,
+                        null,
+                        "test")));
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void isValidWhenOnlyWarningDiagnosticsArePresent() {
+        QueryValidationResult result = new QueryValidationResult(List.of(
+                new QueryDiagnostic(
+                        QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                        QueryDiagnostic.Severity.WARNING,
+                        "Warning diagnostic",
+                        -1,
+                        -1,
+                        null,
+                        "test")));
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void isInvalidWhenAtLeastOneErrorDiagnosticIsPresent() {
+        QueryValidationResult result = new QueryValidationResult(List.of(
+                new QueryDiagnostic(
+                        QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                        QueryDiagnostic.Severity.WARNING,
+                        "Warning diagnostic",
+                        -1,
+                        -1,
+                        null,
+                        "test"),
+                new QueryDiagnostic(
+                        QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                        QueryDiagnostic.Severity.ERROR,
+                        "Error diagnostic",
+                        -1,
+                        -1,
+                        null,
+                        "test")));
+
+        assertFalse(result.isValid());
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderDescribeTest.java
@@ -118,8 +118,8 @@ class SparqlAstBuilderDescribeTest {
             builder.addDescribeResource(builder.var("?s"));
             DescribeQueryAst result = buildWithEmptyWhere();
 
-            VarAst var = (VarAst) result.described().getFirst();
-            assertEquals("s", var.name());
+            VarAst describedVar = (VarAst) result.described().getFirst();
+            assertEquals("s", describedVar.name());
         }
 
         @Test
@@ -128,8 +128,8 @@ class SparqlAstBuilderDescribeTest {
             builder.addDescribeResource(builder.var("$x"));
             DescribeQueryAst result = buildWithEmptyWhere();
 
-            VarAst var = (VarAst) result.described().getFirst();
-            assertEquals("x", var.name());
+            VarAst describedVar = (VarAst) result.described().getFirst();
+            assertEquals("x", describedVar.name());
         }
     }
 
@@ -203,7 +203,7 @@ class SparqlAstBuilderDescribeTest {
         @Test
         @DisplayName("null described list defaults to empty list")
         void nullDescribedDefaultsToEmpty() {
-            DescribeQueryAst ast = new DescribeQueryAst(null,null, null);
+            DescribeQueryAst ast = new DescribeQueryAst(null, null, null);
             assertNotNull(ast.described());
             assertTrue(ast.described().isEmpty());
         }
@@ -211,9 +211,19 @@ class SparqlAstBuilderDescribeTest {
         @Test
         @DisplayName("null whereClause defaults to empty GroupGraphPatternAst")
         void nullWhereClauseDefaultsToEmptyGroup() {
-            DescribeQueryAst ast = new DescribeQueryAst(null,null, null);
+            DescribeQueryAst ast = new DescribeQueryAst(null, null, null);
             assertNotNull(ast.whereClause());
             assertTrue(ast.whereClause().patterns().isEmpty());
+        }
+
+        @Test
+        @DisplayName("null solutionModifier defaults to empty SolutionModifierAst")
+        void nullSolutionModifierDefaultsToEmpty() {
+            DescribeQueryAst ast = new DescribeQueryAst(null, null, null, null);
+            assertNotNull(ast.solutionModifier());
+            assertTrue(ast.solutionModifier().orderBy().isEmpty());
+            assertNull(ast.solutionModifier().limit());
+            assertNull(ast.solutionModifier().offset());
         }
 
         @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserConstructQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserConstructQueryTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SparqlParserConstructQueryTest extends AbstractSparqlParserFeatureTest {
+class SparqlParserConstructQueryTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("Should parse a basic CONSTRUCT query")
@@ -44,9 +44,9 @@ public class SparqlParserConstructQueryTest extends AbstractSparqlParserFeatureT
     @Test
     @DisplayName("Should parse a template with Blank Nodes")
     void shouldParseATemplateWithBlankNodes() {
-        SparqlParser parse = newParserDefault();
+        SparqlParser sparqlParser = newParserDefault();
 
-        QueryAst ast = parse.parse("""
+        QueryAst ast = sparqlParser.parse("""
                 PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
                 PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>
                 
@@ -65,46 +65,79 @@ public class SparqlParserConstructQueryTest extends AbstractSparqlParserFeatureT
 
         assertNotNull(construct.constructTemplate());
         assertNotNull(construct.whereClause());
+        assertTemplateWithBlankNodes(construct.constructTemplate());
+        assertWhereContainsTwoUnions(construct.whereClause());
+    }
 
-        // --- Template: 3 triples (?x vcard:N _:v . _:v vcard:givenName ?gname . _:v vcard:familyName ?fname)
-        ConstructTemplateAst template = construct.constructTemplate();
+    @Test
+    @DisplayName("Should parse CONSTRUCT solution modifiers")
+    void shouldParseConstructSolutionModifiers() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+            CONSTRUCT {
+                ?s ?p ?o
+            }
+            WHERE {
+                ?s ?p ?o
+            }
+            ORDER BY DESC(?o)
+            LIMIT 10
+            OFFSET 5
+            """);
+
+        assertInstanceOf(ConstructQueryAst.class, ast);
+
+        ConstructQueryAst construct = (ConstructQueryAst) ast;
+        SolutionModifierAst solutionModifier = construct.solutionModifier();
+
+        assertNotNull(solutionModifier);
+        assertEquals(1, solutionModifier.orderBy().size());
+        assertEquals(ASTConstants.OrderDirection.DESC, solutionModifier.orderBy().getFirst().orderDirection());
+        assertInstanceOf(VarAst.class, solutionModifier.orderBy().getFirst().expression());
+        assertEquals("o", ((VarAst) solutionModifier.orderBy().getFirst().expression()).name());
+        assertEquals(10L, solutionModifier.limit());
+        assertEquals(5L, solutionModifier.offset());
+    }
+
+    private void assertTemplateWithBlankNodes(ConstructTemplateAst template) {
         assertEquals(3, template.triplePatternAsts().size());
 
-        TriplePatternAst t0 = template.triplePatternAsts().get(0);
-        assertInstanceOf(VarAst.class, t0.subject());
-        assertInstanceOf(IriAst.class, t0.predicate());
-        assertInstanceOf(IriAst.class, t0.object());
-        assertEquals("x", ((VarAst) t0.subject()).name());
-        assertEquals("vcard:N", ((IriAst) t0.predicate()).raw());
-        assertTrue(((IriAst) t0.object()).raw().startsWith("_:"), "object should be a blank node");
+        TriplePatternAst firstTriple = template.triplePatternAsts().get(0);
+        assertInstanceOf(VarAst.class, firstTriple.subject());
+        assertInstanceOf(IriAst.class, firstTriple.predicate());
+        assertInstanceOf(IriAst.class, firstTriple.object());
+        assertEquals("x", ((VarAst) firstTriple.subject()).name());
+        assertEquals("vcard:N", ((IriAst) firstTriple.predicate()).raw());
+        assertTrue(((IriAst) firstTriple.object()).raw().startsWith("_:"), "object should be a blank node");
 
-        TriplePatternAst t1 = template.triplePatternAsts().get(1);
-        assertInstanceOf(IriAst.class, t1.subject());
-        assertInstanceOf(IriAst.class, t1.predicate());
-        assertInstanceOf(VarAst.class, t1.object());
-        assertTrue(((IriAst) t1.subject()).raw().startsWith("_:"), "subject should be a blank node");
-        assertEquals("vcard:givenName", ((IriAst) t1.predicate()).raw());
-        assertEquals("gname", ((VarAst) t1.object()).name());
+        TriplePatternAst secondTriple = template.triplePatternAsts().get(1);
+        assertInstanceOf(IriAst.class, secondTriple.subject());
+        assertInstanceOf(IriAst.class, secondTriple.predicate());
+        assertInstanceOf(VarAst.class, secondTriple.object());
+        assertTrue(((IriAst) secondTriple.subject()).raw().startsWith("_:"), "subject should be a blank node");
+        assertEquals("vcard:givenName", ((IriAst) secondTriple.predicate()).raw());
+        assertEquals("gname", ((VarAst) secondTriple.object()).name());
 
-        TriplePatternAst t2 = template.triplePatternAsts().get(2);
-        assertInstanceOf(IriAst.class, t2.subject());
-        assertInstanceOf(IriAst.class, t2.predicate());
-        assertInstanceOf(VarAst.class, t2.object());
-        assertTrue(((IriAst) t2.subject()).raw().startsWith("_:"), "subject should be a blank node");
-        assertEquals("vcard:familyName", ((IriAst) t2.predicate()).raw());
-        assertEquals("fname", ((VarAst) t2.object()).name());
+        TriplePatternAst thirdTriple = template.triplePatternAsts().get(2);
+        assertInstanceOf(IriAst.class, thirdTriple.subject());
+        assertInstanceOf(IriAst.class, thirdTriple.predicate());
+        assertInstanceOf(VarAst.class, thirdTriple.object());
+        assertTrue(((IriAst) thirdTriple.subject()).raw().startsWith("_:"), "subject should be a blank node");
+        assertEquals("vcard:familyName", ((IriAst) thirdTriple.predicate()).raw());
+        assertEquals("fname", ((VarAst) thirdTriple.object()).name());
+    }
 
-        // --- WHERE: two UNION patterns
-        GroupGraphPatternAst where = construct.whereClause();
-        assertEquals(2, where.patterns().size());
-        assertInstanceOf(UnionAst.class, where.patterns().get(0));
-        assertInstanceOf(UnionAst.class, where.patterns().get(1));
+    private void assertWhereContainsTwoUnions(GroupGraphPatternAst whereClause) {
+        assertEquals(2, whereClause.patterns().size());
+        assertInstanceOf(UnionAst.class, whereClause.patterns().get(0));
+        assertInstanceOf(UnionAst.class, whereClause.patterns().get(1));
 
-        UnionAst union1 = (UnionAst) where.patterns().get(0);
-        UnionAst union2 = (UnionAst) where.patterns().get(1);
-        assertNotNull(union1.left());
-        assertNotNull(union1.right());
-        assertNotNull(union2.left());
-        assertNotNull(union2.right());
+        UnionAst firstUnion = (UnionAst) whereClause.patterns().get(0);
+        UnionAst secondUnion = (UnionAst) whereClause.patterns().get(1);
+        assertNotNull(firstUnion.left());
+        assertNotNull(firstUnion.right());
+        assertNotNull(secondUnion.left());
+        assertNotNull(secondUnion.right());
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDescribeTest.java
@@ -49,8 +49,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
             DescribeQueryAst result = (DescribeQueryAst) parser.parse(
                     "DESCRIBE ?s WHERE { ?s ?p ?o }");
 
-            VarAst var = (VarAst) result.described().getFirst();
-            assertEquals("s", var.name());
+            VarAst describedVar = (VarAst) result.described().getFirst();
+            assertEquals("s", describedVar.name());
         }
 
         @Test
@@ -138,8 +138,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("a list of From graphs can be inserted")
-    public void fromGraphs() {
-        SparqlParser parser = newParserDefault();
+    void fromGraphs() {
+        SparqlParser queryParser = newParserDefault();
         String commentedQuery = """
                 DESCRIBE ?s
                 FROM <http://ns.inria.fr/graph>
@@ -148,7 +148,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        QueryAst queryAst = queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -160,8 +160,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("a list of From graphs can be inserted")
-    public void fromMultipleGraphs() {
-        SparqlParser parser = newParserDefault();
+    void fromMultipleGraphs() {
+        SparqlParser queryParser = newParserDefault();
         String commentedQuery = """
                 DESCRIBE ?s
                 FROM <http://ns.inria.fr/graph1>
@@ -172,7 +172,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        QueryAst queryAst = queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -186,8 +186,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("a list of From graphs can be inserted")
-    public void fromNamedGraphs() {
-        SparqlParser parser = newParserDefault();
+    void fromNamedGraphs() {
+        SparqlParser queryParser = newParserDefault();
         String commentedQuery = """
                 DESCRIBE ?s
                 FROM NAMED <http://ns.inria.fr/graph>
@@ -196,7 +196,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        QueryAst queryAst = queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().namedGraphs());
@@ -208,8 +208,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("a list of From graphs can be inserted")
-    public void fromMultipleNamedGraphs() {
-        SparqlParser parser = newParserDefault();
+    void fromMultipleNamedGraphs() {
+        SparqlParser queryParser = newParserDefault();
         String commentedQuery = """
                 DESCRIBE ?s
                 FROM NAMED <http://ns.inria.fr/graph1>
@@ -220,7 +220,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        QueryAst queryAst = queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -234,8 +234,8 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
 
     @Test
     @DisplayName("a list of From graphs can be inserted")
-    public void fromMultipleMixedGraphs() {
-        SparqlParser parser = newParserDefault();
+    void fromMultipleMixedGraphs() {
+        SparqlParser queryParser = newParserDefault();
         String commentedQuery = """
                 DESCRIBE ?s
                 FROM <http://ns.inria.fr/graph1>
@@ -246,7 +246,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        QueryAst queryAst = queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -256,5 +256,30 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(queryAst.datasetClause().namedGraphs());
         assertEquals(1, queryAst.datasetClause().namedGraphs().size());
         assertInstanceOf(IriAst.class, queryAst.datasetClause().namedGraphs().toArray()[0]);
+    }
+
+    @Test
+    @DisplayName("DESCRIBE should parse solution modifiers")
+    void describeShouldParseSolutionModifiers() {
+        QueryAst ast = parser.parse("""
+                DESCRIBE ?s
+                WHERE {
+                    ?s ?p ?o
+                }
+                ORDER BY ?o
+                LIMIT 10
+                OFFSET 5
+                """);
+
+        assertInstanceOf(DescribeQueryAst.class, ast);
+        DescribeQueryAst describe = (DescribeQueryAst) ast;
+
+        assertNotNull(describe.solutionModifier());
+        assertEquals(1, describe.solutionModifier().orderBy().size());
+        assertEquals(ASTConstants.OrderDirection.ASC, describe.solutionModifier().orderBy().getFirst().orderDirection());
+        assertInstanceOf(VarAst.class, describe.solutionModifier().orderBy().getFirst().expression());
+        assertEquals("o", ((VarAst) describe.solutionModifier().orderBy().getFirst().expression()).name());
+        assertEquals(10L, describe.solutionModifier().limit());
+        assertEquals(5L, describe.solutionModifier().offset());
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
@@ -20,6 +20,10 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.io.parser.QueryOptions;
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.api.validation.QueryTextValidator;
+import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
+import fr.inria.corese.core.next.query.api.validation.QueryValidators;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
@@ -150,19 +154,23 @@ class SparqlParserTest {
     @Test
     void parseReaderIoExceptionWrapsInQueryEvaluationException() {
         SparqlParser parser = new SparqlParser(new SparqlParserOptions.Builder().build());
-        Reader failingReader = new Reader() {
-            @Override
-            public int read(char[] cbuf, int off, int len) throws IOException {
-                throw new IOException("read failed");
-            }
-            @Override
-            public void close() {}
-        };
+        Reader failingReader = newFailingReader();
 
         QueryEvaluationException ex = assertThrows(QueryEvaluationException.class, () ->
                 parser.parse(failingReader, null));
 
         assertTrue(ex.getMessage().contains("Failed to parse") || ex.getCause() instanceof IOException);
+    }
+
+    @Test
+    void validateReaderIoExceptionWrapsInQueryEvaluationException() {
+        SparqlParser parser = new SparqlParser(new SparqlParserOptions.Builder().build());
+        Reader failingReader = newFailingReader();
+
+        QueryEvaluationException ex = assertThrows(QueryEvaluationException.class, () ->
+                parser.validate(failingReader, null));
+
+        assertTrue(ex.getMessage().contains("Failed to validate") || ex.getCause() instanceof IOException);
     }
 
     @Test
@@ -174,5 +182,161 @@ class SparqlParserTest {
         assertNotNull(ast);
         assertNotNull(parser.getConfig());
         assertInstanceOf(SparqlParserOptions.class, parser.getConfig());
+    }
+
+    @Test
+    void validateReturnsNoDiagnosticsForValidQuery() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate(VALID_SELECT_QUERY);
+
+        assertTrue(result.isValid());
+        assertTrue(result.diagnostics().isEmpty());
+    }
+
+    @Test
+    void validateReturnsSyntaxDiagnosticInsteadOfThrowing() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate("SELECT * WHERE { ?s ?p . }");
+
+        assertFalse(result.isValid());
+        assertEquals(1, result.diagnostics().size());
+        assertEquals(QueryDiagnostic.Kind.SYNTAX_ERROR, result.diagnostics().getFirst().kind());
+    }
+
+    @Test
+    void validateReturnsLexerDiagnosticInsteadOfThrowing() {
+        SparqlParser parser = new SparqlParser();
+        String query = "SELECT * WHERE { ?s ?p ?o \u0001 }";
+
+        QueryValidationResult result = parser.validate(query);
+
+        assertFalse(result.isValid());
+        assertTrue(result.diagnostics().stream()
+                .anyMatch(diagnostic -> diagnostic.kind() == QueryDiagnostic.Kind.LEXER_ERROR));
+    }
+
+    @Test
+    void validateReturnsMultipleSemanticDiagnostics() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate("""
+                SELECT ?x ?y WHERE {
+                    ?s ?p ?o
+                }
+                ORDER BY ?z ?a
+                """);
+
+        assertFalse(result.isValid());
+        assertEquals(4, result.diagnostics().size());
+        assertTrue(result.diagnostics().stream()
+                .allMatch(diagnostic -> diagnostic.kind() == QueryDiagnostic.Kind.SEMANTIC_ERROR));
+
+
+                // Print all diagnostic messages for debugging
+        result.diagnostics().forEach(diagnostic -> System.out.println(diagnostic.message()));
+    }
+
+    @Test
+    void validateReturnsConstructSemanticDiagnostic() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate("""
+                CONSTRUCT {
+                    ?s ?p ?o
+                }
+                WHERE {
+                    ?s ?p ?o
+                }
+                ORDER BY ?z
+                """);
+
+        assertFalse(result.isValid());
+        assertEquals(1, result.diagnostics().size());
+        assertEquals(QueryDiagnostic.Kind.SEMANTIC_ERROR, result.diagnostics().getFirst().kind());
+        assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause",
+                result.diagnostics().getFirst().message());
+        assertEquals(QueryDiagnostic.Severity.ERROR, result.diagnostics().getFirst().severity());
+        assertEquals("OrderByScopeValidationRule", result.diagnostics().getFirst().source());
+    }
+
+    @Test
+    void validateReturnsDescribeSemanticDiagnostic() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate("""
+                DESCRIBE ?s
+                WHERE {
+                    ?s ?p ?o
+                }
+                ORDER BY ?z
+                """);
+
+        assertFalse(result.isValid());
+        assertEquals(1, result.diagnostics().size());
+        assertEquals(QueryDiagnostic.Kind.SEMANTIC_ERROR, result.diagnostics().getFirst().kind());
+        assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause",
+                result.diagnostics().getFirst().message());
+    }
+
+    @Test
+    void validateSyntaxDiagnosticKeepsLocationWhenAvailable() {
+        SparqlParser parser = new SparqlParser();
+
+        QueryValidationResult result = parser.validate("""
+                SELECT * WHERE {
+                    ?s ?p .
+                }
+                """);
+
+        assertFalse(result.isValid());
+        assertFalse(result.diagnostics().isEmpty());
+        assertEquals(QueryDiagnostic.Kind.SYNTAX_ERROR, result.diagnostics().getFirst().kind());
+        assertEquals(QueryDiagnostic.Severity.ERROR, result.diagnostics().getFirst().severity());
+        assertTrue(result.diagnostics().getFirst().line() >= 1);
+        assertTrue(result.diagnostics().getFirst().column() >= 0);
+        assertEquals("SparqlParser", result.diagnostics().getFirst().source());
+    }
+
+    @Test
+    void validateLexerDiagnosticKeepsLocationAndSourceWhenAvailable() {
+        SparqlParser parser = new SparqlParser();
+        String query = "SELECT * WHERE { ?s ?p ?o \u0001 }";
+
+        QueryValidationResult result = parser.validate(query);
+
+        QueryDiagnostic lexerDiagnostic = result.diagnostics().stream()
+                .filter(diagnostic -> diagnostic.kind() == QueryDiagnostic.Kind.LEXER_ERROR)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(QueryDiagnostic.Severity.ERROR, lexerDiagnostic.severity());
+        assertTrue(lexerDiagnostic.line() >= 1);
+        assertTrue(lexerDiagnostic.column() >= 0);
+        assertEquals("SparqlLexer", lexerDiagnostic.source());
+    }
+
+    @Test
+    void queryValidatorsFactoryReturnsWorkingSparqlValidator() {
+        QueryTextValidator validator = QueryValidators.sparql();
+
+        QueryValidationResult result = validator.validate(VALID_SELECT_QUERY);
+
+        assertTrue(result.isValid());
+    }
+
+    private Reader newFailingReader() {
+        return new Reader() {
+            @Override
+            public int read(char[] cbuf, int off, int len) throws IOException {
+                throw new IOException("read failed");
+            }
+
+            @Override
+            public void close() {
+                // Nothing to close for this in-memory failing reader.
+            }
+        };
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
@@ -232,10 +232,6 @@ class SparqlParserTest {
         assertEquals(4, result.diagnostics().size());
         assertTrue(result.diagnostics().stream()
                 .allMatch(diagnostic -> diagnostic.kind() == QueryDiagnostic.Kind.SEMANTIC_ERROR));
-
-
-                // Print all diagnostic messages for debugging
-        result.diagnostics().forEach(diagnostic -> System.out.println(diagnostic.message()));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -4,121 +4,141 @@ import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
+class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
-    @Nested
-    class SelectValidationTest {
+    private static final String ORDER_BY_SCOPE_MESSAGE =
+            "Variable ?z used in ORDER BY is not visible in WHERE clause";
+    private static final String SELECT_PROJECTION_SCOPE_MESSAGE =
+            "Variable ?x used in SELECT projection is not visible in WHERE clause";
+    private static final String CITY_LABEL_SCOPE_MESSAGE =
+            "Variable ?cityLabel used in SELECT projection is not visible in WHERE clause";
 
-        @Test
-        @DisplayName("Should reject SELECT * with ORDER BY variable not visible in WHERE")
-        void shouldRejectSelectAllWithOrderByVariableNotVisibleInWhere() {
-            SparqlParser parser = newParserDefault();
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidSelectQueries")
+    void shouldRejectInvalidSelectQueries(String testName, String query, String expectedMessage) {
+        SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY ?z
-                """));
+        QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse(query));
 
-            assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause", exception.getMessage());
-        }
-
-        @Test
-        void shouldRejectProjectionVariableOnlyReferencedInFilter() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                SELECT ?x WHERE {
-                  ?s ?p ?o .
-                  FILTER(BOUND(?x))
-                }
-                """));
-
-            assertEquals("Variable ?x used in SELECT projection is not visible in WHERE clause", exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should reject projection variable not visible through UNION")
-        void shouldRejectInvalidProjectionWithUnion() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT ?cityLabel
-                    WHERE {
-                      { ?country wdt:P36 ?city. }
-                      UNION
-                      { ?city wdt:P17 ?country. }
-                    }
-                """));
-
-            assertEquals("Variable ?cityLabel used in SELECT projection is not visible in WHERE clause",
-                    exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should reject ORDER BY variable not visible in WHERE")
-        void shouldRejectOrderByVariableNotVisibleInWhere() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT ?s WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY ?z
-                """));
-
-            assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause", exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should reject multiple ORDER BY clauses when one variable is not visible in WHERE")
-        void shouldRejectMultipleOrderByWhenOneVariableIsNotVisibleInWhere() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT ?s WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY ?s ?z
-                """));
-
-            assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause", exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should reject ORDER BY expression using a variable not visible in WHERE")
-        void shouldRejectOrderByExpressionNotVisibleInWhere() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT ?s WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY STR(?z)
-                """));
-
-            assertEquals("Variable ?z used in ORDER BY is not visible in WHERE clause", exception.getMessage());
-        }
-
-        @Test
-        @DisplayName("Should reject SELECT projection variables not visible in WHERE")
-        void shouldRejectInvalidProjection() {
-            SparqlParser parser = newParserDefault();
-
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT ?x WHERE {
-                        ?s ?p ?o
-                    }
-                """));
-
-            assertEquals("Variable ?x used in SELECT projection is not visible in WHERE clause", exception.getMessage());
-        }
-
+        assertEquals(expectedMessage, exception.getMessage());
     }
 
+    @Nested
+    class ConstructValidationTest {
+
+        @Test
+        @DisplayName("Should reject CONSTRUCT ORDER BY variable not visible in WHERE")
+        void shouldRejectConstructOrderByVariableNotVisibleInWhere() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    CONSTRUCT {
+                        ?s ?p ?o
+                    }
+                    WHERE {
+                        ?s ?p ?o
+                    }
+                    ORDER BY ?z
+                """));
+
+            assertEquals(ORDER_BY_SCOPE_MESSAGE, exception.getMessage());
+        }
+    }
+
+    @Nested
+    class DescribeValidationTest {
+
+        @Test
+        @DisplayName("Should reject DESCRIBE ORDER BY variable not visible in WHERE")
+        void shouldRejectDescribeOrderByVariableNotVisibleInWhere() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    DESCRIBE ?s
+                    WHERE {
+                        ?s ?p ?o
+                    }
+                    ORDER BY ?z
+                """));
+
+            assertEquals(ORDER_BY_SCOPE_MESSAGE, exception.getMessage());
+        }
+    }
+
+    private static Stream<Arguments> invalidSelectQueries() {
+        return Stream.of(
+                Arguments.of(
+                        "Should reject SELECT * with ORDER BY variable not visible in WHERE",
+                        """
+                        SELECT * WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY ?z
+                        """,
+                        ORDER_BY_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject projection variable only referenced in FILTER",
+                        """
+                        SELECT ?x WHERE {
+                          ?s ?p ?o .
+                          FILTER(BOUND(?x))
+                        }
+                        """,
+                        SELECT_PROJECTION_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject projection variable not visible through UNION",
+                        """
+                        SELECT ?cityLabel
+                        WHERE {
+                          { ?country wdt:P36 ?city. }
+                          UNION
+                          { ?city wdt:P17 ?country. }
+                        }
+                        """,
+                        CITY_LABEL_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject ORDER BY variable not visible in WHERE",
+                        """
+                        SELECT ?s WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY ?z
+                        """,
+                        ORDER_BY_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject multiple ORDER BY clauses when one variable is not visible in WHERE",
+                        """
+                        SELECT ?s WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY ?s ?z
+                        """,
+                        ORDER_BY_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject ORDER BY expression using a variable not visible in WHERE",
+                        """
+                        SELECT ?s WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY STR(?z)
+                        """,
+                        ORDER_BY_SCOPE_MESSAGE),
+                Arguments.of(
+                        "Should reject SELECT projection variables not visible in WHERE",
+                        """
+                        SELECT ?x WHERE {
+                            ?s ?p ?o
+                        }
+                        """,
+                        SELECT_PROJECTION_SCOPE_MESSAGE));
+    }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzerTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzerTest.java
@@ -1,0 +1,55 @@
+package fr.inria.corese.core.next.query.impl.parser;
+
+import fr.inria.corese.core.next.query.api.sparql.options.SparqlAstError;
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SparqlQueryAnalyzerTest {
+
+    @Test
+    void toQueryDiagnosticPreservesInfoSeverity() {
+        QueryDiagnostic diagnostic = SparqlQueryAnalyzer.toQueryDiagnostic(new SparqlAstError(
+                SparqlAstError.Kind.SYNTAX_ERROR,
+                SparqlAstError.Severity.INFO,
+                "Informational syntax diagnostic",
+                1,
+                2,
+                "token",
+                "source"));
+
+        assertEquals(QueryDiagnostic.Kind.SYNTAX_ERROR, diagnostic.kind());
+        assertEquals(QueryDiagnostic.Severity.INFO, diagnostic.severity());
+    }
+
+    @Test
+    void toQueryDiagnosticPreservesWarningSeverity() {
+        QueryDiagnostic diagnostic = SparqlQueryAnalyzer.toQueryDiagnostic(new SparqlAstError(
+                SparqlAstError.Kind.LEXER_ERROR,
+                SparqlAstError.Severity.WARNING,
+                "Warning lexer diagnostic",
+                1,
+                2,
+                "token",
+                "source"));
+
+        assertEquals(QueryDiagnostic.Kind.LEXER_ERROR, diagnostic.kind());
+        assertEquals(QueryDiagnostic.Severity.WARNING, diagnostic.severity());
+    }
+
+    @Test
+    void toQueryDiagnosticMapsStrictModeErrorsToSemanticKind() {
+        QueryDiagnostic diagnostic = SparqlQueryAnalyzer.toQueryDiagnostic(new SparqlAstError(
+                SparqlAstError.Kind.STRICT_MODE_ERROR,
+                SparqlAstError.Severity.ERROR,
+                "Strict mode diagnostic",
+                1,
+                2,
+                "token",
+                "source"));
+
+        assertEquals(QueryDiagnostic.Kind.SEMANTIC_ERROR, diagnostic.kind());
+        assertEquals(QueryDiagnostic.Severity.ERROR, diagnostic.severity());
+    }
+}


### PR DESCRIPTION
## Summary

Refs #380  
Refs #382

This PR:
- adds `SolutionModifierAst` support to `DescribeQueryAst`
- propagates solution modifiers to `DESCRIBE` in the AST builder
- moves semantic validation out of `SparqlAstBuilder`
- adds scope validation for:
  - `SELECT` projection variables
  - `ORDER BY` variables in `SELECT`, `CONSTRUCT`, and `DESCRIBE`
- exposes a public validation API with unified diagnostics
