### PR TITLE
#396 [Bug] SPARQL Grammar: allow additive expressions without mandatory whitespace

### DIFF
--- a/src/main/antlr/SparqlLexer.g4
+++ b/src/main/antlr/SparqlLexer.g4
@@ -236,7 +236,7 @@ fragment PN_CHARS
 
 PN_PREFIX: PN_CHARS_BASE ((PN_CHARS | '.')* PN_CHARS)?;
 
-PN_LOCAL: (PN_CHARS_U | ':' | DIGIT | PLX) ((PN_CHARS | '.' | ':' | PLX)* (PN_CHARS | ':' | PLX))?;
+fragment PN_LOCAL: (PN_CHARS_U | ':' | DIGIT | PLX) ((PN_CHARS | '.' | ':' | PLX)* (PN_CHARS | ':' | PLX))?;
 
 fragment PLX: PERCENT | PN_LOCAL_ESC;
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBgpTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBgpTest.java
@@ -142,6 +142,78 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
+    void shouldParsePrefixedNameWithDigitOnlyLocalPart() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                PREFIX ex: <http://example.org/>
+                SELECT * WHERE {
+                  ?s ex:1 ?o .
+                }
+                """);
+
+        BgpAst bgp = (BgpAst) ast.whereClause().patterns().getFirst();
+        TriplePatternAst triple = bgp.triples().getFirst();
+
+        assertInstanceOf(IriAst.class, triple.predicate());
+        assertEquals("ex:1", ((IriAst) triple.predicate()).raw());
+    }
+
+    @Test
+    void shouldParsePrefixedNameWithHyphenInLocalPart() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                PREFIX ex: <http://example.org/>
+                SELECT * WHERE {
+                  ?s ex:abc-def ?o .
+                }
+                """);
+
+        BgpAst bgp = (BgpAst) ast.whereClause().patterns().getFirst();
+        TriplePatternAst triple = bgp.triples().getFirst();
+
+        assertInstanceOf(IriAst.class, triple.predicate());
+        assertEquals("ex:abc-def", ((IriAst) triple.predicate()).raw());
+    }
+
+    @Test
+    void shouldParsePrefixedNameWithEscapedReservedCharacterInLocalPart() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                PREFIX ns: <http://example.org/ns#>
+                SELECT * WHERE {
+                  ?s ns:id\\=123 ?o .
+                }
+                """);
+
+        BgpAst bgp = (BgpAst) ast.whereClause().patterns().getFirst();
+        TriplePatternAst triple = bgp.triples().getFirst();
+
+        assertInstanceOf(IriAst.class, triple.predicate());
+        assertEquals("ns:id\\=123", ((IriAst) triple.predicate()).raw());
+    }
+
+    @Test
+    void shouldParsePrefixedNameWithDefaultPrefix() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                PREFIX : <http://example.org/default#>
+                SELECT * WHERE {
+                  ?s :foo ?o .
+                }
+                """);
+
+        BgpAst bgp = (BgpAst) ast.whereClause().patterns().getFirst();
+        TriplePatternAst triple = bgp.triples().getFirst();
+
+        assertInstanceOf(IriAst.class, triple.predicate());
+        assertEquals(":foo", ((IriAst) triple.predicate()).raw());
+    }
+
+    @Test
     void failFastTrueShouldThrowQuerySyntaxExceptionOnInvalidQuery() {
         SparqlParser parser = newParser(true, true);
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBindTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBindTest.java
@@ -2,6 +2,8 @@ package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FunctionCallAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.MultiplyAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.SubtractAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +89,41 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
         BindAst bindAst = (BindAst) last;
         assertEquals("y", bindAst.variable().name());
         assertNotNull(bindAst.expression());
+    }
+
+    @Test
+    @DisplayName("BIND(?p*(1-?discount) AS ?price) — arithmetic expression without whitespace around minus")
+    void shouldParseBindWithSubtractWithoutWhitespace() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT ?price WHERE {
+                  ?x ?p ?discount .
+                  BIND(?p*(1-?discount) AS ?price)
+                }
+                """);
+
+        assertNotNull(ast);
+        GroupGraphPatternAst where = ast.whereClause();
+        assertEquals(2, where.patterns().size());
+
+        PatternAst last = where.patterns().getLast();
+        assertInstanceOf(BindAst.class, last);
+
+        BindAst bindAst = (BindAst) last;
+        assertEquals("price", bindAst.variable().name());
+        assertInstanceOf(MultiplyAst.class, bindAst.expression());
+
+        MultiplyAst multiplyAst = (MultiplyAst) bindAst.expression();
+        assertInstanceOf(VarAst.class, multiplyAst.getLeftArgument());
+        assertEquals("p", ((VarAst) multiplyAst.getLeftArgument()).name());
+        assertInstanceOf(SubtractAst.class, multiplyAst.getRightArgument());
+
+        SubtractAst subtractAst = (SubtractAst) multiplyAst.getRightArgument();
+        assertInstanceOf(LiteralAst.class, subtractAst.getLeftArgument());
+        assertEquals("1", ((LiteralAst) subtractAst.getLeftArgument()).lexical());
+        assertInstanceOf(VarAst.class, subtractAst.getRightArgument());
+        assertEquals("discount", ((VarAst) subtractAst.getRightArgument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -1012,6 +1012,37 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
+    void shouldParseSubtractWithoutWhitespaceInsideParenthesizedMultiplyExpression() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT * WHERE {
+                  ?x ?p ?discount .
+                  ?x ?pricePredicate ?price .
+                  FILTER(?p*(1-?discount) = ?price)
+                }
+                """);
+
+        FilterAst filterAst = (FilterAst) ast.whereClause().patterns().getLast();
+        EqualsAst equalsAst = (EqualsAst) filterAst.operator();
+
+        assertInstanceOf(MultiplyAst.class, equalsAst.getLeftArgument());
+        assertInstanceOf(VarAst.class, equalsAst.getRightArgument());
+        assertEquals("price", ((VarAst) equalsAst.getRightArgument()).name());
+
+        MultiplyAst multiplyAst = (MultiplyAst) equalsAst.getLeftArgument();
+        assertInstanceOf(VarAst.class, multiplyAst.getLeftArgument());
+        assertEquals("p", ((VarAst) multiplyAst.getLeftArgument()).name());
+        assertInstanceOf(SubtractAst.class, multiplyAst.getRightArgument());
+
+        SubtractAst subtractAst = (SubtractAst) multiplyAst.getRightArgument();
+        assertInstanceOf(LiteralAst.class, subtractAst.getLeftArgument());
+        assertEquals("1", ((LiteralAst) subtractAst.getLeftArgument()).lexical());
+        assertInstanceOf(VarAst.class, subtractAst.getRightArgument());
+        assertEquals("discount", ((VarAst) subtractAst.getRightArgument()).name());
+    }
+
+    @Test
     void shouldParseUnaryPlusFilter() {
         SparqlParser parser = newParserDefault();
 


### PR DESCRIPTION
Fixes #396 by allowing additive expressions without mandatory whitespace.