### PR TITLE
339 [SPARQL 1.1] - Parser and AST not exist and exist

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -1223,10 +1223,20 @@ public final class SparqlAstBuilder {
 
     public TermAst termFromBuiltInCall(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.BuiltInCallContext ctx) {
         if (ctx.existsFunc() != null) {
-            return new ExistsAst(popCapturedExistsPattern());
-        } else if (ctx.notExistsFunc() != null) {
-            return new NotExistsAst(popCapturedExistsPattern());
-        } else if (ctx.regexExpression() != null) {
+            GroupGraphPatternAst existsPattern = popCapturedExistsPattern();
+            if (existsPattern == null) {
+                throw new QueryEvaluationException("EXISTS { ... } inner pattern was not captured; check listener order");
+            }
+            return new ExistsAst(existsPattern);
+        }
+        if (ctx.notExistsFunc() != null) {
+            GroupGraphPatternAst notExistsPattern = popCapturedExistsPattern();
+            if (notExistsPattern == null) {
+                throw new QueryEvaluationException("NOT EXISTS { ... } inner pattern was not captured; check listener order");
+            }
+            return new NotExistsAst(notExistsPattern);
+        }
+        if (ctx.regexExpression() != null) {
             return termFromRegex(ctx.regexExpression());
         } else if (ctx.strReplaceExpression() != null) {
             return termFromReplace(ctx.strReplaceExpression());

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
@@ -3,8 +3,15 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
+import java.util.Objects;
+
 /**
- * Operator {@code EXISTS { ... }} in SPARQL 1.1 FILTER
+ * SPARQL 1.1 {@code EXISTS { pattern }} in a {@code FILTER} (and elsewhere an expression is allowed).
+ * Evaluates whether the pattern has a solution given the current binding.
  */
-public record ExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst {
+public record ExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst, BooleanExpressionAst {
+
+    public ExistsAst {
+        Objects.requireNonNull(pattern, "pattern");
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
 import java.util.Objects;
@@ -9,7 +8,7 @@ import java.util.Objects;
  * SPARQL 1.1 {@code EXISTS { pattern }} in a {@code FILTER} (and elsewhere an expression is allowed).
  * Evaluates whether the pattern has a solution given the current binding.
  */
-public record ExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst, BooleanExpressionAst {
+public record ExistsAst(GroupGraphPatternAst pattern) implements BooleanExpressionAst {
 
     public ExistsAst {
         Objects.requireNonNull(pattern, "pattern");

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
 import java.util.Objects;
@@ -9,7 +8,7 @@ import java.util.Objects;
  * SPARQL 1.1 {@code NOT EXISTS { pattern }} in a {@code FILTER}.
  * Semantically equivalent to applying {@code fn:not} to {@link ExistsAst} on the same pattern.
  */
-public record NotExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst, BooleanExpressionAst {
+public record NotExistsAst(GroupGraphPatternAst pattern) implements BooleanExpressionAst {
 
     public NotExistsAst {
         Objects.requireNonNull(pattern, "pattern");

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
@@ -3,8 +3,15 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
+import java.util.Objects;
+
 /**
- * Operator {@code NOT EXISTS { ... }} in SPARQL 1.1 FILTER
+ * SPARQL 1.1 {@code NOT EXISTS { pattern }} in a {@code FILTER}.
+ * Semantically equivalent to applying {@code fn:not} to {@link ExistsAst} on the same pattern.
  */
-public record NotExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst {
+public record NotExistsAst(GroupGraphPatternAst pattern) implements ConstraintAst, BooleanExpressionAst {
+
+    public NotExistsAst {
+        Objects.requireNonNull(pattern, "pattern");
+    }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import org.junit.jupiter.api.Test;
 
@@ -1301,6 +1300,52 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertInstanceOf(NotExistsAst.class, filterAst.operator());
 
         NotExistsAst notExistsAst = (NotExistsAst) filterAst.operator();
+        assertNotNull(notExistsAst.pattern());
+        assertFalse(notExistsAst.pattern().patterns().isEmpty());
+    }
+
+    @Test
+    void shouldParseNotOverExistsFilter() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT * WHERE {
+                  ?s ?p ?o .
+                  FILTER(!EXISTS { ?s ex:email ?e })
+                }
+                """);
+
+        assertNotNull(ast);
+        FilterAst filterAst = (FilterAst) ast.whereClause().patterns().getLast();
+        assertInstanceOf(BooleanNotAst.class, filterAst.operator());
+
+        BooleanNotAst booleanNotAst = (BooleanNotAst) filterAst.operator();
+        assertInstanceOf(ExistsAst.class, booleanNotAst.getArgument());
+
+        ExistsAst existsAst = (ExistsAst) booleanNotAst.getArgument();
+        assertNotNull(existsAst.pattern());
+        assertFalse(existsAst.pattern().patterns().isEmpty());
+    }
+
+    @Test
+    void shouldParseNotOverNotExistsFilter() {
+        SparqlParser parser = newParserDefault();
+
+        QueryAst ast = parser.parse("""
+                SELECT * WHERE {
+                  ?s ?p ?o .
+                  FILTER(!NOT EXISTS { ?s ex:email ?e })
+                }
+                """);
+
+        assertNotNull(ast);
+        FilterAst filterAst = (FilterAst) ast.whereClause().patterns().getLast();
+        assertInstanceOf(BooleanNotAst.class, filterAst.operator());
+
+        BooleanNotAst booleanNotAst = (BooleanNotAst) filterAst.operator();
+        assertInstanceOf(NotExistsAst.class, booleanNotAst.getArgument());
+
+        NotExistsAst notExistsAst = (NotExistsAst) booleanNotAst.getArgument();
         assertNotNull(notExistsAst.pattern());
         assertFalse(notExistsAst.pattern().patterns().isEmpty());
     }


### PR DESCRIPTION
Added BooleanExpressionAst to NotExist and Exist record.
Added a throw new QueryEvaluationException when poping exist or not exist pattern