### PR TITLE
370 [SPARQL 1.1 Update] - Parser and AST : LOAD Query

### DIFF
--- a/src/main/antlr/SparqlParser.g4
+++ b/src/main/antlr/SparqlParser.g4
@@ -45,16 +45,17 @@ options {
     tokenVocab = SparqlLexer;
 }
 
-queryUnit
-    : query EOF
+query
+    : queryUnit EOF
+    | updateUnit EOF
     ;
 
-query
+queryUnit
     : prologue (selectQuery | constructQuery | describeQuery | askQuery) valuesClause
     ;
 
 updateUnit
-    : update EOF
+    : update
     ;
 
 prologue

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -13,6 +13,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Build a minimal SPARQL AST for:
@@ -81,7 +82,7 @@ public final class SparqlAstBuilder {
      *                   i.e. the depth before the SERVICE body's {@link #enterGroup()} is invoked.
      *                   After {@link #exitGroup()} pops the service body the stack returns to this
      *                   depth, which is used as the signal to wrap the group in a
-     *                   {@link fr.inria.corese.core.next.query.impl.sparql.ast.ServiceAst}.
+     *                   {@link ServiceAst}.
      * @param endpoint   the remote service endpoint (IRI or variable)
      * @param silent     whether the {@code SILENT} keyword was present
      */
@@ -387,7 +388,7 @@ public final class SparqlAstBuilder {
                 expressionBoundNames.stream()
                         .map(s -> s == null ? "" : (s.startsWith("?") || s.startsWith("$") ? s.substring(1).trim() : s.trim()))
                         .filter(s -> !s.isBlank())
-                        .collect(java.util.stream.Collectors.toUnmodifiableSet());
+                        .collect(Collectors.toUnmodifiableSet());
 
         ProjectionAst newProjection = vars.isEmpty()
                 ? ProjectionAsts.selectAll()
@@ -680,7 +681,7 @@ public final class SparqlAstBuilder {
      * Enter SERVICE scope.  Records the current group stack size, the endpoint term and the
      * {@code SILENT} flag so that when {@link #exitGroup()} is called and the stack returns to
      * that size, the closed group is wrapped in a
-     * {@link fr.inria.corese.core.next.query.impl.sparql.ast.ServiceAst}.
+     * {@link ServiceAst}.
      *
      * @param endpoint the remote endpoint (IRI or variable)
      * @param silent   {@code true} when the {@code SILENT} keyword was present
@@ -691,7 +692,7 @@ public final class SparqlAstBuilder {
 
     /**
      * Exit SERVICE scope.  No-op: the service body was already wrapped in
-     * {@link fr.inria.corese.core.next.query.impl.sparql.ast.ServiceAst} in {@link #exitGroup()}.
+     * {@link ServiceAst} in {@link #exitGroup()}.
      */
     public void exitService() {
     }
@@ -734,20 +735,26 @@ public final class SparqlAstBuilder {
     public QueryAst getResult() {
         if (selectQueryResult != null) return selectQueryResult;
 
-        if (whereClause == null) {
-            throw new IllegalStateException("No WHERE clause: did you call exitGroup() for the top-level GroupGraphPattern?");
+        // Non-update query
+        if (this.queryType == ASTConstants.QUERY_TYPE.ASK || this.queryType == ASTConstants.QUERY_TYPE.CONSTRUCT || this.queryType == ASTConstants.QUERY_TYPE.DESCRIBE || this.queryType == ASTConstants.QUERY_TYPE.SELECT ) {
+            if (whereClause == null) {
+                throw new IllegalStateException("No WHERE clause: did you call exitGroup() for the top-level GroupGraphPattern?");
+            }
+            DatasetClauseAst datasetClauseAst = new DatasetClauseAst(datasetDefaultGraphs, datasetNamedGraphs);
+            QueryPrologueAst prologueAst = new QueryPrologueAst(List.copyOf(prefixDeclarations), new IriAst(baseUri));
+            return switch (this.queryType) {
+                case ASK -> buildAskQueryAst(datasetClauseAst, prologueAst);
+                case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst);
+                case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst);
+                case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst);
+                default -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
+            };
+        } else {
+            return switch (this.queryType) {
+                case LOAD -> buildLoadQueryAst();
+                default -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
+            };
         }
-        DatasetClauseAst datasetClauseAst = new DatasetClauseAst(datasetDefaultGraphs, datasetNamedGraphs);
-        QueryPrologueAst prologueAst = new QueryPrologueAst(List.copyOf(prefixDeclarations), new IriAst(baseUri));
-        ValuesAst valuesClause = new ValuesAst(this.values);
-        return switch (this.queryType) {
-            case ASK -> buildAskQueryAst(datasetClauseAst, prologueAst, valuesClause);
-            case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst, valuesClause);
-            case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst, valuesClause);
-            case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst, valuesClause);
-            case LOAD -> buildLoadQueryAst(prologueAst);
-            case UNDEFINED -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
-        };
     }
 
     // --- Internal helpers ---
@@ -781,8 +788,8 @@ public final class SparqlAstBuilder {
      * @param prologueAst prologue
      * @return a {@link LoadQueryAst}
      */
-    private LoadQueryAst buildLoadQueryAst(QueryPrologueAst prologueAst) {
-        return new LoadQueryAst(prologueAst, sourceGraphSet, targetGraphSet, silentFlag);
+    private LoadQueryAst buildLoadQueryAst() {
+        return new LoadQueryAst(sourceGraphSet, targetGraphSet, silentFlag);
     }
 
     /**
@@ -1199,12 +1206,12 @@ public final class SparqlAstBuilder {
 
     // ---- term helpers ----
 
-    public TermAst termFromVerb(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.VerbContext ctx) {
+    public TermAst termFromVerb(SparqlParser.VerbContext ctx) {
         if (ctx.A() != null) return this.iri("a");
         return termFromVarOrIriRef(ctx.varOrIri());
     }
 
-    public TermAst termFromVarOrTerm(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.VarOrTermContext ctx) {
+    public TermAst termFromVarOrTerm(SparqlParser.VarOrTermContext ctx) {
         if (ctx.var_() != null) return termFromVar(ctx.var_());
         return termFromGraphTerm(ctx.graphTerm());
     }
@@ -1216,7 +1223,7 @@ public final class SparqlAstBuilder {
         return termFromIriRef(ctx.iriRef());
     }
 
-    public TermAst termFromGraphTerm(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.GraphTermContext ctx) {
+    public TermAst termFromGraphTerm(SparqlParser.GraphTermContext ctx) {
         if (ctx.iriRef() != null) {
             return termFromIriRef(ctx.iriRef());
         }
@@ -1246,7 +1253,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public List<TermAst> termListFromObjectList(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ObjectListContext ctx) {
+    public List<TermAst> termListFromObjectList(SparqlParser.ObjectListContext ctx) {
         List<TermAst> out = new ArrayList<>();
         for (var obj : ctx.object_()) {
             out.add(termFromObject(obj));
@@ -1254,12 +1261,12 @@ public final class SparqlAstBuilder {
         return out;
     }
 
-    public TermAst termFromObject(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.Object_Context ctx) {
+    public TermAst termFromObject(SparqlParser.Object_Context ctx) {
         // object_ : graphNode
         return termFromGraphNode(ctx.graphNode());
     }
 
-    public TermAst termFromGraphNode(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.GraphNodeContext ctx) {
+    public TermAst termFromGraphNode(SparqlParser.GraphNodeContext ctx) {
         if (ctx.varOrTerm() != null) return termFromVarOrTerm(ctx.varOrTerm());
         if (ctx.triplesNode() != null) {
             // MVP: pas encore supporté ( [ ... ] ou ( ... ) )
@@ -1269,7 +1276,7 @@ public final class SparqlAstBuilder {
         return this.iri(ctx.getText());
     }
 
-    public TermAst termFromRdfLiteral(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.RdfLiteralContext ctx) {
+    public TermAst termFromRdfLiteral(SparqlParser.RdfLiteralContext ctx) {
         // rdfLiteral : string_ ( LANGTAG | '^^' iriRef )?
 
         String lexical = ctx.string_().getText();
@@ -1285,7 +1292,7 @@ public final class SparqlAstBuilder {
         return this.literal(lexical, lang, datatype);
     }
 
-    public TermAst termFromPrimary(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.PrimaryExpressionContext ctx) {
+    public TermAst termFromPrimary(SparqlParser.PrimaryExpressionContext ctx) {
         if (ctx.brackettedExpression() != null) {
             return termFromBrackettedExpression(ctx.brackettedExpression());
         } else if (ctx.builtInCall() != null) {
@@ -1305,11 +1312,11 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromVar(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.Var_Context ctx) {
+    public TermAst termFromVar(SparqlParser.Var_Context ctx) {
         return this.var(ctx.getText());
     }
 
-    public TermAst termFromBooleanLiteral(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.BooleanLiteralContext ctx) {
+    public TermAst termFromBooleanLiteral(SparqlParser.BooleanLiteralContext ctx) {
         if (ctx.FALSE() != null) {
             return new LiteralAst("false", null, XSD.xsdBoolean.getIRI().stringValue());
         } else if (ctx.TRUE() != null) {
@@ -1319,7 +1326,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromIriRefOrFunction(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.IriRefOrFunctionContext ctx) {
+    public TermAst termFromIriRefOrFunction(SparqlParser.IriRefOrFunctionContext ctx) {
         if (ctx.iriRef() != null && ctx.argList() == null) {
             return termFromIriRef(ctx.iriRef());
         } else if (ctx.iriRef() != null && ctx.argList() != null) {
@@ -1331,15 +1338,15 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public List<TermAst> termListFromArgList(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ArgListContext ctx) {
+    public List<TermAst> termListFromArgList(SparqlParser.ArgListContext ctx) {
         return ctx.expression().stream().map(this::termFromExpression).toList();
     }
 
-    public TermAst termFromIriRef(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.IriRefContext ctx) {
+    public TermAst termFromIriRef(SparqlParser.IriRefContext ctx) {
         return this.iri(ctx.getText());
     }
 
-    public TermAst termFromNumericLiteral(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralContext ctx) {
+    public TermAst termFromNumericLiteral(SparqlParser.NumericLiteralContext ctx) {
         if (ctx.numericLiteralUnsigned() != null) {
             return termFromNumericLiteralUnsigned(ctx.numericLiteralUnsigned());
         } else if (ctx.numericLiteralPositive() != null) {
@@ -1351,7 +1358,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromNumericLiteralNegative(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralNegativeContext ctx) {
+    public TermAst termFromNumericLiteralNegative(SparqlParser.NumericLiteralNegativeContext ctx) {
         if (ctx.INTEGER_NEGATIVE() != null) {
             return this.literal(ctx.getText(), null, XSD.xsdNegativeInteger.getIRI().stringValue());
         } else if (ctx.DECIMAL_NEGATIVE() != null) {
@@ -1363,7 +1370,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromNumericLiteralPositive(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralPositiveContext ctx) {
+    public TermAst termFromNumericLiteralPositive(SparqlParser.NumericLiteralPositiveContext ctx) {
         if (ctx.INTEGER_POSITIVE() != null) {
             return this.literal(ctx.getText(), null, XSD.xsdPositiveInteger.getIRI().stringValue());
         } else if (ctx.DECIMAL_POSITIVE() != null) {
@@ -1375,7 +1382,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromNumericLiteralUnsigned(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralUnsignedContext ctx) {
+    public TermAst termFromNumericLiteralUnsigned(SparqlParser.NumericLiteralUnsignedContext ctx) {
         if (ctx.INTEGER() != null) {
             return this.literal(ctx.getText(), null, XSD.xsdUnsignedInt.getIRI().stringValue());
         } else if (ctx.DECIMAL() != null) {
@@ -1387,7 +1394,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromBlankNode(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.BlankNodeContext ctx) {
+    public TermAst termFromBlankNode(SparqlParser.BlankNodeContext ctx) {
         return this.iri(ctx.getText());
     }
 
@@ -1421,7 +1428,7 @@ public final class SparqlAstBuilder {
         throw new QueryEvaluationException("Unsupported group condition: " + ctx.getText());
     }
 
-    public TermAst termFromConstraint(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ConstraintContext ctx) {
+    public TermAst termFromConstraint(SparqlParser.ConstraintContext ctx) {
         if (ctx.builtInCall() != null) {
             return termFromBuiltInCall(ctx.builtInCall());
         } else if (ctx.functionCall() != null) {
@@ -1435,11 +1442,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromBuiltInCall(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.BuiltInCallContext ctx) {
-        if (ctx.aggregate() != null) {
-            return termFromAggregate(ctx.aggregate());
-        }
-
+    public TermAst termFromBuiltInCall(SparqlParser.BuiltInCallContext ctx) {
         if (ctx.existsFunc() != null) {
             GroupGraphPatternAst existsPattern = popCapturedExistsPattern();
             if (existsPattern == null) {
@@ -1573,7 +1576,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromExpression(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ExpressionContext ctx) {
+    public TermAst termFromExpression(SparqlParser.ExpressionContext ctx) {
         if (ctx.conditionalOrExpression() != null) {
             return this.termFromConditionalOr(ctx.conditionalOrExpression());
         } else {
@@ -1581,7 +1584,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromConditionalOr(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ConditionalOrExpressionContext ctx) {
+    public TermAst termFromConditionalOr(SparqlParser.ConditionalOrExpressionContext ctx) {
         if (ctx.conditionalAndExpression() != null && !ctx.conditionalAndExpression().isEmpty()) {
             if (ctx.conditionalAndExpression().size() > 1) {
                 List<TermAst> args = ctx.conditionalAndExpression().stream().map(this::termFromConditionalAnd).toList();
@@ -1594,7 +1597,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromConditionalAnd(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ConditionalAndExpressionContext ctx) {
+    public TermAst termFromConditionalAnd(SparqlParser.ConditionalAndExpressionContext ctx) {
         if (ctx.valueLogical() != null && !ctx.valueLogical().isEmpty()) {
             if (ctx.valueLogical().size() > 1) {
                 List<TermAst> args = ctx.valueLogical().stream().map(this::termFromValueLogical).toList();
@@ -1607,7 +1610,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromValueLogical(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ValueLogicalContext ctx) {
+    public TermAst termFromValueLogical(SparqlParser.ValueLogicalContext ctx) {
         if (ctx.relationalExpression() != null) {
             return this.termFromRelational(ctx.relationalExpression());
         } else {
@@ -1615,7 +1618,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromRelational(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.RelationalExpressionContext ctx) {
+    public TermAst termFromRelational(SparqlParser.RelationalExpressionContext ctx) {
         if (ctx.numericExpression() == null || ctx.numericExpression().isEmpty()) {
             throw new QueryEvaluationException("No numeric termFromExpression found");
         }
@@ -1669,7 +1672,7 @@ public final class SparqlAstBuilder {
         return List.of();
     }
 
-    public TermAst termFromNumeric(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericExpressionContext ctx) {
+    public TermAst termFromNumeric(SparqlParser.NumericExpressionContext ctx) {
         if (ctx.additiveExpression() != null) {
             return this.termFromAdditive(ctx.additiveExpression());
         } else {
@@ -1677,7 +1680,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromAdditive(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.AdditiveExpressionContext ctx) {
+    public TermAst termFromAdditive(SparqlParser.AdditiveExpressionContext ctx) {
         if (ctx.multiplicativeExpression() != null && !ctx.multiplicativeExpression().isEmpty()) {
             if (ctx.multiplicativeExpression().size() > 1
                     || !ctx.numericLiteralNegative().isEmpty()
@@ -1696,11 +1699,11 @@ public final class SparqlAstBuilder {
                         }
                     } else {
                         TermAst rightHand = switch (child) {
-                            case fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.MultiplicativeExpressionContext multiplicativeExpressionContext ->
+                            case SparqlParser.MultiplicativeExpressionContext multiplicativeExpressionContext ->
                                     termFromMultiplicative(multiplicativeExpressionContext);
-                            case fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralPositiveContext numericLiteralPositiveContext ->
+                            case SparqlParser.NumericLiteralPositiveContext numericLiteralPositiveContext ->
                                     (ExprAst) termFromNumericLiteralPositive(numericLiteralPositiveContext);
-                            case fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.NumericLiteralNegativeContext numericLiteralNegativeContext ->
+                            case SparqlParser.NumericLiteralNegativeContext numericLiteralNegativeContext ->
                                     (ExprAst) termFromNumericLiteralNegative(numericLiteralNegativeContext);
                             case null, default ->
                                     throw new QueryEvaluationException(
@@ -1722,7 +1725,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromMultiplicative(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.MultiplicativeExpressionContext ctx) {
+    public TermAst termFromMultiplicative(SparqlParser.MultiplicativeExpressionContext ctx) {
         if (ctx.unaryExpression() != null && !ctx.unaryExpression().isEmpty()) {
             if (ctx.unaryExpression().size() > 1) {
                 TermAst head = termFromUnary(ctx.unaryExpression().getFirst());
@@ -1758,7 +1761,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromUnary(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.UnaryExpressionContext ctx) {
+    public TermAst termFromUnary(SparqlParser.UnaryExpressionContext ctx) {
         ASTConstants.Constraint op = null;
         if (ctx.PLUS() != null) {
             op = ASTConstants.OPERATOR.PLUS;
@@ -1774,7 +1777,7 @@ public final class SparqlAstBuilder {
         }
     }
 
-    public TermAst termFromBrackettedExpression(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.BrackettedExpressionContext ctx) {
+    public TermAst termFromBrackettedExpression(SparqlParser.BrackettedExpressionContext ctx) {
         return termFromExpression(ctx.expression());
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -209,6 +209,21 @@ public final class SparqlAstBuilder {
     private ConstructTemplateAst constructTemplate;
 
     /**
+     * Flag for UPDATE queries to be silent or not
+     */
+    private boolean silentFlag = false;
+
+    /**
+     * List of IRIs used in an TO clause in a UPDATE query
+     */
+    private Set<IriAst> sourceGraphSet = new HashSet<>();
+
+    /**
+     * List of IRIs used in an TO clause in a UPDATE query
+     */
+    private Set<IriAst> targetGraphSet = new HashSet<>();
+
+    /**
      * Used for BIND scope checks (variable must not already be visible in the same group).
      */
     private final VariableScopeAnalyzer variableScopeAnalyzer = new VariableScopeAnalyzer();
@@ -217,6 +232,7 @@ public final class SparqlAstBuilder {
      * Effective base URI after prologue (parser options, then possibly {@code BASE}).
      */
     private String baseUri;
+
     /**
      * Prefix declarations in source order (including redeclarations).
      */
@@ -729,6 +745,7 @@ public final class SparqlAstBuilder {
             case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst, valuesClause);
             case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst, valuesClause);
             case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst, valuesClause);
+            case LOAD -> buildLoadQueryAst(prologueAst);
             case UNDEFINED -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
         };
     }
@@ -757,6 +774,39 @@ public final class SparqlAstBuilder {
                     "exitGroup() called while a TriplesBlock/BGP is still open" +
                             " (open bgpStack depth=" + bgpStack.size() + ")");
         }
+    }
+
+    /**
+     * Build the AST for LOAD queries
+     * @param prologueAst prologue
+     * @return a {@link LoadQueryAst}
+     */
+    private LoadQueryAst buildLoadQueryAst(QueryPrologueAst prologueAst) {
+        return new LoadQueryAst(prologueAst, sourceGraphSet, targetGraphSet, silentFlag);
+    }
+
+    /**
+     * Add a source graph IRI for an UPDATE query (FROM clause)
+     * @param iri
+     */
+    public void addSourceGraphIri(IriAst iri) {
+        this.sourceGraphSet.add(iri);
+    }
+
+    /**
+     * Add a target graph IRI for an UPDATE query (TO clause)
+     * @param iri
+     */
+    public void addTargetGraphIri(IriAst iri) {
+        this.targetGraphSet.add(iri);
+    }
+
+    /**
+     * Set the Silent flag of an UPDATE query.
+     * @param silent
+     */
+    public void setSilentFlag(boolean silent) {
+        this.silentFlag = silent;
     }
 
     /**
@@ -933,6 +983,16 @@ public final class SparqlAstBuilder {
     public void enterDescribeQuery() {
         assertTopLevelQueryFormOnly("DESCRIBE");
         queryType = ASTConstants.QUERY_TYPE.DESCRIBE;
+    }
+
+    /**
+     * Signals the start of a LOAD query desclaration
+     */
+    public void enterLoadQuery() {
+        queryType = ASTConstants.QUERY_TYPE.LOAD;
+        this.sourceGraphSet.clear();
+        this.targetGraphSet.clear();
+        this.silentFlag = false;
     }
 
     /**
@@ -1176,6 +1236,14 @@ public final class SparqlAstBuilder {
             return this.iri("()");
         } // NIL = () in SPARQL
         return this.iri(ctx.getText());
+    }
+
+    public TermAst termFromGraphRef(SparqlParser.GraphRefContext ctx) {
+        if (ctx.iriRef() != null) {
+            return termFromIriRef(ctx.iriRef());
+        } else {
+            throw new QueryEvaluationException("Expecting an IRIRef in the Graph clause");
+        }
     }
 
     public List<TermAst> termListFromObjectList(fr.inria.corese.core.next.impl.parser.antlr.SparqlParser.ObjectListContext ctx) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -735,21 +735,22 @@ public final class SparqlAstBuilder {
     public QueryAst getResult() {
         if (selectQueryResult != null) return selectQueryResult;
 
-        // Non-update query
+        // Interrogation query
         if (this.queryType == ASTConstants.QUERY_TYPE.ASK || this.queryType == ASTConstants.QUERY_TYPE.CONSTRUCT || this.queryType == ASTConstants.QUERY_TYPE.DESCRIBE || this.queryType == ASTConstants.QUERY_TYPE.SELECT ) {
             if (whereClause == null) {
                 throw new IllegalStateException("No WHERE clause: did you call exitGroup() for the top-level GroupGraphPattern?");
             }
             DatasetClauseAst datasetClauseAst = new DatasetClauseAst(datasetDefaultGraphs, datasetNamedGraphs);
             QueryPrologueAst prologueAst = new QueryPrologueAst(List.copyOf(prefixDeclarations), new IriAst(baseUri));
+            ValuesAst valuesClause = new ValuesAst(this.values);
             return switch (this.queryType) {
-                case ASK -> buildAskQueryAst(datasetClauseAst, prologueAst);
-                case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst);
-                case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst);
-                case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst);
+                case ASK -> buildAskQueryAst(datasetClauseAst, prologueAst, valuesClause);
+                case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst,valuesClause);
+                case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst, valuesClause);
+                case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst, valuesClause);
                 default -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
             };
-        } else {
+        } else { // Update query
             return switch (this.queryType) {
                 case LOAD -> buildLoadQueryAst();
                 default -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
@@ -785,7 +786,6 @@ public final class SparqlAstBuilder {
 
     /**
      * Build the AST for LOAD queries
-     * @param prologueAst prologue
      * @return a {@link LoadQueryAst}
      */
     private LoadQueryAst buildLoadQueryAst() {
@@ -1443,6 +1443,9 @@ public final class SparqlAstBuilder {
     }
 
     public TermAst termFromBuiltInCall(SparqlParser.BuiltInCallContext ctx) {
+        if (ctx.aggregate() != null) {
+            return termFromAggregate(ctx.aggregate());
+        }
         if (ctx.existsFunc() != null) {
             GroupGraphPatternAst existsPattern = popCapturedExistsPattern();
             if (existsPattern == null) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
@@ -70,6 +70,16 @@ public final class SparqlListener extends SparqlParserBaseListener {
     }
 
     @Override
+    public void enterLoad(SparqlParser.LoadContext ctx) {
+        for (var d : delegates) d.enterLoad(ctx);
+    }
+
+    @Override
+    public void exitLoad(SparqlParser.LoadContext ctx) {
+        for (var d : delegates) d.exitLoad(ctx);
+    }
+
+    @Override
     public void enterWhereClause(SparqlParser.WhereClauseContext ctx) {
         for (var d : delegates) d.enterWhereClause(ctx);
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
@@ -127,7 +127,8 @@ final class SparqlQueryAnalyzer {
                 new PrologueFeature(builder),
                 new BindFeature(builder),
                 new ServiceFeature(builder),
-                new ValuesFeature(builder)
+                new ValuesFeature(builder),
+                new LoadQueryFeature(builder)
         ));
 
         ParseTreeWalker walker = new ParseTreeWalker();

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/LoadQueryFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/LoadQueryFeature.java
@@ -1,0 +1,23 @@
+package fr.inria.corese.core.next.query.impl.parser.listener;
+
+import fr.inria.corese.core.next.impl.parser.antlr.SparqlParser;
+import fr.inria.corese.core.next.query.impl.parser.SparqlAstBuilder;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+
+public class LoadQueryFeature extends AbstractSparqlFeature {
+
+    public LoadQueryFeature(SparqlAstBuilder builder) {
+        super(builder);
+    }
+
+    public void exitLoad(SparqlParser.LoadContext ctx) {
+        this.builder().enterLoadQuery();
+        this.builder().setSilentFlag(ctx.SILENT() != null);
+        if(ctx.iriRef() != null) {
+            this.builder().addSourceGraphIri((IriAst) this.builder().termFromIriRef(ctx.iriRef()));
+        }
+        if(ctx.graphRef() != null) {
+            this.builder().addSourceGraphIri((IriAst) this.builder().termFromGraphRef(ctx.graphRef()));
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/LoadQueryFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/LoadQueryFeature.java
@@ -17,7 +17,7 @@ public class LoadQueryFeature extends AbstractSparqlFeature {
             this.builder().addSourceGraphIri((IriAst) this.builder().termFromIriRef(ctx.iriRef()));
         }
         if(ctx.graphRef() != null) {
-            this.builder().addSourceGraphIri((IriAst) this.builder().termFromGraphRef(ctx.graphRef()));
+            this.builder().addTargetGraphIri((IriAst) this.builder().termFromGraphRef(ctx.graphRef()));
         }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OrderByScopeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OrderByScopeValidationRule.java
@@ -2,16 +2,7 @@ package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VariableScopeAnalyzer;
-import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.DescribeQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.OrderConditionAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ProjectionAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SolutionModifierAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -45,6 +36,7 @@ public final class OrderByScopeValidationRule extends AbstractSemanticValidation
                     describeQueryAst.solutionModifier());
             // TODO: handle ASK solution modifiers with SPARQL 1.1 support.
             case AskQueryAst ignored -> List.of();
+            case LoadQueryAst ignored -> List.of();
         };
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
@@ -5,10 +5,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Collects visible and referenced variables from the next SPARQL AST.
@@ -26,8 +23,13 @@ public final class VariableScopeAnalyzer {
      * @return the set of visible variable names, without {@code ?} or {@code $} in the patterns used for the resolution of the query
      */
     public Set<String> collectVisibleVariables(QueryAst query) {
-        Set<String> visibleVariables = collectVisibleVariables(query.whereClause());
-        visibleVariables.addAll(collectVisibleVariables(query.valuesClause()));
+        Set<String> visibleVariables = new TreeSet<>();
+        if(query instanceof WhereClauseQueryAst whereClauseQueryAst) {
+            visibleVariables.addAll(collectVisibleVariables(whereClauseQueryAst.whereClause()));
+        }
+        if(query instanceof SparqlQueryAst sparqlQueryAst) {
+            visibleVariables.addAll(collectVisibleVariables(sparqlQueryAst.valuesClause()));
+        }
         return visibleVariables;
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ASTConstants.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ASTConstants.java
@@ -11,6 +11,8 @@ public class ASTConstants {
         DESCRIBE,
         SELECT,
 
+        LOAD,
+
         UNDEFINED
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AskQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AskQueryAst.java
@@ -16,7 +16,7 @@ import java.util.List;
  * }</pre>
  */
 public record AskQueryAst(DatasetClauseAst datasetClause, GroupGraphPatternAst whereClause,
-                          SolutionModifierAst solutionModifier, QueryPrologueAst prologue, ValuesAst valuesClause) implements QueryAst {
+                          SolutionModifierAst solutionModifier, QueryPrologueAst prologue, ValuesAst valuesClause) implements SparqlQueryAst {
 
     public AskQueryAst(DatasetClauseAst datasetClause, GroupGraphPatternAst whereClause) {
         this(datasetClause, whereClause, null, null, null);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructQueryAst.java
@@ -37,7 +37,7 @@ public record ConstructQueryAst(
         SolutionModifierAst solutionModifier,
         QueryPrologueAst prologue,
         ValuesAst valuesClause
-            ) implements QueryAst {
+            ) implements SparqlQueryAst {
     public ConstructQueryAst {
         if (constructTemplate == null) {
             constructTemplate = new ConstructTemplateAst(List.of());

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
@@ -28,7 +28,7 @@ public record DescribeQueryAst(
         SolutionModifierAst solutionModifier,
         QueryPrologueAst prologue,
         ValuesAst valuesClause
-) implements QueryAst {
+) implements SparqlQueryAst {
     public DescribeQueryAst {
         described = described != null ? List.copyOf(described) : List.of();
         if (whereClause == null) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadQueryAst.java
@@ -5,16 +5,12 @@ import java.util.Set;
 
 /**
  * Represents the LOAD queries as defined in the <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#load">SPARQL 1.1 recommendation<a/>.
- * @param prologue Prologue declarations
  * @param fromClause From clause, set of graphs IRIs
  * @param toClause To clause. Set of Graph IRIs
  * @param silent Determine if the resolution of the query must be resolved silently or not.
  */
-public record LoadQueryAst(QueryPrologueAst prologue, Set<IriAst> fromClause, Set<IriAst> toClause, boolean silent) implements UpdateQueryAst {
+public record LoadQueryAst(Set<IriAst> fromClause, Set<IriAst> toClause, boolean silent) implements UpdateQueryAst {
     public LoadQueryAst {
-        if(prologue == null) {
-            prologue = QueryPrologueAst.empty();
-        }
         if(fromClause == null) {
             fromClause = new HashSet<>();
         }
@@ -23,7 +19,7 @@ public record LoadQueryAst(QueryPrologueAst prologue, Set<IriAst> fromClause, Se
         }
     }
 
-    public LoadQueryAst(QueryPrologueAst prologue, Set<IriAst> fromClause, Set<IriAst> toClause) {
-        this(prologue, fromClause, toClause, false);
+    public LoadQueryAst(Set<IriAst> fromClause, Set<IriAst> toClause) {
+        this(fromClause, toClause, false);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadQueryAst.java
@@ -1,0 +1,29 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents the LOAD queries as defined in the <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#load">SPARQL 1.1 recommendation<a/>.
+ * @param prologue Prologue declarations
+ * @param fromClause From clause, set of graphs IRIs
+ * @param toClause To clause. Set of Graph IRIs
+ * @param silent Determine if the resolution of the query must be resolved silently or not.
+ */
+public record LoadQueryAst(QueryPrologueAst prologue, Set<IriAst> fromClause, Set<IriAst> toClause, boolean silent) implements UpdateQueryAst {
+    public LoadQueryAst {
+        if(prologue == null) {
+            prologue = QueryPrologueAst.empty();
+        }
+        if(fromClause == null) {
+            fromClause = new HashSet<>();
+        }
+        if(toClause == null) {
+            toClause = new HashSet<>();
+        }
+    }
+
+    public LoadQueryAst(QueryPrologueAst prologue, Set<IriAst> fromClause, Set<IriAst> toClause) {
+        this(prologue, fromClause, toClause, false);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrologueQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrologueQueryAst.java
@@ -1,0 +1,8 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+/**
+ * Represents queries that can be prefixed with a prologue declaration (i.e. Select, Insert, etc.)
+ */
+public sealed interface PrologueQueryAst permits SparqlQueryAst {
+    QueryPrologueAst prologue();
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
@@ -1,6 +1,4 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 public sealed interface QueryAst permits SparqlQueryAst, UpdateQueryAst {
-    QueryPrologueAst prologue();
-    ValuesAst valuesClause();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
@@ -1,12 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-/**
- * Minimal SPARQL query AST (SELECT, ASK, CONSTRUCT, DESCRIBE).
- * Holds the WHERE clause as a group graph pattern; query-specific projection/template can be added later.
- */
-public sealed interface QueryAst permits AskQueryAst, ConstructQueryAst, DescribeQueryAst, SelectQueryAst {
-    DatasetClauseAst datasetClause();
-    GroupGraphPatternAst whereClause();
+public sealed interface QueryAst permits SparqlQueryAst, UpdateQueryAst {
     QueryPrologueAst prologue();
     ValuesAst valuesClause();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SelectQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SelectQueryAst.java
@@ -9,7 +9,7 @@ import java.util.List;
  * {@link #prologue()} captures PREFIX/BASE for SELECT;
  * for {@link QueryAst} compatibility.
  */
-public record SelectQueryAst(ProjectionAst projection, DatasetClauseAst datasetClause, GroupGraphPatternAst whereClause, SolutionModifierAst solutionModifier, QueryPrologueAst prologue, ValuesAst valuesClause) implements QueryAst {
+public record SelectQueryAst(ProjectionAst projection, DatasetClauseAst datasetClause, GroupGraphPatternAst whereClause, SolutionModifierAst solutionModifier, QueryPrologueAst prologue, ValuesAst valuesClause) implements SparqlQueryAst {
 
     /** Constructor with default projection SELECT *. */
     public SelectQueryAst(GroupGraphPatternAst whereClause) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
@@ -5,6 +5,7 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
  * Holds the WHERE clause as a group graph pattern; query-specific projection/template can be added later.
  */
 public sealed interface SparqlQueryAst extends QueryAst permits AskQueryAst, ConstructQueryAst, DescribeQueryAst, SelectQueryAst {
+    QueryPrologueAst prologue();
     DatasetClauseAst datasetClause();
     GroupGraphPatternAst whereClause();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
@@ -1,0 +1,10 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+/**
+ * Minimal SPARQL query AST (SELECT, ASK, CONSTRUCT, DESCRIBE).
+ * Holds the WHERE clause as a group graph pattern; query-specific projection/template can be added later.
+ */
+public sealed interface SparqlQueryAst extends QueryAst permits AskQueryAst, ConstructQueryAst, DescribeQueryAst, SelectQueryAst {
+    DatasetClauseAst datasetClause();
+    GroupGraphPatternAst whereClause();
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlQueryAst.java
@@ -4,8 +4,7 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
  * Minimal SPARQL query AST (SELECT, ASK, CONSTRUCT, DESCRIBE).
  * Holds the WHERE clause as a group graph pattern; query-specific projection/template can be added later.
  */
-public sealed interface SparqlQueryAst extends QueryAst permits AskQueryAst, ConstructQueryAst, DescribeQueryAst, SelectQueryAst {
-    QueryPrologueAst prologue();
+public sealed interface SparqlQueryAst extends QueryAst, PrologueQueryAst, WhereClauseQueryAst permits AskQueryAst, ConstructQueryAst, DescribeQueryAst, SelectQueryAst {
     DatasetClauseAst datasetClause();
-    GroupGraphPatternAst whereClause();
+    ValuesAst valuesClause();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateQueryAst.java
@@ -1,0 +1,7 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+/**
+ * Root interface for all queries related to the SPARQL Update queries listed in <a href="https://www.w3.org/TR/sparql11-update/">SPARQL 1.1 Update</>.
+ */
+public sealed interface UpdateQueryAst extends QueryAst permits LoadQueryAst {
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/WhereClauseQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/WhereClauseQueryAst.java
@@ -1,0 +1,8 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+/**
+ * Represents the AST elements of a query that has a WHERE clause (SELECT, CONSTRUCT, INSERT, DELETE, etc.)
+ */
+public sealed interface WhereClauseQueryAst permits SparqlQueryAst {
+    GroupGraphPatternAst whereClause();
+}

--- a/src/test/java/fr/inria/corese/core/next/query/api/sparql/ast/SparqlAstTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/api/sparql/ast/SparqlAstTest.java
@@ -385,7 +385,7 @@ class SparqlAstTest {
             GroupGraphPatternAst where = new GroupGraphPatternAst(List.of(
                     new BgpAst(List.of(new TriplePatternAst(
                             new VarAst("s"), new VarAst("p"), new VarAst("o"))))));
-            QueryAst q = new SelectQueryAst(where);
+            SparqlQueryAst q = new SelectQueryAst(where);
             assertSame(where, q.whereClause());
         }
 
@@ -426,7 +426,7 @@ class SparqlAstTest {
             GroupGraphPatternAst where = new GroupGraphPatternAst(List.of(
                     new BgpAst(List.of(new TriplePatternAst(
                             new VarAst("s"), new VarAst("p"), new VarAst("o"))))));
-            QueryAst q = new AskQueryAst(DatasetClauseAst.none(), where);
+            SparqlQueryAst q = new AskQueryAst(DatasetClauseAst.none(), where);
             assertSame(where, q.whereClause());
         }
 
@@ -503,7 +503,7 @@ class SparqlAstTest {
             BgpAst bgp = new BgpAst(List.of(
                     new TriplePatternAst(new VarAst("s"), new IriAst("a"), new VarAst("o"))));
             GroupGraphPatternAst where = new GroupGraphPatternAst(List.of(bgp));
-            QueryAst q = new SelectQueryAst(where);
+            SparqlQueryAst q = new SelectQueryAst(where);
             assertEquals(1, q.whereClause().patterns().size());
             assertEquals(1, ((BgpAst) q.whereClause().patterns().get(0)).triples().size());
         }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderTest.java
@@ -36,7 +36,7 @@ class SparqlAstBuilderTest {
         b.exitGroup();
         b.exitSelectQuery();
 
-        QueryAst ast = b.getResult();
+        SparqlQueryAst ast = (SparqlQueryAst) b.getResult();
         assertNotNull(ast);
         assertNotNull(ast.whereClause());
         assertEquals(0, ast.whereClause().patterns().size());
@@ -81,7 +81,7 @@ class SparqlAstBuilderTest {
         b.exitGroup();
         b.exitSelectQuery();
 
-        QueryAst ast = b.getResult();
+        SparqlQueryAst ast = (SparqlQueryAst) b.getResult();
         BgpAst bgp = singleBgp(ast);
 
         assertEquals(2, bgp.triples().size());
@@ -141,7 +141,7 @@ class SparqlAstBuilderTest {
         b.exitGroup();
         b.exitSelectQuery();
 
-        QueryAst ast = b.getResult();
+        SparqlQueryAst ast = (SparqlQueryAst) b.getResult();
         GroupGraphPatternAst where = ast.whereClause();
 
         assertEquals(2, where.patterns().size());
@@ -166,7 +166,7 @@ class SparqlAstBuilderTest {
         b.exitGroup();
         b.exitSelectQuery();
 
-        QueryAst ast = b.getResult();
+        SparqlQueryAst ast = (SparqlQueryAst) b.getResult();
         assertEquals(0, ast.whereClause().patterns().size(), "Empty TriplesBlock should not create a BGP pattern");
     }
 
@@ -191,7 +191,7 @@ class SparqlAstBuilderTest {
         b.exitGroup();
         b.exitSelectQuery();
 
-        BgpAst bgp = singleBgp(b.getResult());
+        BgpAst bgp = singleBgp((SparqlQueryAst) b.getResult());
         assertEquals(2, bgp.triples().size());
 
         LiteralAst l1 = (LiteralAst) bgp.triples().get(0).object();
@@ -305,7 +305,7 @@ class SparqlAstBuilderTest {
 
     // ---------- Helpers ----------
 
-    private static BgpAst singleBgp(QueryAst ast) {
+    private static BgpAst singleBgp(SparqlQueryAst ast) {
         GroupGraphPatternAst where = ast.whereClause();
         assertEquals(1, where.patterns().size(), "Expected exactly 1 pattern in WHERE");
         assertInstanceOf(BgpAst.class, where.patterns().getFirst(), "Expected first pattern to be a BGP");

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderUnionTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilderUnionTest.java
@@ -44,7 +44,7 @@ class SparqlAstBuilderUnionTest {
         builder.exitUnion();
         builder.exitGroup();           // }
         builder.exitSelectQuery();
-        return Objects.requireNonNull(builder.getResult()).whereClause();
+        return Objects.requireNonNull((SelectQueryAst)builder.getResult()).whereClause();
     }
 
     /**

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlListenerTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlListenerTest.java
@@ -2,11 +2,8 @@ package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.impl.parser.antlr.SparqlLexer;
 import fr.inria.corese.core.next.query.impl.parser.listener.SelectQueryFeature;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.parser.listener.BgpFeature;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -61,7 +58,7 @@ class SparqlListenerTest {
         fr.inria.corese.core.next.impl.parser.antlr.SparqlParser antlrParser = createAntlrParser("SELECT * WHERE { ?s ?p ?o }");
         new ParseTreeWalker().walk(listener, antlrParser.query());
 
-        QueryAst ast = builder.getResult();
+        SparqlQueryAst ast = (SparqlQueryAst) builder.getResult();
         assertNotNull(ast);
         assertNotNull(ast.whereClause());
         assertEquals(1, ast.whereClause().patterns().size());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAggregateTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAggregateTest.java
@@ -1,14 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VariableScopeAnalyzer;
-import fr.inria.corese.core.next.query.impl.sparql.ast.AggregateAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.AggregateFunction;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.OrderConditionAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.GreaterThanAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DisplayName("SPARQL 1.1 — Parser and AST : aggregates")
 class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
 
-    private static AggregateAst lastBindAggregate(QueryAst ast) {
+    private static AggregateAst lastBindAggregate(WhereClauseQueryAst ast) {
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         return assertInstanceOf(AggregateAst.class, bind.expression());
     }
@@ -54,7 +47,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCountWithVariableArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     BIND(COUNT(?s) AS ?c)
@@ -74,7 +67,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCountStar() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     BIND(COUNT(*) AS ?c)
@@ -93,7 +86,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCountDistinct() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     BIND(COUNT(DISTINCT ?s) AS ?c)
@@ -111,7 +104,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSum() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?x .
                     BIND(SUM(?x) AS ?sum)
@@ -130,7 +123,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAvgDistinct() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?x .
                     BIND(AVG(DISTINCT ?x) AS ?avg)
@@ -148,17 +141,17 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseMinMaxSample() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst minQ = parser.parse("""
+        SparqlQueryAst minQ = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE { ?s ?p ?x . BIND(MIN(?x) AS ?m) }
                 """);
         assertEquals(AggregateFunction.MIN, lastBindAggregate(minQ).function());
 
-        QueryAst maxQ = parser.parse("""
+        SparqlQueryAst maxQ = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE { ?s ?p ?x . BIND(MAX(?x) AS ?m) }
                 """);
         assertEquals(AggregateFunction.MAX, lastBindAggregate(maxQ).function());
 
-        QueryAst sampleQ = parser.parse("""
+        SparqlQueryAst sampleQ = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE { ?s ?p ?x . BIND(SAMPLE(?x) AS ?m) }
                 """);
         assertEquals(AggregateFunction.SAMPLE, lastBindAggregate(sampleQ).function());
@@ -169,7 +162,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseGroupConcatWithoutSeparator() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     BIND(GROUP_CONCAT(?o) AS ?g)
@@ -188,7 +181,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseGroupConcatWithSeparator() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     BIND(GROUP_CONCAT(?o ; SEPARATOR = "|") AS ?g)
@@ -205,7 +198,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAggregateInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?o .
                     FILTER(COUNT(*) > 0)
@@ -225,7 +218,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAggregateInOrderBy() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT ?s WHERE {
                     ?s ?p ?val
                 }
@@ -245,7 +238,7 @@ class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
     void shouldCollectVariablesReferencedInsideAggregate() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                     ?s ?p ?price .
                     BIND(AVG(?price) AS ?a)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAskQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAskQueryTest.java
@@ -15,7 +15,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
     public void shouldParseBasicAskQueryTest() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 ASK WHERE {
                   ?s ?p ?o .
                 }
@@ -50,7 +50,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
     public void shouldParseShortAskQueryTest() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 ASK {
                   <https://ns.inria.fr/corese> ?p ?o .
                 }
@@ -221,7 +221,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -245,7 +245,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -269,7 +269,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().namedGraphs());
@@ -293,7 +293,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -319,7 +319,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -375,7 +375,7 @@ public class SparqlParserAskQueryTest extends AbstractSparqlParserFeatureTest {
                     ?s ?p ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(query);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(query);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertInstanceOf(AskQueryAst.class, queryAst);

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBgpTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBgpTest.java
@@ -7,17 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import org.junit.jupiter.api.Test;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.PatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 
 /**
  * Test if we parse the Basic Graph Pattern (BGP)
@@ -28,7 +21,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSingleTriplePatternInBgp() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                 }
@@ -61,7 +54,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParsePropertyListSemicolonAndCommaIntoMultipleTriples() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
                 SELECT * WHERE {
                   ?s a foaf:Person ;
@@ -101,7 +94,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParseRdfLiteralWithLanguageTag() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example/p> "salut"@fr .
                 }
@@ -123,7 +116,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParseRdfLiteralWithDatatype() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 SELECT * WHERE {
                   ?s <http://example/p> "12"^^xsd:integer .
@@ -145,7 +138,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParsePrefixedNameWithDigitOnlyLocalPart() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX ex: <http://example.org/>
                 SELECT * WHERE {
                   ?s ex:1 ?o .
@@ -163,7 +156,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParsePrefixedNameWithHyphenInLocalPart() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX ex: <http://example.org/>
                 SELECT * WHERE {
                   ?s ex:abc-def ?o .
@@ -181,7 +174,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParsePrefixedNameWithEscapedReservedCharacterInLocalPart() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX ns: <http://example.org/ns#>
                 SELECT * WHERE {
                   ?s ns:id\\=123 ?o .
@@ -199,7 +192,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     void shouldParsePrefixedNameWithDefaultPrefix() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX : <http://example.org/default#>
                 SELECT * WHERE {
                   ?s :foo ?o .
@@ -238,7 +231,7 @@ class SparqlParserBgpTest extends AbstractSparqlParserFeatureTest {
     @Test
     void shouldParseEmptyWhereGroup() {
         SparqlParser parser = newParserDefault();
-        QueryAst ast = parser.parse("SELECT * WHERE { }");
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("SELECT * WHERE { }");
 
         assertNotNull(ast.whereClause());
         // selon ton builder: TriplesBlock absent => pas de BgpAst, donc patterns vide

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBindTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBindTest.java
@@ -17,7 +17,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithVariable() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(?s AS ?x)
@@ -42,7 +42,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithConcat() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(CONCAT(?a, ?b) AS ?c)
@@ -71,7 +71,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithArithmetic() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(?x + 1 AS ?y)
@@ -95,7 +95,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithSubtractWithoutWhitespace() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT ?price WHERE {
                   ?x ?p ?discount .
                   BIND(?p*(1-?discount) AS ?price)
@@ -130,7 +130,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithStringLiteral() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND("hello" AS ?label)
@@ -155,7 +155,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindWithIri() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(<http://example.org> AS ?type)
@@ -180,7 +180,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseMultipleBinds() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(?s AS ?x)
@@ -206,7 +206,7 @@ class SparqlParserBindTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBindInsideOptional() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   OPTIONAL { BIND(?s AS ?x) }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBnodeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBnodeTest.java
@@ -1,11 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BnodeAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IsBlankAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +22,7 @@ class SparqlParserBnodeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBnodeWithoutLabelInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(BNODE() AS ?b)
@@ -45,7 +41,7 @@ class SparqlParserBnodeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBnodeWithLabelInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(BNODE(?label) AS ?b)
@@ -64,7 +60,7 @@ class SparqlParserBnodeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNestedBnodeInIsBlankFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(isBlank(BNODE(?label)))

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
@@ -6,16 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.CoalesceAst;
 
 @DisplayName("SPARQL 1.1 - Parser and AST : COALESCE")
@@ -26,7 +21,7 @@ class SparqlParserCoalesceTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCoalesceWithThreeArgs() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(COALESCE(?s, ?p, ?o))
@@ -52,7 +47,7 @@ class SparqlParserCoalesceTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCoalesceInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(COALESCE(?s, "default") AS ?result)
@@ -75,7 +70,7 @@ class SparqlParserCoalesceTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCoalesceWithOneArg() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(COALESCE(?s))

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserConcatTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserConcatTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.ConcatAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserConcatTest extends AbstractSparqlParserFeatureTest {
     void shouldParseConcatInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?given, ?family .
                   BIND(CONCAT(?given, " ", ?family) AS ?label)
@@ -48,7 +43,7 @@ class SparqlParserConcatTest extends AbstractSparqlParserFeatureTest {
     void shouldParseConcatWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(CONCAT("foo", "bar") AS ?label)
@@ -68,7 +63,7 @@ class SparqlParserConcatTest extends AbstractSparqlParserFeatureTest {
     void shouldParseConcatInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(CONCAT(?a, ?b) = "ab")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserContainsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserContainsTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.ContainsAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +20,7 @@ class SparqlParserContainsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseContainsInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(CONTAINS(?label, "core"))
@@ -44,7 +39,7 @@ class SparqlParserContainsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseContainsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(CONTAINS(?label, "core") AS ?hasCore)
@@ -64,7 +59,7 @@ class SparqlParserContainsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseContainsWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(CONTAINS("foobar", "bar") AS ?hasBar)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDateTimeFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDateTimeFunctionsTest.java
@@ -1,10 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.DayAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.HoursAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.MinutesAst;
@@ -37,7 +34,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseNowInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(NOW() AS ?now)
@@ -75,7 +72,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseYearInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/date> ?date .
                   BIND(YEAR(?date) AS ?y)
@@ -127,7 +124,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseMonthInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/date> ?date .
                   BIND(MONTH(?date) AS ?m)
@@ -148,7 +145,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseDayInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/date> ?date .
                   BIND(DAY(?date) AS ?d)
@@ -169,7 +166,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseHoursInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/dt> ?dt .
                   BIND(HOURS(?dt) AS ?h)
@@ -190,7 +187,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseMinutesInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/dt> ?dt .
                   BIND(MINUTES(?dt) AS ?min)
@@ -211,7 +208,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseSecondsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/dt> ?dt .
                   BIND(SECONDS(?dt) AS ?sec)
@@ -232,7 +229,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseTimezoneInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/dt> ?dt .
                   BIND(TIMEZONE(?dt) AS ?tz)
@@ -253,7 +250,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
     void shouldParseTzInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/dt> ?dt .
                   BIND(TZ(?dt) AS ?tzStr)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDescribeTest.java
@@ -148,7 +148,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = queryParser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -172,7 +172,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = queryParser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -196,7 +196,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = queryParser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().namedGraphs());
@@ -220,7 +220,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = queryParser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -246,7 +246,7 @@ class SparqlParserDescribeTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 }
                """;
-        QueryAst queryAst = queryParser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) queryParser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserEncodeForUriTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserEncodeForUriTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EncodeForUriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseEncodeForUriInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(ENCODE_FOR_URI(?label) AS ?encoded)
@@ -45,7 +40,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseEncodeForUriWithLiteralArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(ENCODE_FOR_URI("Los Angeles") AS ?encoded)
@@ -65,7 +60,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseEncodeForUriInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(ENCODE_FOR_URI(?label) = "abc")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -48,7 +48,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseTrueFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(true)
@@ -76,7 +76,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAndFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s && true)
@@ -108,7 +108,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseOrFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT ?s WHERE {
                   ?s ?p ?o .
                   FILTER(?s || true)
@@ -140,7 +140,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(! ?s)
@@ -170,7 +170,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBoundFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(Bound( ?s))
@@ -200,7 +200,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIsIriFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(isIri( ?s))
@@ -230,7 +230,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIsUriFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(isUri( ?s))
@@ -260,7 +260,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIsBlankFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(isBlank( ?s))
@@ -290,7 +290,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIsLiteralFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(isLiteral( ?s))
@@ -320,7 +320,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(str(?s) = "test")
@@ -354,7 +354,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(lang(?s) = "test")
@@ -388,7 +388,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseDatatypeEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(datatype(?s) = "test")
@@ -422,7 +422,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s = <http://example.com>)
@@ -454,7 +454,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseDifferentFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s != <http://example.com>)
@@ -486,7 +486,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLowerFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s < <http://example.com>)
@@ -518,7 +518,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLowerOrEqualFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s <= <http://example.com>)
@@ -550,7 +550,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseGreaterFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s > <http://example.com>)
@@ -582,7 +582,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseGreaterOrEqualFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s >= <http://example.com>)
@@ -614,7 +614,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseDivideEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s / 2 = "test")
@@ -650,7 +650,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseTimesEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s * 2 = "test")
@@ -686,7 +686,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAddsEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s + 2 = "test")
@@ -722,7 +722,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSubstractEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s - 2 = "test")
@@ -758,7 +758,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSameTermFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(sameTerm(?s, <http://example.com>))
@@ -791,7 +791,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangMatchesFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(langMatches(?s, "test"))
@@ -823,7 +823,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBinaryRegexFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(REGEX(?s, "test"))
@@ -854,7 +854,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseTrinaryRegexFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(REGEX(?s, "test", "i"))
@@ -888,7 +888,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseFunCallFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(<http://example.org/function>(?s, "test"))
@@ -924,7 +924,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAddsUnaryMinusEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s + - 2 = "test")
@@ -962,7 +962,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAddSubChainEqualsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s * 2 + ?o - 5 = "test")
@@ -1014,7 +1014,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSubtractWithoutWhitespaceInsideParenthesizedMultiplyExpression() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?x ?p ?discount .
                   ?x ?pricePredicate ?price .
@@ -1045,7 +1045,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUnaryPlusFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(+ ?s)
@@ -1075,7 +1075,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUnaryMinusFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(- ?s)
@@ -1104,7 +1104,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseChainedOrFilterLeftAssociatively() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?a || ?b || ?c)
@@ -1130,7 +1130,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseChainedAndFilterLeftAssociatively() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?a && ?b && ?c)
@@ -1156,7 +1156,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSignedNegativeLiteralInAdditiveExpression() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s - -2 = "test")
@@ -1179,7 +1179,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSignedPositiveLiteralInAdditiveExpression() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s + +2 = "test")
@@ -1202,7 +1202,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseMixedMultiplyThenDivideLeftAssociatively() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s * 2 / 3 = "test")
@@ -1229,7 +1229,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseMixedDivideThenMultiplyLeftAssociatively() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(?s / 2 * 3 = "test")
@@ -1256,7 +1256,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseExistsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER EXISTS { ?s ex:email ?e }
@@ -1282,7 +1282,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotExistsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER NOT EXISTS { ?s ex:email ?e }
@@ -1354,7 +1354,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseExistsWithMultipleTriples() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER EXISTS {
@@ -1376,7 +1376,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotExistsEmpty() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER NOT EXISTS { }
@@ -1395,7 +1395,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     @Test
     void shouldParseAndBetweenTwoExistsFilters() {
         SparqlParser parser = newParserDefault();
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
           PREFIX ex: <http://example.org/>
           
           SELECT * WHERE {
@@ -1419,7 +1419,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     @Test
     void shouldParseOrBetweenExistsAndNotExistsFilters() {
         SparqlParser parser = newParserDefault();
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
           PREFIX ex: <http://example.org/>
           
           SELECT * WHERE {

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import org.junit.jupiter.api.Test;
 
@@ -7,13 +8,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.PatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AddAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AndAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BinaryRegexAst;
@@ -1308,7 +1302,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotOverExistsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(!EXISTS { ?s ex:email ?e })
@@ -1331,7 +1325,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotOverNotExistsFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(!NOT EXISTS { ?s ex:email ?e })

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserHashFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserHashFunctionsTest.java
@@ -6,14 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.Md5Ast;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.Sha1Ast;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.Sha256Ast;
@@ -28,7 +25,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseMd5InBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(MD5(?label) AS ?hash)
@@ -47,7 +44,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSha1InBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SHA1(?label) AS ?hash)
@@ -66,7 +63,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSha256InBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SHA256(?label) AS ?hash)
@@ -85,7 +82,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSha384InBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SHA384(?label) AS ?hash)
@@ -104,7 +101,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSha512InBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SHA512(?label) AS ?hash)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIfTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIfTest.java
@@ -16,7 +16,7 @@ class SparqlParserIfTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIfInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(IF(?s > 0, true, false))
@@ -38,7 +38,7 @@ class SparqlParserIfTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIfInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(IF(?s > 0, ?s, ?o) AS ?result)
@@ -60,7 +60,7 @@ class SparqlParserIfTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIfWithBoundCondition() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(IF(BOUND(?o), ?o, "default") AS ?val)
@@ -82,7 +82,7 @@ class SparqlParserIfTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNestedIf() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(IF(?s, IF(?p, ?p, ?o), ?o) AS ?r)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserInTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserInTest.java
@@ -1,11 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.InAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.NotInAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +22,7 @@ class SparqlParserInTest extends AbstractSparqlParserFeatureTest {
     void shouldParseInWithLiterals() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?x .
                   FILTER(?x IN (1, 2, 3))
@@ -48,7 +44,7 @@ class SparqlParserInTest extends AbstractSparqlParserFeatureTest {
     void shouldParseInEmptyList() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(2 IN ())
@@ -67,7 +63,7 @@ class SparqlParserInTest extends AbstractSparqlParserFeatureTest {
     void shouldParseNotIn() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?x .
                   FILTER(?x NOT IN (1, 2))

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIriTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIriTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IriFunctionAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIriInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?lex .
                   BIND(IRI(?lex) AS ?iri)
@@ -45,7 +40,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUriAliasInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?lex .
                   BIND(URI(?lex) AS ?iri)
@@ -64,7 +59,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseIriInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?lex .
                   FILTER(IRI(?lex) = <http://example.org/resource>)
@@ -84,7 +79,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
     void shouldParseOrderByIri() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT ?lex WHERE {
                   ?s ?p ?lex .
                 } ORDER BY IRI(?lex)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLangMatchesTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLangMatchesTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BooleanExpressionAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.LangMatchesAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserLangMatchesTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangMatchesInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(LANGMATCHES(LANG(?o), "fr") AS ?match)
@@ -45,7 +40,7 @@ class SparqlParserLangMatchesTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangMatchesInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/title> ?title .
                   FILTER(LANGMATCHES(LANG(?title), "fr"))
@@ -63,7 +58,7 @@ class SparqlParserLangMatchesTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangMatchesWithWildcardRange() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s <http://example.org/title> ?title .
                   FILTER(LANGMATCHES(LANG(?title), "*"))
@@ -82,7 +77,7 @@ class SparqlParserLangMatchesTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLangMatchesWithVariableArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(LANGMATCHES(?lang, "fr"))
@@ -101,7 +96,7 @@ class SparqlParserLangMatchesTest extends AbstractSparqlParserFeatureTest {
     void shouldParseOrderByLangMatches() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT ?title WHERE {
                   ?s <http://example.org/title> ?title .
                 } ORDER BY LANGMATCHES(LANG(?title), "fr")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLcaseTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLcaseTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.LcaseAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLcaseInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(LCASE(?label) AS ?lower)
@@ -45,7 +40,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLcaseWithLiteralArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(LCASE("CORESE") AS ?lower)
@@ -65,7 +60,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseLcaseInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(LCASE(?label) = "core")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
@@ -27,4 +27,59 @@ public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
         assertEquals(0, loadQueryAst.toClause().size());
         assertEquals(false, loadQueryAst.silent());
     }
+
+    @Test
+    public void simpleSilentQueryTest() {
+        QueryParser parser = newParserDefault();
+        String query = """
+                LOAD SILENT <http://ns.inria.fr/test>
+                """;
+
+        QueryAst queryAst = parser.parse(query);
+        assertInstanceOf(LoadQueryAst.class, queryAst);
+        LoadQueryAst loadQueryAst = (LoadQueryAst) queryAst;
+        assertEquals(1, loadQueryAst.fromClause().size());
+        IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
+        assertEquals(0, loadQueryAst.toClause().size());
+        assertEquals(true, loadQueryAst.silent());
+    }
+
+    @Test
+    public void fullQueryTest() {
+        QueryParser parser = newParserDefault();
+        String query = """
+                LOAD <http://ns.inria.fr/test> INTO GRAPH <http://ns.inria.fr/otherGraph>
+                """;
+
+        QueryAst queryAst = parser.parse(query);
+        assertInstanceOf(LoadQueryAst.class, queryAst);
+        LoadQueryAst loadQueryAst = (LoadQueryAst) queryAst;
+        assertEquals(1, loadQueryAst.fromClause().size());
+        IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
+        assertEquals(1, loadQueryAst.toClause().size());
+        IriAst targetGraphIri = (IriAst) loadQueryAst.toClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/otherGraph>", targetGraphIri.raw());
+        assertEquals(false, loadQueryAst.silent());
+    }
+
+    @Test
+    public void fullSilentQueryTest() {
+        QueryParser parser = newParserDefault();
+        String query = """
+                LOAD <http://ns.inria.fr/test> INTO GRAPH <http://ns.inria.fr/otherGraph>
+                """;
+
+        QueryAst queryAst = parser.parse(query);
+        assertInstanceOf(LoadQueryAst.class, queryAst);
+        LoadQueryAst loadQueryAst = (LoadQueryAst) queryAst;
+        assertEquals(1, loadQueryAst.fromClause().size());
+        IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
+        assertEquals(1, loadQueryAst.toClause().size());
+        IriAst targetGraphIri = (IriAst) loadQueryAst.toClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/otherGraph>", targetGraphIri.raw());
+        assertEquals(true, loadQueryAst.silent());
+    }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
@@ -1,0 +1,30 @@
+package fr.inria.corese.core.next.query.impl.parser;
+
+import fr.inria.corese.core.next.query.api.io.parser.QueryParser;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LoadQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
+
+    @Test
+    public void simpleQueryTest() {
+        QueryParser parser = newParserDefault();
+        String query = """
+                LOAD <http://ns.inria.fr/test>
+                """;
+
+        QueryAst queryAst = parser.parse(query);
+        assertInstanceOf(LoadQueryAst.class, queryAst);
+        LoadQueryAst loadQueryAst = (LoadQueryAst) queryAst;
+        assertEquals(1, loadQueryAst.fromClause().size());
+        IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
+        assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
+        assertEquals(0, loadQueryAst.toClause().size());
+        assertEquals(false, loadQueryAst.silent());
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLoadQueryTest.java
@@ -6,8 +6,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.LoadQueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
 
@@ -25,7 +24,7 @@ public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
         IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
         assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
         assertEquals(0, loadQueryAst.toClause().size());
-        assertEquals(false, loadQueryAst.silent());
+        assertFalse(loadQueryAst.silent());
     }
 
     @Test
@@ -42,7 +41,7 @@ public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
         IriAst graphIri = (IriAst) loadQueryAst.fromClause().toArray()[0];
         assertEquals("<http://ns.inria.fr/test>", graphIri.raw());
         assertEquals(0, loadQueryAst.toClause().size());
-        assertEquals(true, loadQueryAst.silent());
+        assertTrue(loadQueryAst.silent());
     }
 
     @Test
@@ -61,14 +60,14 @@ public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
         assertEquals(1, loadQueryAst.toClause().size());
         IriAst targetGraphIri = (IriAst) loadQueryAst.toClause().toArray()[0];
         assertEquals("<http://ns.inria.fr/otherGraph>", targetGraphIri.raw());
-        assertEquals(false, loadQueryAst.silent());
+        assertFalse(loadQueryAst.silent());
     }
 
     @Test
     public void fullSilentQueryTest() {
         QueryParser parser = newParserDefault();
         String query = """
-                LOAD <http://ns.inria.fr/test> INTO GRAPH <http://ns.inria.fr/otherGraph>
+                LOAD SILENT <http://ns.inria.fr/test> INTO GRAPH <http://ns.inria.fr/otherGraph>
                 """;
 
         QueryAst queryAst = parser.parse(query);
@@ -80,6 +79,6 @@ public class SparqlParserLoadQueryTest extends AbstractSparqlParserFeatureTest{
         assertEquals(1, loadQueryAst.toClause().size());
         IriAst targetGraphIri = (IriAst) loadQueryAst.toClause().toArray()[0];
         assertEquals("<http://ns.inria.fr/otherGraph>", targetGraphIri.raw());
-        assertEquals(true, loadQueryAst.silent());
+        assertTrue(loadQueryAst.silent());
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserMinusTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserMinusTest.java
@@ -2,12 +2,7 @@ package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VariableScopeAnalyzer;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.MinusAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +46,7 @@ class SparqlParserMinusTest extends AbstractSparqlParserFeatureTest {
     void shouldNotExposeMinusVariablesToFollowingBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   MINUS { ?s ?q ?hidden . }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
@@ -1,11 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AbsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.CeilAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FloorAst;
@@ -28,7 +24,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseAbsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(ABS(?x) AS ?abs)
@@ -47,7 +43,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseRoundInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(ROUND(?x))
@@ -65,7 +61,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseCeilInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(CEIL(?x))
@@ -83,7 +79,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseFloorInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(FLOOR(?x))
@@ -101,7 +97,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseRandInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(RAND() AS ?rand)
@@ -119,7 +115,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseRandInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(RAND())

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserPrologueTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserPrologueTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.SparqlQueryAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +28,7 @@ class SparqlParserPrologueTest extends AbstractSparqlParserFeatureTest {
 
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse(query);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(query);
         assertEquals("http://ns.inria.fr/test/", ast.prologue().baseIri().raw());
     }
 
@@ -46,7 +47,7 @@ class SparqlParserPrologueTest extends AbstractSparqlParserFeatureTest {
 
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse(query);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(query);
         assertEquals("http://ns.inria.fr/test/", ast.prologue().baseIri().raw());
     }
 
@@ -62,7 +63,7 @@ class SparqlParserPrologueTest extends AbstractSparqlParserFeatureTest {
 
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse(query);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(query);
         assertEquals("http://ns.inria.fr/test/", ast.prologue().baseIri().raw());
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserRegexTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserRegexTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BinaryRegexAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.TrinaryRegexAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserRegexTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBinaryRegexInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(REGEX(?label, "test"))
@@ -45,7 +40,7 @@ class SparqlParserRegexTest extends AbstractSparqlParserFeatureTest {
     void shouldParseBinaryRegexInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(REGEX(?label, "test") AS ?matches)
@@ -65,7 +60,7 @@ class SparqlParserRegexTest extends AbstractSparqlParserFeatureTest {
     void shouldParseTrinaryRegexInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(REGEX(?label, "test", "i"))
@@ -85,7 +80,7 @@ class SparqlParserRegexTest extends AbstractSparqlParserFeatureTest {
     void shouldParseTrinaryRegexInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(REGEX(?label, "^hello", "i") AS ?matches)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserReplaceTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserReplaceTest.java
@@ -1,11 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.ReplaceAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +21,7 @@ class SparqlParserReplaceTest extends AbstractSparqlParserFeatureTest {
     void shouldParseReplaceWithoutFlagsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(REPLACE(?label, "core", "CORE") AS ?normalized)
@@ -48,7 +44,7 @@ class SparqlParserReplaceTest extends AbstractSparqlParserFeatureTest {
     void shouldParseReplaceWithFlagsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(REPLACE(?label, "core", "CORE", "i") AS ?normalized)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserSelectQueryTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserSelectQueryTest.java
@@ -948,7 +948,7 @@ class SparqlParserSelectQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -972,7 +972,7 @@ class SparqlParserSelectQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -996,7 +996,7 @@ class SparqlParserSelectQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().namedGraphs());
@@ -1020,7 +1020,7 @@ class SparqlParserSelectQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());
@@ -1046,7 +1046,7 @@ class SparqlParserSelectQueryTest extends AbstractSparqlParserFeatureTest {
                         <http://ns.inria.fr/test#property> ?o .
                 } LIMIT 10
                """;
-        QueryAst queryAst = parser.parse(commentedQuery);
+        SparqlQueryAst queryAst = (SparqlQueryAst) parser.parse(commentedQuery);
         assertNotNull(queryAst);
         assertNotNull(queryAst.datasetClause());
         assertNotNull(queryAst.datasetClause().graphs());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserServiceTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserServiceTest.java
@@ -24,7 +24,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void shouldParseServiceWithIriEndpoint() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://dbpedia.org/sparql> {
@@ -52,7 +52,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void serviceBodyShouldContainBgp() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://dbpedia.org/sparql> {
@@ -83,7 +83,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void shouldParseSilentService() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE SILENT <https://example.org/sparql> {
@@ -105,7 +105,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void shouldParseNonSilentService() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://example.org/sparql> {
@@ -128,7 +128,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void shouldParseServiceWithVariableEndpoint() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       ?endpoint a <http://example.org/Service> .
@@ -158,7 +158,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void bgpBeforeAndAfterService() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       ?s a <http://example.org/Type> .
@@ -181,7 +181,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void serviceAndOptional() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://remote.org/sparql> {
@@ -202,7 +202,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void nestedServiceInsideOptional() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       ?s a <http://example.org/Type> .
@@ -234,7 +234,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void multipleTriplesSameBgp() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://dbpedia.org/sparql> {
@@ -255,7 +255,7 @@ class SparqlParserServiceTest extends AbstractSparqlParserFeatureTest {
         void serviceBodyWithFilter() {
             SparqlParser parser = newParserDefault();
 
-            QueryAst ast = parser.parse("""
+            SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                     SELECT *
                     WHERE {
                       SERVICE <https://remote.org/sparql> {

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrAfterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrAfterTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrAfterAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserStrAfterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrAfterInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRAFTER(?label, "core") AS ?suffix)
@@ -46,7 +41,7 @@ class SparqlParserStrAfterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrAfterWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRAFTER("foobar", "foo") AS ?suffix)
@@ -66,7 +61,7 @@ class SparqlParserStrAfterTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrAfterInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(STRAFTER(?label, "core") = "suffix")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrBeforeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrBeforeTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrBeforeAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserStrBeforeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrBeforeInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRBEFORE(?label, "core") AS ?prefix)
@@ -46,7 +41,7 @@ class SparqlParserStrBeforeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrBeforeWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRBEFORE("foobar", "bar") AS ?prefix)
@@ -66,7 +61,7 @@ class SparqlParserStrBeforeTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrBeforeInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(STRBEFORE(?label, "core") = "pre")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrDtTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrDtTest.java
@@ -1,13 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrDtAst;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +21,7 @@ class SparqlParserStrDtTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrDtInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 SELECT * WHERE {
                   ?s ?p ?label .
@@ -48,7 +42,7 @@ class SparqlParserStrDtTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrDtWithLiteralArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 SELECT * WHERE {
                   ?s ?p ?label .
@@ -69,7 +63,7 @@ class SparqlParserStrDtTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrDtInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                 SELECT * WHERE {
                   ?s ?p ?label .

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrEndsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrEndsTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrEndsAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +20,7 @@ class SparqlParserStrEndsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrEndsInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(STRENDS(?label, "core"))
@@ -44,7 +39,7 @@ class SparqlParserStrEndsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrEndsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRENDS(?label, "core") AS ?endsWithCore)
@@ -64,7 +59,7 @@ class SparqlParserStrEndsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrEndsWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRENDS("foobar", "bar") AS ?endsWithBar)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrLangTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrLangTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrLangAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserStrLangTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrLangInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRLANG(?label, "en") AS ?tagged)
@@ -46,7 +41,7 @@ class SparqlParserStrLangTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrLangWithLiteralArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRLANG("chat", "fr") AS ?tagged)
@@ -66,7 +61,7 @@ class SparqlParserStrLangTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrLangInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(STRLANG("chat", "fr") = "chat"@fr)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrLenTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrLenTest.java
@@ -1,10 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrLenAst;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +18,7 @@ class SparqlParserStrLenTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrLen() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(STRLEN(?s) AS ?len)
@@ -41,7 +37,7 @@ class SparqlParserStrLenTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrLenInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(STRLEN(?s) = 2)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrStartsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrStartsTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrStartsAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +20,7 @@ class SparqlParserStrStartsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrStartsInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(STRSTARTS(?label, "core"))
@@ -44,7 +39,7 @@ class SparqlParserStrStartsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrStartsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRSTARTS(?label, "core") AS ?startsWithCore)
@@ -64,7 +59,7 @@ class SparqlParserStrStartsTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrStartsWithLiteralArguments() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(STRSTARTS("foobar", "foo") AS ?startsWithFoo)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrUuidTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrUuidTest.java
@@ -1,10 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.StrUuidAst;
@@ -24,7 +20,7 @@ class SparqlParserStrUuidTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrUuid() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(STRUUID() AS ?id)
@@ -42,7 +38,7 @@ class SparqlParserStrUuidTest extends AbstractSparqlParserFeatureTest {
     void shouldParseStrUuidInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(STRUUID() = STR(?s))

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserSubstrTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserSubstrTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.SubstrAst;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +22,7 @@ class SparqlParserSubstrTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSubstrWithTwoArgumentsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SUBSTR(?label, 2) AS ?slice)
@@ -48,7 +43,7 @@ class SparqlParserSubstrTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSubstrWithThreeArgumentsInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(SUBSTR("foobar", 4, 3) AS ?slice)
@@ -69,7 +64,7 @@ class SparqlParserSubstrTest extends AbstractSparqlParserFeatureTest {
     void shouldParseSubstrInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(SUBSTR(?label, 2, 3) = "ore")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserTest.java
@@ -14,6 +14,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
+import fr.inria.corese.core.next.query.impl.sparql.ast.SparqlQueryAst;
 import org.junit.jupiter.api.Test;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
@@ -39,8 +40,8 @@ class SparqlParserTest {
     void parseStringReturnsSameResultAsParseReader() {
         SparqlParser parser = new SparqlParser(new SparqlParserOptions.Builder().build());
 
-        QueryAst fromString = parser.parse(VALID_SELECT_QUERY);
-        QueryAst fromReader = parser.parse(new StringReader(VALID_SELECT_QUERY));
+        SparqlQueryAst fromString = (SparqlQueryAst) parser.parse(VALID_SELECT_QUERY);
+        SparqlQueryAst fromReader = (SparqlQueryAst) parser.parse(new StringReader(VALID_SELECT_QUERY));
 
         assertNotNull(fromString);
         assertNotNull(fromReader);
@@ -55,7 +56,7 @@ class SparqlParserTest {
         SparqlParser parser = new SparqlParser(new SparqlParserOptions.Builder().build());
         byte[] bytes = VALID_SELECT_QUERY.getBytes(StandardCharsets.UTF_8);
 
-        QueryAst ast = parser.parse(new ByteArrayInputStream(bytes));
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(new ByteArrayInputStream(bytes));
 
         assertNotNull(ast);
         assertNotNull(ast.whereClause());
@@ -136,7 +137,7 @@ class SparqlParserTest {
     void parserWithNullConfigParseStillWorks() {
         SparqlParser parser = new SparqlParser((QueryOptions) null);
 
-        QueryAst ast = parser.parse(VALID_SELECT_QUERY);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(VALID_SELECT_QUERY);
 
         assertNotNull(ast);
         assertNotNull(ast.whereClause());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUcaseTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUcaseTest.java
@@ -1,12 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.UcaseAst;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +21,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUcaseInBind() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(UCASE(?label) AS ?upper)
@@ -45,7 +40,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUcaseWithLiteralArgument() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   BIND(UCASE("corese") AS ?upper)
@@ -65,7 +60,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUcaseInFilterComparison() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?label .
                   FILTER(UCASE(?label) = "CORE")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUuidTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUuidTest.java
@@ -19,7 +19,7 @@ class SparqlParserUuidTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUuid() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   BIND(UUID() AS ?id)
@@ -37,7 +37,7 @@ class SparqlParserUuidTest extends AbstractSparqlParserFeatureTest {
     void shouldParseUuidInFilter() {
         SparqlParser parser = newParserDefault();
 
-        QueryAst ast = parser.parse("""
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
                   FILTER(UUID() = ?s)

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValuesTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValuesTest.java
@@ -20,7 +20,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES ?var { "test" <http://ns.inria.fr/test> }
                 }
                 """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);
@@ -45,7 +45,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES (?var1 ?var2) { ("test1" <http://ns.inria.fr/test1>) ("test2" <http://ns.inria.fr/test2>) }
                 }
                 """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);
@@ -87,7 +87,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                 }
                VALUES (?var2 ?var3) { ("test2" <http://ns.inria.fr/test2>) }
                """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);
@@ -123,7 +123,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES ?var { "test" UNDEF }
                 }
                 """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);
@@ -147,7 +147,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES () { () }
                 }
                 """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);
@@ -163,7 +163,7 @@ public class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES () { ( "test" ) }
                 }
                 """;
-        QueryAst ast = parser.parse(inlineValueTest);
+        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
         ValuesAst valuesAst = ast.valuesClause();
         assertNotNull(valuesAst);

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlAstTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/ast/SparqlAstTest.java
@@ -385,7 +385,7 @@ class SparqlAstTest {
             GroupGraphPatternAst where = new GroupGraphPatternAst(List.of(
                     new BgpAst(List.of(new TriplePatternAst(
                             new VarAst("s"), new VarAst("p"), new VarAst("o"))))));
-            QueryAst q = new SelectQueryAst(where);
+            SparqlQueryAst q = new SelectQueryAst(where);
             assertSame(where, q.whereClause());
         }
 
@@ -462,7 +462,7 @@ class SparqlAstTest {
             BgpAst bgp = new BgpAst(List.of(
                     new TriplePatternAst(new VarAst("s"), new IriAst("a"), new VarAst("o"))));
             GroupGraphPatternAst where = new GroupGraphPatternAst(List.of(bgp));
-            QueryAst q = new SelectQueryAst(where);
+            SparqlQueryAst q = new SelectQueryAst(where);
             assertEquals(1, q.whereClause().patterns().size());
             assertEquals(1, ((BgpAst) q.whereClause().patterns().get(0)).triples().size());
         }


### PR DESCRIPTION
This aims to add the update query LOAD.

Breaking change: A new sub-interface SPARQLQueryAst is inserted between QueryAst and the SELECT, CONSTRUCT, etc queries. A new sub-interface for update queries is also added at the same level. 
Furthermore, the declaration of a prologue or of a where clause is delegated to interfaces that can be used both in updates and regular queries. 

Explanation:
Update queries can be graph management queries (such as LOAD) or graph update queries (INSERT,DELETE). U Graph management have no prologue and no WHERE where clause. 