### PR TITLE
410 [SPARQL] Reject non-boolean expressions in FILTER and HAVING

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
@@ -16,4 +16,15 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
                 "?" + variableName,
                 getDiagnosticSource());
     }
+
+    protected QueryDiagnostic buildIncorrectTypeDiagnostic(String variableName, String clause, String expectedType) {
+        return new QueryDiagnostic(
+                QueryDiagnostic.Kind.SEMANTIC_ERROR,
+                QueryDiagnostic.Severity.ERROR,
+                 variableName + " used in " + clause + " should be resolvable to a " + expectedType,
+                -1,
+                -1,
+                "?" + variableName,
+                getDiagnosticSource());
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
@@ -35,5 +35,5 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
                 variableName,
                 source);
     }
-    }
+    
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
@@ -7,6 +7,10 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
     protected abstract String getDiagnosticSource();
 
     protected QueryDiagnostic buildOutOfScopeDiagnostic(String variableName, String clause) {
+        return buildOutOfScopeDiagnostic(getDiagnosticSource(), variableName, clause);
+    }
+
+    public static QueryDiagnostic buildOutOfScopeDiagnostic(String source, String variableName, String clause) {
         return new QueryDiagnostic(
                 QueryDiagnostic.Kind.SEMANTIC_ERROR,
                 QueryDiagnostic.Severity.ERROR,
@@ -14,17 +18,21 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
                 -1,
                 -1,
                 "?" + variableName,
-                getDiagnosticSource());
+                source);
     }
 
     protected QueryDiagnostic buildIncorrectTypeDiagnostic(String variableName, String clause, String expectedType) {
+        return buildIncorrectTypeDiagnostic(getDiagnosticSource(), variableName, clause, expectedType);
+    }
+
+    public static QueryDiagnostic buildIncorrectTypeDiagnostic(String source, String variableName, String clause, String expectedType) {
         return new QueryDiagnostic(
                 QueryDiagnostic.Kind.SEMANTIC_ERROR,
                 QueryDiagnostic.Severity.ERROR,
-                 variableName + " used in " + clause + " should be resolvable to a " + expectedType,
+                variableName + " used in " + clause + " should be resolvable to a " + expectedType,
                 -1,
                 -1,
                 "?" + variableName,
-                getDiagnosticSource());
+                source);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
@@ -32,7 +32,8 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
                 variableName + " used in " + clause + " should be resolvable to a " + expectedType,
                 -1,
                 -1,
-                "?" + variableName,
+                variableName,
                 source);
+    }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
@@ -12,6 +13,7 @@ import java.util.List;
  * This rule checks the operators used in Filter asts
  */
 public final class FilterArgumentsValidationRule extends AbstractSemanticValidationRule {
+
     @Override
     protected String getDiagnosticSource() {
         return FilterArgumentsValidationRule.class.getSimpleName();
@@ -25,19 +27,41 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
     }
 
     /**
-     * Checks that the operators used in FILTER and HAVING are either boolean expression, literal expression (that may return a boolean result or variables)
+     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
      */
-    private static boolean checkFilterBoolean(FilterAst filterAst) {
-        return !(filterAst.operator() instanceof BooleanExpressionAst
-                || (filterAst.operator() instanceof LiteralExpressionAst
-                        && ! (filterAst.operator() instanceof XsdDateTimeExpressionAst
-                            || filterAst.operator() instanceof XsdDayTimeDurationExpressionAst
-                            || filterAst.operator() instanceof NumericExpressionAst)
-                    )
-                || filterAst.operator() instanceof FunctionCallAst
-                || filterAst.operator() instanceof IfAst
-                || filterAst.operator() instanceof VarAst
-                || filterAst.operator() instanceof LiteralAst);
+    private static boolean checkTermIsPotentialBoolean(TermAst termAst) {
+        if(termAst instanceof BooleanExpressionAst) {
+            return true;
+        }
+        if(termAst instanceof LiteralExpressionAst literalExpressionAst
+                && ! ( literalExpressionAst instanceof XsdDateTimeExpressionAst
+                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
+                || literalExpressionAst instanceof NumericExpressionAst
+            )) { // Is a literal expression that could be a boolean, we cannot know
+            return true;
+        }
+        if(termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
+            return true;
+        }
+        if(termAst instanceof IfAst ifAst
+                && checkTermIsPotentialBoolean(ifAst.thenExpr())
+                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
+            return true;
+        }
+        if(termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {// is a literal that is a typed as a boolean or the string representation of one
+                if(datatype != null) {
+                    if(datatype.equals(XSD.xsdBoolean.getIRI().stringValue())) {
+                        return true;
+                    }
+                } else {
+                    return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
+                }
+        }
+        if(termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
+            return true;
+        }
+
+        return false;
     }
 
     private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
@@ -47,8 +71,8 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
             return result;
         };
         public void visit(PatternAst patternAst) {
-            if(patternAst instanceof FilterAst filterAst && checkFilterBoolean(filterAst)) {
-                result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
+            if(patternAst instanceof FilterAst(TermAst operator) && ! checkTermIsPotentialBoolean(operator)) {
+                result.add(buildIncorrectTypeDiagnostic(operator.getName(), "FILTER", "boolean"));
             }
         }
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,0 +1,47 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This rule checks the operators used in Filter asts
+ */
+public final class FilterArgumentsValidationRule extends AbstractSemanticValidationRule {
+    @Override
+    protected String getDiagnosticSource() {
+        return FilterArgumentsValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        List<QueryDiagnostic> result = new ArrayList<>();
+        List<PatternAst> filterPatternAst = queryAst.whereClause().patterns().stream().filter(patternAst -> patternAst instanceof FilterAst).toList();
+        List<FilterAst> badFilters = filterPatternAst.stream().filter(patternAst -> {
+           FilterAst filter = (FilterAst) patternAst;
+           return checkFilterBoolean(filter);
+        }).map(patternAst -> (FilterAst) patternAst).toList();
+        badFilters.forEach(patternAst -> {
+            result.add(this.buildIncorrectTypeDiagnostic(patternAst.operator().getName(), "FILTER", "boolean"));
+        });
+        return result;
+    }
+
+    /**
+     * Checks that the operators used in FILTER and HAVING are either boolean expression, literal expression (that may return a boolean result or variables)
+     */
+    private static boolean checkFilterBoolean(FilterAst filterAst) {
+        return !(filterAst.operator() instanceof BooleanExpressionAst
+                || (filterAst.operator() instanceof LiteralExpressionAst
+                        && ! (filterAst.operator() instanceof XsdDateTimeExpressionAst
+                            || filterAst.operator() instanceof XsdDayTimeDurationExpressionAst
+                            || filterAst.operator() instanceof NumericExpressionAst)
+                    )
+                || filterAst.operator() instanceof VarAst
+                || filterAst.operator() instanceof LiteralAst);
+    }
+}
+

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -69,10 +69,21 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
 
         public List<QueryDiagnostic> getResult() {
             return result;
-        };
+        }
+
+        @Override
         public void visit(PatternAst patternAst) {
-            if(patternAst instanceof FilterAst(TermAst operator) && ! checkTermIsPotentialBoolean(operator)) {
+            if (patternAst instanceof FilterAst(TermAst operator) && !checkTermIsPotentialBoolean(operator)) {
                 result.add(buildIncorrectTypeDiagnostic(operator.getName(), "FILTER", "boolean"));
+            }
+        }
+
+        @Override
+        public void visit(HavingAst havingAst) {
+            for (TermAst condition : havingAst.conditions()) {
+                if (!checkTermIsPotentialBoolean(condition)) {
+                    result.add(buildIncorrectTypeDiagnostic(condition.getName(), "HAVING", "boolean"));
+                }
             }
         }
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 
@@ -42,6 +43,19 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
                     )
                 || filterAst.operator() instanceof VarAst
                 || filterAst.operator() instanceof LiteralAst);
+    }
+
+    private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        };
+        public void visit(PatternAst patternAst) {
+            if(patternAst instanceof FilterAst filterAst) {
+                result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
+            }
+        }
     }
 }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -19,16 +19,9 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
 
     @Override
     public List<QueryDiagnostic> validate(QueryAst queryAst) {
-        List<QueryDiagnostic> result = new ArrayList<>();
-        List<PatternAst> filterPatternAst = queryAst.whereClause().patterns().stream().filter(patternAst -> patternAst instanceof FilterAst).toList();
-        List<FilterAst> badFilters = filterPatternAst.stream().filter(patternAst -> {
-           FilterAst filter = (FilterAst) patternAst;
-           return checkFilterBoolean(filter);
-        }).map(patternAst -> (FilterAst) patternAst).toList();
-        badFilters.forEach(patternAst -> {
-            result.add(this.buildIncorrectTypeDiagnostic(patternAst.operator().getName(), "FILTER", "boolean"));
-        });
-        return result;
+        FilterArgumentsValidationVisitor visitor = new FilterArgumentsValidationVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
     }
 
     /**
@@ -41,6 +34,8 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
                             || filterAst.operator() instanceof XsdDayTimeDurationExpressionAst
                             || filterAst.operator() instanceof NumericExpressionAst)
                     )
+                || filterAst.operator() instanceof FunctionCallAst
+                || filterAst.operator() instanceof IfAst
                 || filterAst.operator() instanceof VarAst
                 || filterAst.operator() instanceof LiteralAst);
     }
@@ -52,7 +47,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
             return result;
         };
         public void visit(PatternAst patternAst) {
-            if(patternAst instanceof FilterAst filterAst) {
+            if(patternAst instanceof FilterAst filterAst && checkFilterBoolean(filterAst)) {
                 result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
             }
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -8,11 +8,33 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
- * This rule checks the operators used in Filter asts
+ * Validates that FILTER and HAVING expressions are compatible with SPARQL
+ * effective boolean value evaluation.
  */
 public final class FilterArgumentsValidationRule extends AbstractSemanticValidationRule {
+
+    private static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
+    private static final String STRING_DATATYPE = XSD.xsdString.getIRI().stringValue();
+    private static final Set<String> NUMERIC_DATATYPES = Set.of(
+            XSD.xsdInteger.getIRI().stringValue(),
+            XSD.xsdNonNegativeInteger.getIRI().stringValue(),
+            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
+            XSD.xsdPositiveInteger.getIRI().stringValue(),
+            XSD.xsdNegativeInteger.getIRI().stringValue(),
+            XSD.xsdInt.getIRI().stringValue(),
+            XSD.xsdUnsignedInt.getIRI().stringValue(),
+            XSD.xsdLong.getIRI().stringValue(),
+            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdDecimal.getIRI().stringValue(),
+            XSD.xsdShort.getIRI().stringValue(),
+            XSD.xsdUnsignedShort.getIRI().stringValue(),
+            XSD.xsdByte.getIRI().stringValue(),
+            XSD.xsdUnsignedByte.getIRI().stringValue(),
+            XSD.xsdFloat.getIRI().stringValue(),
+            XSD.xsdDouble.getIRI().stringValue());
 
     @Override
     protected String getDiagnosticSource() {
@@ -27,41 +49,49 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
     }
 
     /**
-     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
+     * Checks whether the given term is statically compatible with SPARQL
+     * effective boolean value evaluation.
      */
-    private static boolean checkTermIsPotentialBoolean(TermAst termAst) {
-        if(termAst instanceof BooleanExpressionAst) {
-            return true;
-        }
-        if(termAst instanceof LiteralExpressionAst literalExpressionAst
-                && ! ( literalExpressionAst instanceof XsdDateTimeExpressionAst
-                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
-                || literalExpressionAst instanceof NumericExpressionAst
-            )) { // Is a literal expression that could be a boolean, we cannot know
-            return true;
-        }
-        if(termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
-            return true;
-        }
-        if(termAst instanceof IfAst ifAst
-                && checkTermIsPotentialBoolean(ifAst.thenExpr())
-                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
-            return true;
-        }
-        if(termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {// is a literal that is a typed as a boolean or the string representation of one
-                if(datatype != null) {
-                    if(datatype.equals(XSD.xsdBoolean.getIRI().stringValue())) {
-                        return true;
-                    }
-                } else {
-                    return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
-                }
-        }
-        if(termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
+    private static boolean isPotentiallyEbvCompatible(TermAst termAst) {
+        if (termAst instanceof BooleanExpressionAst
+                || termAst instanceof NumericExpressionAst
+                || termAst instanceof VarAst
+                || termAst instanceof FunctionCallAst
+                || termAst instanceof UnlimitedArgumentsFunctionAst) {
             return true;
         }
 
+        if (termAst instanceof LiteralAst literalAst) {
+            return isEbvCompatibleLiteral(literalAst);
+        }
+
+        if (termAst instanceof IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr)) {
+            return isPotentiallyEbvCompatible(condition)
+                    && isPotentiallyEbvCompatible(thenExpr)
+                    && isPotentiallyEbvCompatible(elseExpr);
+        }
+
+        if (termAst instanceof LiteralExpressionAst literalExpressionAst) {
+            return !(literalExpressionAst instanceof XsdDateTimeExpressionAst
+                    || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst);
+        }
+
         return false;
+    }
+
+    private static boolean isEbvCompatibleLiteral(LiteralAst literalAst) {
+        if (literalAst.lang() != null && !literalAst.lang().isBlank()) {
+            return true;
+        }
+
+        String datatype = literalAst.datatype();
+        if (datatype == null) {
+            return true;
+        }
+
+        return BOOLEAN_DATATYPE.equals(datatype)
+                || STRING_DATATYPE.equals(datatype)
+                || NUMERIC_DATATYPES.contains(datatype);
     }
 
     private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
@@ -73,7 +103,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
 
         @Override
         public void visit(PatternAst patternAst) {
-            if (patternAst instanceof FilterAst(TermAst operator) && !checkTermIsPotentialBoolean(operator)) {
+            if (patternAst instanceof FilterAst(TermAst operator) && !isPotentiallyEbvCompatible(operator)) {
                 result.add(buildIncorrectTypeDiagnostic(operator.getName(), "FILTER", "boolean"));
             }
         }
@@ -81,11 +111,10 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
         @Override
         public void visit(HavingAst havingAst) {
             for (TermAst condition : havingAst.conditions()) {
-                if (!checkTermIsPotentialBoolean(condition)) {
+                if (!isPotentiallyEbvCompatible(condition)) {
                     result.add(buildIncorrectTypeDiagnostic(condition.getName(), "HAVING", "boolean"));
                 }
             }
         }
     }
 }
-

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AbstractAstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AbstractAstVisitor.java
@@ -1,0 +1,94 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+
+/**
+ * Default implementation for AstVisitor
+ */
+public abstract class AbstractAstVisitor implements AstVisitor {
+
+    @Override
+    public void visit(PatternAst ast) {
+
+    }
+
+    @Override
+    public void visit(QueryAst ast) {
+
+    }
+
+    @Override
+    public void visit(TermAst ast) {
+
+    }
+
+    @Override
+    public void visit(ProjectionAst ast) {
+
+    }
+
+    @Override
+    public void visit(QueryPrologueAst ast) {
+
+    }
+
+    @Override
+    public void visit(ValuesAst ast) {
+
+    }
+
+    @Override
+    public void visit(ValueMappingAst ast) {
+
+    }
+
+    @Override
+    public void visit(SolutionModifierAst ast) {
+
+    }
+
+    @Override
+    public void visit(GroupGraphPatternAst ast) {
+
+    }
+
+    @Override
+    public void visit(TriplePatternAst ast) {
+
+    }
+
+    @Override
+    public void visit(ConstructTemplateAst ast) {
+
+    }
+
+    @Override
+    public void visit(DatasetClauseAst ast) {
+
+    }
+
+    @Override
+    public void visit(GroupByAst ast) {
+
+    }
+
+    @Override
+    public void visit(HavingAst ast) {
+
+    }
+
+    @Override
+    public void visit(OrderConditionAst ast) {
+
+    }
+
+    @Override
+    public void visit(PrefixDeclarationAst ast) {
+
+    }
+
+    @Override
+    public void visit(ServiceAst ast) {
+
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AbstractAstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AbstractAstVisitor.java
@@ -18,6 +18,11 @@ public abstract class AbstractAstVisitor implements AstVisitor {
     }
 
     @Override
+    public void visit(UpdateRequestUnitAst ast) {
+
+    }
+
+    @Override
     public void visit(TermAst ast) {
 
     }
@@ -89,6 +94,11 @@ public abstract class AbstractAstVisitor implements AstVisitor {
 
     @Override
     public void visit(ServiceAst ast) {
+
+    }
+
+    @Override
+    public void visit(GraphRefAst ast) {
 
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AstVisitor.java
@@ -1,0 +1,26 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+
+/**
+ * Visitor interface for the AST hierarchy
+ */
+public interface AstVisitor {
+    void visit(PatternAst ast);
+    void visit(QueryAst ast);
+    void visit(TermAst ast);
+    void visit(ProjectionAst ast);
+    void visit(QueryPrologueAst ast);
+    void visit(ValuesAst ast);
+    void visit(ValueMappingAst ast);
+    void visit(SolutionModifierAst ast);
+    void visit(GroupGraphPatternAst ast);
+    void visit(TriplePatternAst ast);
+    void visit(ConstructTemplateAst ast);
+    void visit(DatasetClauseAst ast);
+    void visit(GroupByAst ast);
+    void visit(HavingAst ast);
+    void visit(OrderConditionAst ast);
+    void visit(PrefixDeclarationAst ast);
+    void visit(ServiceAst ast);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/AstVisitor.java
@@ -8,6 +8,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 public interface AstVisitor {
     void visit(PatternAst ast);
     void visit(QueryAst ast);
+    void visit(UpdateRequestUnitAst ast);
     void visit(TermAst ast);
     void visit(ProjectionAst ast);
     void visit(QueryPrologueAst ast);
@@ -23,4 +24,5 @@ public interface AstVisitor {
     void visit(OrderConditionAst ast);
     void visit(PrefixDeclarationAst ast);
     void visit(ServiceAst ast);
+    void visit(GraphRefAst ast);
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
@@ -136,15 +136,15 @@ public final class VariableScopeAnalyzer {
                 addIfVariable(endpoint, visibleVariables);
             }
 
-            case SubQueryAst(QueryAst query) -> {
-                if (query instanceof SelectQueryAst select) {
-                    ProjectionAst proj = select.projection();
-                    if (proj.selectAll()) {
-                        collectVisibleVariables(select.whereClause(), visibleVariables);
-                    } else {
-                        for (VarAst v : proj.variables()) {
-                            visibleVariables.add(v.name());
-                        }
+            case SubQueryAst(SelectQueryAst select) -> {
+
+                ProjectionAst proj = select.projection();
+
+                if (proj.selectAll()) {
+                    collectVisibleVariables(select.whereClause(), visibleVariables);
+                } else {
+                    for (VarAst v : proj.variables()) {
+                        visibleVariables.add(v.name());
                     }
                 }
             }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VariableScopeAnalyzer.java
@@ -164,7 +164,7 @@ public final class VariableScopeAnalyzer {
 
             // Recurse into unary expressions such as STR(?x) or BOUND(?x).
             case UnaryConstraintAst unaryConstraint ->
-                collectReferencedVariables(unaryConstraint.getArgument(), referencedVariables);
+                collectReferencedVariables(unaryConstraint.argument(), referencedVariables);
 
             case BinaryConstraintAst binaryConstraint -> {
                 // Recurse into both operands of binary expressions.
@@ -218,14 +218,14 @@ public final class VariableScopeAnalyzer {
                 collectReferencedVariables(elseExpr, referencedVariables);
             }
 
-            case CoalesceAst(List<TermAst> arguments) -> {
-                for (TermAst argument : arguments) {
+            case CoalesceAst coalesceAst -> {
+                for (TermAst argument : coalesceAst.arguments()) {
                     collectReferencedVariables(argument, referencedVariables);
                 }
             }
 
-            case ConcatAst(List<TermAst> arguments) -> {
-                for (TermAst argument : arguments) {
+            case ConcatAst concatAst -> {
+                for (TermAst argument : concatAst.arguments()) {
                     collectReferencedVariables(argument, referencedVariables);
                 }
             }
@@ -243,8 +243,6 @@ public final class VariableScopeAnalyzer {
                     collectReferencedVariables(candidate, referencedVariables);
                 }
             }
-
-            case StrLenAst(TermAst argument) -> collectReferencedVariables(argument, referencedVariables);
 
             case AggregateAst(
                     AggregateFunction ignoredFunction, boolean ignoredDistinct, TermAst expression, String ignoredSep) ->

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VisitableAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/VisitableAst.java
@@ -1,0 +1,6 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+public interface VisitableAst {
+
+    void accept(AstVisitor visitor);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
@@ -3,6 +3,7 @@ package fr.inria.corese.core.next.query.impl.parser.semantic.validator;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
 import fr.inria.corese.core.next.query.api.validation.QueryValidator;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.FilterArgumentsValidationRule;
 import fr.inria.corese.core.next.query.impl.parser.semantic.rule.OrderByScopeValidationRule;
 import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SelectProjectionScopeValidationRule;
 import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SemanticValidationRule;
@@ -22,7 +23,8 @@ public final class SparqlQuerySemanticValidator implements QueryValidator<QueryA
     public SparqlQuerySemanticValidator() {
         this(List.of(
                 new SelectProjectionScopeValidationRule(),
-                new OrderByScopeValidationRule()));
+                new OrderByScopeValidationRule(),
+                new FilterArgumentsValidationRule()));
     }
 
     /** Package-private for tests or future composition of rule sets. */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AggregateAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AggregateAst.java
@@ -25,7 +25,9 @@ public record AggregateAst(
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.expression.accept(visitor);
+        if(this.expression != null) {
+            this.expression.accept(visitor);
+        }
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AggregateAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AggregateAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 public record AggregateAst(
         AggregateFunction function,
         boolean distinct,
@@ -18,5 +20,16 @@ public record AggregateAst(
         if (groupConcatSeparator != null && function != AggregateFunction.GROUP_CONCAT) {
             throw new IllegalArgumentException("groupConcatSeparator only allowed for GROUP_CONCAT");
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.expression.accept(visitor);
+    }
+
+    @Override
+    public String getName() {
+        return "AGGREGATE";
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AskQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/AskQueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -38,5 +40,15 @@ public record AskQueryAst(DatasetClauseAst datasetClause, GroupGraphPatternAst w
         if(valuesClause == null) {
             valuesClause = ValuesAst.none();
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.datasetClause.accept(visitor);
+        this.prologue.accept(visitor);
+        this.whereClause.accept(visitor);
+        this.solutionModifier.accept(visitor);
+        this.valuesClause.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BgpAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BgpAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -8,6 +10,14 @@ import java.util.List;
 public record BgpAst(List<TriplePatternAst> triples) implements PatternAst {
     public BgpAst {
         triples = triples != null ? List.copyOf(triples) : List.of();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        triples.forEach(triplePatternAst -> {
+            triplePatternAst.accept(visitor);
+        });
     }
 }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BgpAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BgpAst.java
@@ -15,9 +15,6 @@ public record BgpAst(List<TriplePatternAst> triples) implements PatternAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        triples.forEach(triplePatternAst -> {
-            triplePatternAst.accept(visitor);
-        });
+        triples.forEach(triplePatternAst -> triplePatternAst.accept(visitor));
     }
 }
-

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BindAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BindAst.java
@@ -1,6 +1,15 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * BIND(expression AS ?var) clause in SPARQL 1.1
  */
-public record BindAst(TermAst expression, VarAst variable) implements PatternAst {}
+public record BindAst(TermAst expression, VarAst variable) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        expression.accept(visitor);
+        variable.accept(visitor);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BindAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/BindAst.java
@@ -9,7 +9,11 @@ public record BindAst(TermAst expression, VarAst variable) implements PatternAst
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        expression.accept(visitor);
-        variable.accept(visitor);
+        if(this.expression != null) {
+            expression.accept(visitor);
+        }
+        if(this.variable != null) {
+            variable.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ClearRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ClearRequestAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Represents the CLEAR operation as defined in the <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#clear">SPARQL 1.1 recommendation<a/>.
  * @param graphRef targeted graph to be cleared
@@ -12,5 +14,11 @@ public record ClearRequestAst(GraphRefAst graphRef, boolean silent) implements U
      */
     public ClearRequestAst(GraphRefAst graphRef) {
         this( graphRef, false);
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.graphRef.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
@@ -3,5 +3,5 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 /**
  * Root interface for all operators resolving to a term
  */
-public non-sealed interface ConstraintAst extends TermAst {
+public non-sealed interface ConstraintAst extends TermAst, VisitableAst {
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
  * Root interface for all operators resolving to a term
  */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstraintAst.java
@@ -1,9 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
-
 /**
  * Root interface for all operators resolving to a term
  */
-public non-sealed interface ConstraintAst extends TermAst, VisitableAst {
+public non-sealed interface ConstraintAst extends TermAst {
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructQueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -71,5 +73,16 @@ public record ConstructQueryAst(
      */
     public ConstructQueryAst(ConstructTemplateAst template, GroupGraphPatternAst whereClause) {
         this(template, DatasetClauseAst.none(), whereClause, SolutionModifierAst.empty(), null, null);
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.constructTemplate.accept(visitor);
+        this.datasetClause.accept(visitor);
+        this.whereClause.accept(visitor);
+        this.solutionModifier.accept(visitor);
+        this.prologue.accept(visitor);
+        this.valuesClause.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
@@ -1,16 +1,18 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import java.util.List;
+
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
-import java.util.List;
-
 /**
- * CONSTRUCT template: list of triple templates used to build the output RDF graph.
+ * CONSTRUCT template: list of triple templates used to build the output RDF
+ * graph.
  *
  * <p>
- *  Unlike a WHERE clause BGP, a construct template does not represent a graph pattern to match,
- *  but triples to instantiate from bindings.
+ * Unlike a WHERE clause BGP, a construct template does not represent a graph
+ * pattern to match,
+ * but triples to instantiate from bindings.
  * <p/>
  *
  * @param triplePatternAsts triples to instantiate from solution bindings
@@ -23,8 +25,6 @@ public record ConstructTemplateAst(List<TriplePatternAst> triplePatternAsts) imp
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.triplePatternAsts.forEach(triplePatternAst -> {
-            triplePatternAst.accept(visitor);
-        });
+        this.triplePatternAsts.forEach(triplePatternAst -> triplePatternAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ConstructTemplateAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -12,8 +14,16 @@ import java.util.List;
  *
  * @param triplePatternAsts triples to instantiate from solution bindings
  */
-public record ConstructTemplateAst(List<TriplePatternAst> triplePatternAsts) {
+public record ConstructTemplateAst(List<TriplePatternAst> triplePatternAsts) implements VisitableAst {
     public ConstructTemplateAst {
         triplePatternAsts = triplePatternAsts != null ? List.copyOf(triplePatternAsts) : List.of();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.triplePatternAsts.forEach(triplePatternAst -> {
+            triplePatternAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DatasetClauseAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DatasetClauseAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DatasetClauseAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DatasetClauseAst.java
@@ -1,9 +1,11 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public record DatasetClauseAst(Set<IriAst> graphs, Set<IriAst> namedGraphs) {
+public record DatasetClauseAst(Set<IriAst> graphs, Set<IriAst> namedGraphs) implements VisitableAst {
 
     public DatasetClauseAst {
         graphs = graphs == null ? Set.of() : Set.copyOf(new LinkedHashSet<>(graphs));
@@ -12,5 +14,16 @@ public record DatasetClauseAst(Set<IriAst> graphs, Set<IriAst> namedGraphs) {
 
     public static DatasetClauseAst none() {
         return new DatasetClauseAst(Set.of(), Set.of());
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.graphs.forEach(iriAst -> {
+            iriAst.accept(visitor);
+        });
+        this.namedGraphs.forEach(iriAst -> {
+            iriAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -73,5 +75,18 @@ public record DescribeQueryAst(
      */
     public boolean isDescribeAll() {
         return described.isEmpty();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.prologue.accept(visitor);
+        this.datasetClause.accept(visitor);
+        this.described.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
+        this.whereClause.accept(visitor);
+        this.valuesClause.accept(visitor);
+        this.solutionModifier.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DescribeQueryAst.java
@@ -8,7 +8,9 @@ import java.util.List;
  * Abstract Syntax Tree (AST) representation of a SPARQL {@code DESCRIBE} query.
  * DESCRIBE (var|uri)* WHERE { pattern } or DESCRIBE (var|uri)*.
  *
- * <p>Examples:</p>
+ * <p>
+ * Examples:
+ * </p>
  *
  * <pre>{@code
  * DESCRIBE <http://example.org/>
@@ -29,23 +31,22 @@ public record DescribeQueryAst(
         GroupGraphPatternAst whereClause,
         SolutionModifierAst solutionModifier,
         QueryPrologueAst prologue,
-        ValuesAst valuesClause
-) implements SparqlQueryAst {
+        ValuesAst valuesClause) implements SparqlQueryAst {
     public DescribeQueryAst {
         described = described != null ? List.copyOf(described) : List.of();
         if (whereClause == null) {
             whereClause = new GroupGraphPatternAst(List.of());
         }
-        if(datasetClause == null) {
+        if (datasetClause == null) {
             datasetClause = DatasetClauseAst.none();
         }
         if (solutionModifier == null) {
             solutionModifier = SolutionModifierAst.empty();
         }
-        if(prologue == null) {
+        if (prologue == null) {
             prologue = QueryPrologueAst.empty();
         }
-        if(valuesClause == null) {
+        if (valuesClause == null) {
             valuesClause = ValuesAst.none();
         }
     }
@@ -57,8 +58,7 @@ public record DescribeQueryAst(
             DatasetClauseAst datasetClause,
             List<TermAst> described,
             GroupGraphPatternAst whereClause,
-            SolutionModifierAst solutionModifier
-    ) {
+            SolutionModifierAst solutionModifier) {
         this(datasetClause, described, whereClause, solutionModifier, null, null);
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/FilterAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/FilterAst.java
@@ -1,8 +1,15 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Filter clause in a SPARQL query
  * @param operator The operator whose evaluation will make a filter a createFunCall on the query results
  */
 public record FilterAst(TermAst operator) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.operator.accept(visitor);
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GraphRefAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GraphRefAst.java
@@ -1,8 +1,10 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
-public record GraphRefAst(IriAst graph, boolean named, boolean all, boolean defaultGraph) {
+public record GraphRefAst(IriAst graph, boolean named, boolean all, boolean defaultGraph) implements VisitableAst {
     public GraphRefAst {
         int activeTargets = 0;
         if (graph != null) {
@@ -32,5 +34,13 @@ public record GraphRefAst(IriAst graph, boolean named, boolean all, boolean defa
 
     public GraphRefAst(boolean named, boolean all, boolean defaultGraph) {
         this(null, named, all, defaultGraph);
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        if(this.graph != null) {
+            this.graph.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
@@ -1,13 +1,23 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
-public record GroupByAst(List<TermAst> expressions) {
+public record GroupByAst(List<TermAst> expressions) implements VisitableAst {
     public GroupByAst {
         expressions = expressions != null ? List.copyOf(expressions) : List.of();
     }
 
     public boolean isEmpty() {
         return expressions.isEmpty();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.expressions.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
@@ -1,9 +1,9 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import java.util.List;
+
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
-
-import java.util.List;
 
 public record GroupByAst(List<TermAst> expressions) implements VisitableAst {
     public GroupByAst {
@@ -17,8 +17,6 @@ public record GroupByAst(List<TermAst> expressions) implements VisitableAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.expressions.forEach(termAst -> {
-            termAst.accept(visitor);
-        });
+        this.expressions.forEach(termAst -> termAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupByAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupGraphPatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupGraphPatternAst.java
@@ -1,13 +1,13 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 
 /**
  * Group graph pattern: { pattern1 pattern2 ... } (WHERE clause content).
  *
- * */
+ */
 public record GroupGraphPatternAst(List<PatternAst> patterns) implements PatternAst {
     public GroupGraphPatternAst {
         patterns = patterns != null ? List.copyOf(patterns) : List.of();
@@ -16,8 +16,6 @@ public record GroupGraphPatternAst(List<PatternAst> patterns) implements Pattern
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.patterns.forEach(patternAst -> {
-            patternAst.accept(visitor);
-        });
+        this.patterns.forEach(patternAst -> patternAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupGraphPatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GroupGraphPatternAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -9,5 +11,13 @@ import java.util.List;
 public record GroupGraphPatternAst(List<PatternAst> patterns) implements PatternAst {
     public GroupGraphPatternAst {
         patterns = patterns != null ? List.copyOf(patterns) : List.of();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.patterns.forEach(patternAst -> {
+            patternAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
@@ -1,11 +1,13 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
  * SPARQL {@code HAVING} clause: boolean constraints evaluated after grouping.
  */
-public record HavingAst(List<TermAst> conditions) {
+public record HavingAst(List<TermAst> conditions) implements VisitableAst {
     public HavingAst {
         conditions = conditions != null ? List.copyOf(conditions) : List.of();
     }
@@ -16,5 +18,13 @@ public record HavingAst(List<TermAst> conditions) {
 
     public static HavingAst empty() {
         return new HavingAst(List.of());
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.conditions.forEach(conditionAst -> {
+            conditionAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
@@ -1,9 +1,9 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import java.util.List;
+
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
-
-import java.util.List;
 
 /**
  * SPARQL {@code HAVING} clause: boolean constraints evaluated after grouping.
@@ -24,8 +24,6 @@ public record HavingAst(List<TermAst> conditions) implements VisitableAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.conditions.forEach(conditionAst -> {
-            conditionAst.accept(visitor);
-        });
+        this.conditions.forEach(conditionAst -> conditionAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/HavingAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/IriAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/IriAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * IRI or QName in a triple pattern (e.g. &lt;http://...&gt;, foaf:Person, a).
  */
@@ -8,5 +10,15 @@ public record IriAst(String raw) implements TermAst {
         if (raw == null) {
             throw new IllegalArgumentException("IRI raw is null");
         }
+    }
+
+    @Override
+    public String getName() {
+        return this.raw;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LiteralAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LiteralAst.java
@@ -14,7 +14,13 @@ public record LiteralAst(String lexical, String lang, String datatype) implement
 
     @Override
     public String getName() {
-        return this.lexical + " " + this.lang + " " + this.datatype;
+        if (datatype != null && !datatype.isBlank()) {
+            return lexical + "^^" + datatype;
+        }
+        if (lang != null && !lang.isBlank()) {
+            return lexical + "@" + lang;
+        }
+        return lexical;
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LiteralAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LiteralAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * RDF literal in a triple pattern (lexical form, optional language tag or datatype).
  */
@@ -8,5 +10,15 @@ public record LiteralAst(String lexical, String lang, String datatype) implement
         if (lexical == null) {
             throw new IllegalArgumentException("Literal lexical is null");
         }
+    }
+
+    @Override
+    public String getName() {
+        return this.lexical + " " + this.lang + " " + this.datatype;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/LoadRequestAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 
 /**
  * Represents the LOAD operation as defined in the <a href="https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#load">SPARQL 1.1 recommendation<a/>.
@@ -23,5 +24,15 @@ public record LoadRequestAst(GraphRefAst fromClause, GraphRefAst toClause, boole
      */
     public LoadRequestAst(GraphRefAst fromClause, GraphRefAst toClause) {
         this(fromClause, toClause, false);
+    }
+
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.fromClause.accept(visitor);
+        if(this.toClause != null) {
+            this.toClause.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/MinusAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/MinusAst.java
@@ -1,7 +1,14 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * AST node representing a SPARQL {@code MINUS} graph pattern.
  */
 public record MinusAst(GroupGraphPatternAst pattern) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.pattern.accept(visitor);
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OptionalAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OptionalAst.java
@@ -1,8 +1,16 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Optional can contain BGP, FILTER, UNION
  *
  * @param ast PatternAst
  */
-public record OptionalAst(PatternAst ast) implements PatternAst {}
+public record OptionalAst(PatternAst ast) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.ast.accept(visitor);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OrderConditionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OrderConditionAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 /**
  * One ORDER BY condition.

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OrderConditionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/OrderConditionAst.java
@@ -1,14 +1,22 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * One ORDER BY condition.
  */
 public record OrderConditionAst(
         ASTConstants.OrderDirection orderDirection,
         TermAst expression
-) {
+) implements VisitableAst {
     public OrderConditionAst {
         if (orderDirection == null) throw new IllegalArgumentException("direction is null");
         if (expression == null) throw new IllegalArgumentException("expression is null");
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.expression.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
@@ -1,7 +1,10 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Element of a group graph pattern (BGP, optional, union, etc.).
  */
-public sealed interface PatternAst permits BgpAst, BindAst, FilterAst, GroupGraphPatternAst, MinusAst, OptionalAst, ServiceAst, UnionAst, SubQueryAst {
+public sealed interface PatternAst extends VisitableAst permits BgpAst, BindAst, FilterAst, GroupGraphPatternAst, MinusAst, OptionalAst, ServiceAst, UnionAst, SubQueryAst {
+    void accept(AstVisitor visitor);
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 /**
  * Element of a group graph pattern (BGP, optional, union, etc.).

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrefixDeclarationAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrefixDeclarationAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.Objects;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrefixDeclarationAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PrefixDeclarationAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.Objects;
 
 import static fr.inria.corese.core.next.util.StringUtils.trimChevronIRIs;
@@ -8,7 +10,7 @@ import static fr.inria.corese.core.next.util.StringUtils.trimPrefixWithColon;
 /**
  * A {@code PREFIX p: &lt;ns&gt;} declaration from the SPARQL prologue ({@code p} without trailing colon).
  */
-public record PrefixDeclarationAst(String prefix, IriAst namespace) {
+public record PrefixDeclarationAst(String prefix, IriAst namespace) implements VisitableAst {
     public PrefixDeclarationAst {
         if (prefix == null ) {
             throw new IllegalArgumentException("prefix must be non-null");
@@ -18,5 +20,11 @@ public record PrefixDeclarationAst(String prefix, IriAst namespace) {
         if(! namespace.raw().isEmpty()) {
             namespace = new IriAst(trimChevronIRIs(namespace.raw()));
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.namespace.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
@@ -1,18 +1,21 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
-
 import java.util.List;
 import java.util.Set;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
- * SPARQL SELECT projection: either {@code SELECT *} (all variables from the pattern)
+ * SPARQL SELECT projection: either {@code SELECT *} (all variables from the
+ * pattern)
  * or an explicit list of variables {@code SELECT ?s ?p ?o}.
  * <p>
- * Use {@link ProjectionAsts#selectAll()} and {@link ProjectionAsts#of(List)} to create instances.
+ * Use {@link ProjectionAsts#selectAll()} and {@link ProjectionAsts#of(List)} to
+ * create instances.
  */
-public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<String> expressionBoundVariables) implements VisitableAst {
+public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<String> expressionBoundVariables)
+        implements VisitableAst {
     public ProjectionAst {
         variables = variables != null ? List.copyOf(variables) : List.of();
         expressionBoundVariables = expressionBoundVariables != null ? Set.copyOf(expressionBoundVariables) : Set.of();
@@ -27,8 +30,6 @@ public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<Strin
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.variables.forEach(varAst -> {
-            varAst.accept(visitor);
-        });
+        this.variables.forEach(varAst -> varAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ProjectionAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 import java.util.Set;
 
@@ -9,7 +11,7 @@ import java.util.Set;
  * <p>
  * Use {@link ProjectionAsts#selectAll()} and {@link ProjectionAsts#of(List)} to create instances.
  */
-public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<String> expressionBoundVariables) {
+public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<String> expressionBoundVariables) implements VisitableAst {
     public ProjectionAst {
         variables = variables != null ? List.copyOf(variables) : List.of();
         expressionBoundVariables = expressionBoundVariables != null ? Set.copyOf(expressionBoundVariables) : Set.of();
@@ -19,5 +21,13 @@ public record ProjectionAst(boolean selectAll, List<VarAst> variables, Set<Strin
         if (!selectAll && variables.isEmpty()) {
             throw new IllegalArgumentException("Explicit projection is empty (use selectAll=true for SELECT *)");
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.variables.forEach(varAst -> {
+            varAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
@@ -3,6 +3,6 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 /**
  * Root interface for an abstract syntax trees for operation
  */
-public sealed interface QueryAst permits SparqlQueryAst, UpdateRequestAst {
+public sealed interface QueryAst extends VisitableAst permits SparqlQueryAst, UpdateRequestAst {
     QueryPrologueAst prologue();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
  * Root interface for an abstract syntax trees for operation
  */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
@@ -11,11 +11,16 @@ import java.util.List;
 import static fr.inria.corese.core.next.util.StringUtils.trimChevronIRIs;
 
 /**
- * Snapshot of the SPARQL prologue: prefix declarations in source order and the effective base IRI
- * after the prologue (parser options initial base, possibly overridden by {@code BASE}).
+ * Snapshot of the SPARQL prologue: prefix declarations in source order and the
+ * effective base IRI
+ * after the prologue (parser options initial base, possibly overridden by
+ * {@code BASE}).
  * <p>
- * For now this type is only attached to {@link SelectQueryAst}; other query forms still expose
- * prefix/base state via {@link fr.inria.corese.core.next.data.api.IPrefixHandler} on {@link QueryAst}.
+ * For now this type is only attached to {@link SelectQueryAst}; other query
+ * forms still expose
+ * prefix/base state via
+ * {@link fr.inria.corese.core.next.data.api.IPrefixHandler} on
+ * {@link QueryAst}.
  */
 public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, IriAst baseIri) implements VisitableAst {
 
@@ -32,10 +37,11 @@ public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, Ir
         // resolving relative namespaces in prefix declarations
         IriAst finalBaseIri = baseIri;
         prefixDeclarations = prefixDeclarations.stream().map(prefixDecl -> {
-            if(IRIUtils.isAbsoluteIRI(prefixDecl.namespace().raw())) {
+            if (IRIUtils.isAbsoluteIRI(prefixDecl.namespace().raw())) {
                 return prefixDecl;
             }
-            return new PrefixDeclarationAst(prefixDecl.prefix(), new IriAst(IRIUtils.resolveIRIAgainstBase(finalBaseIri.raw(), prefixDecl.namespace().raw())));
+            return new PrefixDeclarationAst(prefixDecl.prefix(),
+                    new IriAst(IRIUtils.resolveIRIAgainstBase(finalBaseIri.raw(), prefixDecl.namespace().raw())));
         }).toList();
     }
 
@@ -46,9 +52,7 @@ public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, Ir
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.prefixDeclarations.forEach(prefixDeclarationAst -> {
-            prefixDeclarationAst.accept(visitor);
-        });
+        this.prefixDeclarations.forEach(prefixDeclarationAst -> prefixDeclarationAst.accept(visitor));
         this.baseIri.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
@@ -3,6 +3,7 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 import fr.inria.corese.core.next.data.impl.common.util.IRIUtils;
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 
 import java.util.List;
 
@@ -15,7 +16,7 @@ import static fr.inria.corese.core.next.util.StringUtils.trimChevronIRIs;
  * For now this type is only attached to {@link SelectQueryAst}; other query forms still expose
  * prefix/base state via {@link fr.inria.corese.core.next.data.api.IPrefixHandler} on {@link QueryAst}.
  */
-public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, IriAst baseIri) {
+public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, IriAst baseIri) implements VisitableAst {
 
     public QueryPrologueAst {
         prefixDeclarations = prefixDeclarations != null ? List.copyOf(prefixDeclarations) : List.of();
@@ -39,5 +40,14 @@ public record QueryPrologueAst(List<PrefixDeclarationAst> prefixDeclarations, Ir
 
     public static QueryPrologueAst empty() {
         return new QueryPrologueAst(List.of(), new IriAst(IOConstants.getDefaultBaseURI()));
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.prefixDeclarations.forEach(prefixDeclarationAst -> {
+            prefixDeclarationAst.accept(visitor);
+        });
+        this.baseIri.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/QueryPrologueAst.java
@@ -4,6 +4,7 @@ import fr.inria.corese.core.next.data.impl.common.util.IRIUtils;
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SelectQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SelectQueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -45,5 +47,16 @@ public record SelectQueryAst(ProjectionAst projection, DatasetClauseAst datasetC
         if(valuesClause == null) {
             valuesClause = ValuesAst.none();
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.projection.accept(visitor);
+        this.datasetClause.accept(visitor);
+        this.whereClause.accept(visitor);
+        this.solutionModifier.accept(visitor);
+        this.prologue.accept(visitor);
+        this.valuesClause.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
@@ -1,8 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.sparql.triple.api.ASTVisitor;
-import fr.inria.corese.core.sparql.triple.api.AstVisitable;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 /**
  * AST node representing a SPARQL {@code SERVICE} graph pattern.
@@ -15,7 +14,7 @@ import fr.inria.corese.core.sparql.triple.api.AstVisitable;
  * @param silent   whether the {@code SILENT} keyword was present
  * @param pattern  the graph pattern to evaluate at the remote endpoint
  */
-public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements  VisitableAst {
+public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements VisitableAst, PatternAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
@@ -1,7 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 /**
  * AST node representing a SPARQL {@code SERVICE} graph pattern.
@@ -14,7 +13,7 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst
  * @param silent   whether the {@code SILENT} keyword was present
  * @param pattern  the graph pattern to evaluate at the remote endpoint
  */
-public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements VisitableAst, PatternAst {
+public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements PatternAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ServiceAst.java
@@ -1,5 +1,9 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.sparql.triple.api.ASTVisitor;
+import fr.inria.corese.core.sparql.triple.api.AstVisitable;
+
 /**
  * AST node representing a SPARQL {@code SERVICE} graph pattern.
  *
@@ -11,5 +15,11 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
  * @param silent   whether the {@code SILENT} keyword was present
  * @param pattern  the graph pattern to evaluate at the remote endpoint
  */
-public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements PatternAst {
+public record ServiceAst(TermAst endpoint, boolean silent, GroupGraphPatternAst pattern) implements  VisitableAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.endpoint.accept(visitor);
+        this.pattern.accept(visitor);
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
@@ -6,18 +6,22 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst
 import java.util.List;
 
 /**
- * AST for SPARQL {@code solutionModifier}, plus DISTINCT and REDUCED as represented in this project:
- * {@code GROUP BY}, {@code DISTINCT} / {@code REDUCED} (syntactically on {@code SELECT} but stored here),
+ * AST for SPARQL {@code solutionModifier}, plus DISTINCT and REDUCED as
+ * represented in this project:
+ * {@code GROUP BY}, {@code DISTINCT} / {@code REDUCED} (syntactically on
+ * {@code SELECT} but stored here),
  * {@code ORDER BY}, {@code LIMIT}, {@code OFFSET}.
  *
  * <ul>
- *   <li>GROUP BY</li>
- *   <li>DISTINCT / REDUCED</li>
- *   <li>HAVING</li>
- *   <li>ORDER BY</li>
- *   <li>LIMIT / OFFSET</li>
+ * <li>GROUP BY</li>
+ * <li>DISTINCT / REDUCED</li>
+ * <li>HAVING</li>
+ * <li>ORDER BY</li>
+ * <li>LIMIT / OFFSET</li>
  * </ul>
- * <p>In SPARQL 1.1 grammar: {@code groupClause? havingClause? orderClause? limitOffsetClauses?}.
+ * <p>
+ * In SPARQL 1.1 grammar:
+ * {@code groupClause? havingClause? orderClause? limitOffsetClauses?}.
  */
 public record SolutionModifierAst(
         GroupByAst groupBy,
@@ -26,8 +30,7 @@ public record SolutionModifierAst(
         List<OrderConditionAst> orderBy,
         HavingAst having,
         Long limit,
-        Long offset
-) implements VisitableAst {
+        Long offset) implements VisitableAst {
     public SolutionModifierAst {
         groupBy = groupBy != null ? groupBy : new GroupByAst(List.of());
         orderBy = orderBy != null ? List.copyOf(orderBy) : List.of();
@@ -44,14 +47,17 @@ public record SolutionModifierAst(
     }
 
     /**
-     * Default empty modifiers: no GROUP BY, no DISTINCT/REDUCED, no ORDER BY, no LIMIT or OFFSET.
+     * Default empty modifiers: no GROUP BY, no DISTINCT/REDUCED, no ORDER BY, no
+     * LIMIT or OFFSET.
      */
     public static SolutionModifierAst empty() {
-        return new SolutionModifierAst(new GroupByAst(List.of()), false, false, List.of(), HavingAst.empty(), null, null);
+        return new SolutionModifierAst(new GroupByAst(List.of()), false, false, List.of(), HavingAst.empty(), null,
+                null);
     }
 
     /**
-     * Builds modifiers without an explicit {@code GROUP BY}, matching the shape from before {@link GroupByAst} was added.
+     * Builds modifiers without an explicit {@code GROUP BY}, matching the shape
+     * from before {@link GroupByAst} was added.
      */
     public static SolutionModifierAst withoutGroupBy(
             boolean distinct,
@@ -59,7 +65,8 @@ public record SolutionModifierAst(
             List<OrderConditionAst> orderBy,
             Long limit,
             Long offset) {
-        return new SolutionModifierAst(new GroupByAst(List.of()), distinct, reduced, orderBy, HavingAst.empty(), limit, offset);
+        return new SolutionModifierAst(new GroupByAst(List.of()), distinct, reduced, orderBy, HavingAst.empty(), limit,
+                offset);
     }
 
     public boolean hasGroupBy() {
@@ -70,7 +77,9 @@ public record SolutionModifierAst(
         return !orderBy.isEmpty();
     }
 
-    public boolean hasHaving() { return !having.isEmpty(); }
+    public boolean hasHaving() {
+        return !having.isEmpty();
+    }
 
     public boolean hasLimit() {
         return limit != null;
@@ -84,9 +93,7 @@ public record SolutionModifierAst(
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
         groupBy.accept(visitor);
-        this.orderBy.forEach(orderConditionAst -> {
-            orderConditionAst.accept(visitor);
-        });
+        this.orderBy.forEach(orderConditionAst -> orderConditionAst.accept(visitor));
         this.having.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -24,7 +26,7 @@ public record SolutionModifierAst(
         HavingAst having,
         Long limit,
         Long offset
-) {
+) implements VisitableAst {
     public SolutionModifierAst {
         groupBy = groupBy != null ? groupBy : new GroupByAst(List.of());
         orderBy = orderBy != null ? List.copyOf(orderBy) : List.of();
@@ -75,5 +77,15 @@ public record SolutionModifierAst(
 
     public boolean hasOffset() {
         return offset != null;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        groupBy.accept(visitor);
+        this.orderBy.forEach(orderConditionAst -> {
+            orderConditionAst.accept(visitor);
+        });
+        this.having.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SolutionModifierAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SubQueryAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/SubQueryAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 public record SubQueryAst(QueryAst query) implements PatternAst {
     public SubQueryAst {
         if (query == null) {
@@ -9,5 +11,11 @@ public record SubQueryAst(QueryAst query) implements PatternAst {
             throw new UnsupportedOperationException(
                     "Only SELECT subqueries are supported in W3C: " + query.getClass().getName());
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.query.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TermAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TermAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
  * AST node for a SPARQL term (variable, IRI or literal) in a triple pattern.
  */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TermAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TermAst.java
@@ -3,7 +3,8 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 /**
  * AST node for a SPARQL term (variable, IRI or literal) in a triple pattern.
  */
-public sealed interface TermAst permits ConstraintAst, IriAst, LiteralAst, VarAst {
+public sealed interface TermAst extends VisitableAst permits ConstraintAst, IriAst, LiteralAst, VarAst {
+    String getName();
 }
 
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TriplePatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TriplePatternAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 /**
  * A single triple pattern (s p o) in a BGP.

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TriplePatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/TriplePatternAst.java
@@ -1,12 +1,22 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * A single triple pattern (s p o) in a BGP.
  */
-public record TriplePatternAst(TermAst subject, TermAst predicate, TermAst object) {
+public record TriplePatternAst(TermAst subject, TermAst predicate, TermAst object) implements VisitableAst {
     public TriplePatternAst {
         if (subject == null || predicate == null || object == null) {
             throw new IllegalArgumentException("subject, predicate and object must be non-null");
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.subject.accept(visitor);
+        this.predicate.accept(visitor);
+        this.object.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UnionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UnionAst.java
@@ -1,7 +1,15 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * AST node representing a SPARQL {@code UNION} of two graph patterns.
  */
 public record UnionAst(GroupGraphPatternAst left, GroupGraphPatternAst right) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.left.accept(visitor);
+        this.right.accept(visitor);
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.List;
 
 /**
@@ -14,5 +16,13 @@ public record UpdateRequestAst(QueryPrologueAst prologue, List<UpdateRequestUnit
 
     public void addQuery(UpdateRequestUnitAst updateQuery) {
         this.operations.add(updateQuery);
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this.prologue);
+        this.operations.forEach(updateRequestUnitAst -> {
+            updateRequestUnitAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 
 /**
  * Represents a series of update operations sharing a prologue
@@ -21,8 +21,6 @@ public record UpdateRequestAst(QueryPrologueAst prologue, List<UpdateRequestUnit
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this.prologue);
-        this.operations.forEach(updateRequestUnitAst -> {
-            updateRequestUnitAst.accept(visitor);
-        });
+        this.operations.forEach(updateRequestUnitAst -> updateRequestUnitAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestUnitAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestUnitAst.java
@@ -1,7 +1,9 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
  * Root interface for all operations related to the SPARQL Update operations listed in <a href="https://www.w3.org/TR/sparql11-update/">SPARQL 1.1 Update</>.
  */
-public sealed interface UpdateRequestUnitAst permits LoadRequestAst, ClearRequestAst {
+public sealed interface UpdateRequestUnitAst extends VisitableAst permits LoadRequestAst, ClearRequestAst {
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -7,11 +9,20 @@ import java.util.Map;
  * Represent one solution mapping for VALUES, in the order it is written. A set of values for variables with null standing for UNDEF.
  * @param values
  */
-public record ValueMappingAst(Map<VarAst, TermAst> values) {
+public record ValueMappingAst(Map<VarAst, TermAst> values) implements VisitableAst {
 
     public ValueMappingAst {
         if(values == null) {
             values = new HashMap<>();
         }
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.values.forEach((varAst, termAst) -> {
+            varAst.accept(visitor);
+            termAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
@@ -22,8 +22,12 @@ public record ValueMappingAst(Map<VarAst, TermAst> values) implements VisitableA
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
         this.values.forEach((varAst, termAst) -> {
-            varAst.accept(visitor);
-            termAst.accept(visitor);
+            if(varAst != null) {
+                varAst.accept(visitor);
+            }
+            if(termAst != null) {
+                termAst.accept(visitor);
+            }
         });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
@@ -1,18 +1,19 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst;
+
 /**
- * VALUES clause. Cumulated mappings of all the VALUES clauses declared in a query
+ * VALUES clause. Cumulated mappings of all the VALUES clauses declared in a
+ * query
  */
 public record ValuesAst(List<ValueMappingAst> mappings) implements VisitableAst {
 
     public ValuesAst {
-        if(mappings == null) {
+        if (mappings == null) {
             mappings = new ArrayList<>();
         }
     }
@@ -24,8 +25,6 @@ public record ValuesAst(List<ValueMappingAst> mappings) implements VisitableAst 
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.mappings.forEach(valueMappingAst -> {
-            valueMappingAst.accept(visitor);
-        });
+        this.mappings.forEach(valueMappingAst -> valueMappingAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
@@ -1,12 +1,14 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * VALUES clause. Cumulated mappings of all the VALUES clauses declared in a query
  */
-public record ValuesAst(List<ValueMappingAst> mappings) {
+public record ValuesAst(List<ValueMappingAst> mappings) implements VisitableAst {
 
     public ValuesAst {
         if(mappings == null) {
@@ -16,5 +18,13 @@ public record ValuesAst(List<ValueMappingAst> mappings) {
 
     public static ValuesAst none() {
         return new ValuesAst(new ArrayList<>());
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.mappings.forEach(valueMappingAst -> {
+            valueMappingAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VarAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VarAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Variable in a triple pattern (e.g. ?s, $x).
  */
@@ -8,5 +10,15 @@ public record VarAst(String name) implements TermAst {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("Variable name is null or blank");
         }
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
@@ -1,8 +1,0 @@
-package fr.inria.corese.core.next.query.impl.sparql.ast;
-
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-
-public interface VisitableAst {
-
-    void accept(AstVisitor visitor);
-}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
@@ -1,0 +1,8 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
+public interface VisitableAst {
+
+    void accept(AstVisitor visitor);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbsAst.java
@@ -11,4 +11,9 @@ public class AbsAst extends AbstractUnaryConstraintAst implements NumericExpress
     public AbsAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ABS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryConstraintAst.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
@@ -35,6 +36,13 @@ public abstract class AbstractBinaryConstraintAst implements BinaryConstraintAst
 
     protected void setRightArgument(TermAst arg) {
         this.rightArgument = arg;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.leftArgument.accept(visitor);
+        this.rightArgument.accept(visitor);
     }
 
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryConstraintAst.java
@@ -1,12 +1,10 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
 import java.util.Objects;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Abstract implementation of {@link BinaryConstraintAst}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractBinaryFunctionAst.java
@@ -4,7 +4,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
 
-public class AbstractBinaryFunctionAst extends AbstractBinaryConstraintAst {
+public abstract class AbstractBinaryFunctionAst extends AbstractBinaryConstraintAst {
     protected AbstractBinaryFunctionAst(List<TermAst> args) {
         super(args);
         this.setLeftArgument(args.getFirst());

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
@@ -10,7 +10,10 @@ public abstract class AbstractUnaryConstraintAst implements UnaryConstraintAst {
     private final TermAst argument;
 
     public AbstractUnaryConstraintAst(TermAst arg) {
-            this.argument = arg;
+        if (arg == null) {
+            throw new IllegalArgumentException("arg must be non-null");
+        }
+        this.argument = arg;
     }
 
     public AbstractUnaryConstraintAst(List<TermAst> args) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
@@ -18,5 +19,11 @@ public abstract class AbstractUnaryConstraintAst implements UnaryConstraintAst {
 
     public TermAst getArgument() {
         return this.argument;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.argument.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
@@ -9,14 +9,14 @@ import java.util.List;
 public abstract class AbstractUnaryConstraintAst implements UnaryConstraintAst {
     private final TermAst argument;
 
-    public AbstractUnaryConstraintAst(TermAst arg) {
+    protected AbstractUnaryConstraintAst(TermAst arg) {
         if (arg == null) {
             throw new IllegalArgumentException("arg must be non-null");
         }
         this.argument = arg;
     }
 
-    public AbstractUnaryConstraintAst(List<TermAst> args) {
+    protected AbstractUnaryConstraintAst(List<TermAst> args) {
         if(args.size() == 1) {
             this.argument = args.getFirst();
         } else {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnaryConstraintAst.java
@@ -9,7 +9,11 @@ import java.util.List;
 public abstract class AbstractUnaryConstraintAst implements UnaryConstraintAst {
     private final TermAst argument;
 
-    protected AbstractUnaryConstraintAst(List<TermAst> args) {
+    public AbstractUnaryConstraintAst(TermAst arg) {
+            this.argument = arg;
+    }
+
+    public AbstractUnaryConstraintAst(List<TermAst> args) {
         if(args.size() == 1) {
             this.argument = args.getFirst();
         } else {
@@ -17,7 +21,7 @@ public abstract class AbstractUnaryConstraintAst implements UnaryConstraintAst {
         }
     }
 
-    public TermAst getArgument() {
+    public TermAst argument() {
         return this.argument;
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnlimitedArgumentsFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnlimitedArgumentsFunctionAst.java
@@ -3,15 +3,14 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractUnlimitedArgumentsFunctionAst implements UnlimitedArgumentsFunctionAst {
 
-    private List<TermAst> arguments = new ArrayList<>();
+    private final List<TermAst> arguments;
 
-    public AbstractUnlimitedArgumentsFunctionAst(List<TermAst> arguments) {
-        this.arguments = arguments;
+    protected AbstractUnlimitedArgumentsFunctionAst(List<TermAst> arguments) {
+        this.arguments = arguments != null ? List.copyOf(arguments) : List.of();
     }
 
     @Override
@@ -22,8 +21,10 @@ public abstract class AbstractUnlimitedArgumentsFunctionAst implements Unlimited
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.arguments.forEach(termAst -> {
-            termAst.accept(visitor);
-        });
+        for (TermAst termAst : arguments) {
+            if (termAst != null) {
+                termAst.accept(visitor);
+            }
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnlimitedArgumentsFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AbstractUnlimitedArgumentsFunctionAst.java
@@ -1,0 +1,29 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractUnlimitedArgumentsFunctionAst implements UnlimitedArgumentsFunctionAst {
+
+    private List<TermAst> arguments = new ArrayList<>();
+
+    public AbstractUnlimitedArgumentsFunctionAst(List<TermAst> arguments) {
+        this.arguments = arguments;
+    }
+
+    @Override
+    public List<TermAst> arguments() {
+        return arguments;
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.arguments.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
@@ -21,6 +21,6 @@ public class AddAst extends AbstractChainableOperatorAst implements NumericExpre
 
     @Override
     public String getName() {
-        return "ADD";
+        return "+";
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
@@ -18,4 +18,9 @@ public class AddAst extends AbstractChainableOperatorAst implements NumericExpre
     protected TermAst create(List<TermAst> args) {
         return new AddAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "ADD";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AddAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A + A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AndAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AndAst.java
@@ -17,4 +17,9 @@ public class AndAst extends AbstractChainableOperatorAst implements BooleanExpre
     protected TermAst create(List<TermAst> args) {
         return new AndAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "&&";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AndAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/AndAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code &&}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BinaryRegexAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BinaryRegexAst.java
@@ -31,4 +31,9 @@ public class BinaryRegexAst extends AbstractBinaryFunctionAst implements RegexAs
     public TermAst getPattern() {
         return this.getRightArgument();
     }
+
+    @Override
+    public String getName() {
+        return "REGEX";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ExprAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
@@ -27,5 +28,11 @@ public final class BnodeAst implements ExprAst {
     @Override
     public String getName() {
         return "BNODE";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.label.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
@@ -23,4 +23,9 @@ public final class BnodeAst implements ExprAst {
     public TermAst getLabel() {
         return this.label;
     }
+
+    @Override
+    public String getName() {
+        return "BNODE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BnodeAst.java
@@ -33,6 +33,8 @@ public final class BnodeAst implements ExprAst {
     @Override
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
-        this.label.accept(visitor);
+        if(this.label != null) {
+            this.label.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BooleanNotAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BooleanNotAst.java
@@ -11,4 +11,9 @@ public class BooleanNotAst extends AbstractUnaryConstraintAst implements Boolean
     public BooleanNotAst(List<TermAst> arg) {
         super(arg);
     }
+
+    @Override
+    public String getName() {
+        return "!";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BoundAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/BoundAst.java
@@ -13,4 +13,9 @@ public class BoundAst extends AbstractUnaryConstraintAst implements BooleanExpre
     public BoundAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "BOUND";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CeilAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CeilAst.java
@@ -11,4 +11,9 @@ public class CeilAst extends AbstractUnaryConstraintAst implements NumericExpres
     public CeilAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "CEIL";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
@@ -8,4 +8,10 @@ import java.util.List;
  * Function {@code COALESCE(expr1, expr2, ...)} in SPARQL 1.1
  * Returns the first argument that evaluates without error.
  */
-public record CoalesceAst(List<TermAst> arguments) implements ConstraintAst {}
+public record CoalesceAst(List<TermAst> arguments) implements ConstraintAst {
+
+    @Override
+    public String getName() {
+        return "COALESCE";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Function {@code COALESCE(expr1, expr2, ...)} in SPARQL 1.1

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/CoalesceAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import java.util.List;
@@ -8,7 +9,11 @@ import java.util.List;
  * Function {@code COALESCE(expr1, expr2, ...)} in SPARQL 1.1
  * Returns the first argument that evaluates without error.
  */
-public record CoalesceAst(List<TermAst> arguments) implements ConstraintAst {
+public class CoalesceAst extends AbstractUnlimitedArgumentsFunctionAst {
+
+    public CoalesceAst(List<TermAst> arguments) {
+        super(arguments);
+    }
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
@@ -7,7 +7,11 @@ import java.util.List;
 /**
  * Function {@code CONCAT(expr1, expr2, ...)} in SPARQL 1.1.
  */
-public record ConcatAst(List<TermAst> arguments) implements SimpleLiteralExpressionAst {
+public class ConcatAst extends AbstractUnlimitedArgumentsFunctionAst {
+
+    public ConcatAst(List<TermAst> arguments) {
+        super(arguments);
+    }
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
@@ -7,4 +7,10 @@ import java.util.List;
 /**
  * Function {@code CONCAT(expr1, expr2, ...)} in SPARQL 1.1.
  */
-public record ConcatAst(List<TermAst> arguments) implements SimpleLiteralExpressionAst {}
+public record ConcatAst(List<TermAst> arguments) implements SimpleLiteralExpressionAst {
+
+    @Override
+    public String getName() {
+        return "CONCAT";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ContainsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ContainsAst.java
@@ -13,4 +13,9 @@ public class ContainsAst extends AbstractBinaryFunctionAst implements BooleanExp
     public ContainsAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "CONTAINS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DatatypeAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DatatypeAst.java
@@ -13,4 +13,9 @@ public class DatatypeAst extends AbstractUnaryConstraintAst implements IriExpres
     public DatatypeAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "DATATYPE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DayAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DayAst.java
@@ -12,4 +12,9 @@ public class DayAst extends AbstractUnaryConstraintAst implements NumericExpress
     public DayAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "DAY";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DifferentAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DifferentAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code !=}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DifferentAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DifferentAst.java
@@ -18,4 +18,8 @@ public class DifferentAst extends AbstractChainableOperatorAst implements Boolea
         return new DifferentAst(args);
     }
 
+    @Override
+    public String getName() {
+        return "!=";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DivideAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DivideAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A / A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DivideAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/DivideAst.java
@@ -17,4 +17,9 @@ public class DivideAst extends AbstractChainableOperatorAst implements NumericEx
     protected TermAst create(List<TermAst> args) {
         return new DivideAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "/";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EncodeForUriAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EncodeForUriAst.java
@@ -11,4 +11,9 @@ public class EncodeForUriAst extends AbstractUnaryConstraintAst implements Simpl
     public EncodeForUriAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ENCODE_FOR_URI";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EqualsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EqualsAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code =}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EqualsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/EqualsAst.java
@@ -17,4 +17,9 @@ public class EqualsAst extends AbstractChainableOperatorAst implements BooleanEx
     protected TermAst create(List<TermAst> args) {
         return new EqualsAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "=";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
@@ -13,4 +13,9 @@ public record ExistsAst(GroupGraphPatternAst pattern) implements BooleanExpressi
     public ExistsAst {
         Objects.requireNonNull(pattern, "pattern");
     }
+
+    @Override
+    public String getName() {
+        return "EXISTS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ExistsAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
 import java.util.Objects;
@@ -17,5 +18,11 @@ public record ExistsAst(GroupGraphPatternAst pattern) implements BooleanExpressi
     @Override
     public String getName() {
         return "EXISTS";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.pattern.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FloorAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FloorAst.java
@@ -11,4 +11,9 @@ public class FloorAst extends AbstractUnaryConstraintAst implements NumericExpre
     public FloorAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "FLOOR";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
@@ -17,4 +17,10 @@ public record FunctionCallAst(TermAst functionName, List<TermAst> arguments) imp
         }
     }
 
+
+    @Override
+    public String getName() {
+        return "Function call " + functionName;
+    }
+
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
@@ -1,11 +1,11 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import java.util.List;
+
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ExprAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
-import java.util.List;
 
 /**
  * Function call of a function identified by an IRI
@@ -18,7 +18,6 @@ public record FunctionCallAst(TermAst functionName, List<TermAst> arguments) imp
         }
     }
 
-
     @Override
     public String getName() {
         return "Function call " + functionName.getName();
@@ -28,8 +27,6 @@ public record FunctionCallAst(TermAst functionName, List<TermAst> arguments) imp
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
         this.functionName.accept(visitor);
-        this.arguments.forEach(termAst -> {
-            termAst.accept(visitor);
-        });
+        this.arguments.forEach(termAst -> termAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ExprAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
@@ -23,4 +24,12 @@ public record FunctionCallAst(TermAst functionName, List<TermAst> arguments) imp
         return "Function call " + functionName;
     }
 
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.functionName.accept(visitor);
+        this.arguments.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/FunctionCallAst.java
@@ -21,7 +21,7 @@ public record FunctionCallAst(TermAst functionName, List<TermAst> arguments) imp
 
     @Override
     public String getName() {
-        return "Function call " + functionName;
+        return "Function call " + functionName.getName();
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterOrEqualThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterOrEqualThanAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A >= A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterOrEqualThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterOrEqualThanAst.java
@@ -17,4 +17,9 @@ public class GreaterOrEqualThanAst extends AbstractChainableOperatorAst implemen
     protected TermAst create(List<TermAst> args) {
         return new GreaterOrEqualThanAst(args);
     }
+
+    @Override
+    public String getName() {
+        return ">=";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterThanAst.java
@@ -17,4 +17,9 @@ public class GreaterThanAst extends AbstractChainableOperatorAst implements Bool
     protected TermAst create(List<TermAst> args) {
         return new GreaterThanAst(args);
     }
+
+    @Override
+    public String getName() {
+        return ">";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/GreaterThanAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A > A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/HoursAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/HoursAst.java
@@ -12,4 +12,9 @@ public class HoursAst extends AbstractUnaryConstraintAst implements NumericExpre
     public HoursAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "HOURS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IfAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IfAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
@@ -12,5 +13,13 @@ public record IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr) imple
     @Override
     public String getName() {
         return "IF";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.condition.accept(visitor);
+        this.thenExpr.accept(visitor);
+        this.elseExpr.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IfAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IfAst.java
@@ -7,4 +7,10 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
  * Function {@code IF(condition, thenExpr, elseExpr)} in SPARQL 1.1
  * Evaluates condition; if true returns thenExpr, otherwise elseExpr.
  */
-public record IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr) implements ConstraintAst {}
+public record IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr) implements ConstraintAst {
+
+    @Override
+    public String getName() {
+        return "IF";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
@@ -20,5 +21,14 @@ public record InAst(TermAst left, List<TermAst> candidates) implements Constrain
     @Override
     public String getName() {
         return "IN";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.left.accept(visitor);
+        this.candidates.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
@@ -16,4 +16,9 @@ public record InAst(TermAst left, List<TermAst> candidates) implements Constrain
         Objects.requireNonNull(candidates, "candidates");
         candidates = List.copyOf(candidates);
     }
+
+    @Override
+    public String getName() {
+        return "IN";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/InAst.java
@@ -1,14 +1,15 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import java.util.List;
+import java.util.Objects;
+
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
-import java.util.List;
-import java.util.Objects;
-
 /**
- * SPARQL 1.1 {@code IN}: {@code rdfTerm IN (expression, ...)} (including {@code IN ()}).
+ * SPARQL 1.1 {@code IN}: {@code rdfTerm IN (expression, ...)} (including
+ * {@code IN ()}).
  */
 public record InAst(TermAst left, List<TermAst> candidates) implements ConstraintAst, BooleanExpressionAst {
 
@@ -27,8 +28,6 @@ public record InAst(TermAst left, List<TermAst> candidates) implements Constrain
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
         this.left.accept(visitor);
-        this.candidates.forEach(termAst -> {
-            termAst.accept(visitor);
-        });
+        this.candidates.forEach(termAst -> termAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IriFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IriFunctionAst.java
@@ -11,4 +11,9 @@ public class IriFunctionAst extends AbstractUnaryConstraintAst implements IriExp
     public IriFunctionAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "IRI";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IriFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IriFunctionAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Function {@code IRI(term)} or {@code URI(term)} in SPARQL 1.1.

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsBlankAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsBlankAst.java
@@ -12,4 +12,9 @@ public class IsBlankAst extends AbstractUnaryConstraintAst implements BooleanExp
     public IsBlankAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ISBLANK";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsBlankAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsBlankAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code isBlank(A)}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsIriAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsIriAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code isIri(A)} and {@code isUri(A)}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsIriAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsIriAst.java
@@ -12,4 +12,9 @@ public class IsIriAst extends AbstractUnaryConstraintAst implements BooleanExpre
     public IsIriAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ISIRI";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsLiteralAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsLiteralAst.java
@@ -12,4 +12,9 @@ public class IsLiteralAst extends AbstractUnaryConstraintAst implements BooleanE
     public IsLiteralAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ISLITERAL";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsLiteralAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsLiteralAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code IsLiteral(A)}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code lang(A)}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangAst.java
@@ -13,4 +13,9 @@ public class LangAst extends AbstractUnaryConstraintAst implements SimpleLiteral
     public LangAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "LANG";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangMatchesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangMatchesAst.java
@@ -14,4 +14,9 @@ public class LangMatchesAst extends AbstractBinaryFunctionAst implements Boolean
     public LangMatchesAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "LANGMATCHES";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangMatchesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LangMatchesAst.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  *

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LcaseAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LcaseAst.java
@@ -11,4 +11,9 @@ public class LcaseAst extends AbstractUnaryConstraintAst implements SimpleLitera
     public LcaseAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "LCASE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerOrEqualThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerOrEqualThanAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code <=}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerOrEqualThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerOrEqualThanAst.java
@@ -17,4 +17,9 @@ public class LowerOrEqualThanAst extends AbstractChainableOperatorAst implements
     protected TermAst create(List<TermAst> args) {
         return new LowerOrEqualThanAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "<=";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerThanAst.java
@@ -17,4 +17,9 @@ public class LowerThanAst extends AbstractChainableOperatorAst implements Boolea
     protected TermAst create(List<TermAst> args) {
         return new LowerThanAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "<";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerThanAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/LowerThanAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code <}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Md5Ast.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Md5Ast.java
@@ -11,4 +11,9 @@ public class Md5Ast extends AbstractUnaryConstraintAst implements SimpleLiteralE
     public Md5Ast(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "MD5";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MinutesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MinutesAst.java
@@ -12,4 +12,9 @@ public class MinutesAst extends AbstractUnaryConstraintAst implements NumericExp
     public MinutesAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "MINUTES";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MonthAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MonthAst.java
@@ -12,4 +12,9 @@ public class MonthAst extends AbstractUnaryConstraintAst implements NumericExpre
     public MonthAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "MONTH";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A * A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
@@ -17,4 +17,9 @@ public class MultiplyAst extends AbstractChainableOperatorAst implements Numeric
     protected TermAst create(List<TermAst> args) {
         return new MultiplyAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "MULTIPLY";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/MultiplyAst.java
@@ -20,6 +20,6 @@ public class MultiplyAst extends AbstractChainableOperatorAst implements Numeric
 
     @Override
     public String getName() {
-        return "MULTIPLY";
+        return "*";
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
@@ -13,4 +13,9 @@ public record NotExistsAst(GroupGraphPatternAst pattern) implements BooleanExpre
     public NotExistsAst {
         Objects.requireNonNull(pattern, "pattern");
     }
+
+    @Override
+    public String getName() {
+        return "NOT EXISTS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotExistsAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 
 import java.util.Objects;
@@ -17,5 +18,11 @@ public record NotExistsAst(GroupGraphPatternAst pattern) implements BooleanExpre
     @Override
     public String getName() {
         return "NOT EXISTS";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.pattern.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
@@ -1,16 +1,15 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
 import java.util.Objects;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * SPARQL 1.1 {@code NOT IN}: {@code rdfTerm NOT IN (expression, ...)}.
  */
-public record NotInAst(TermAst left, List<TermAst> candidates) implements ConstraintAst, BooleanExpressionAst {
+public record NotInAst(TermAst left, List<TermAst> candidates) implements BooleanExpressionAst {
 
     public NotInAst {
         Objects.requireNonNull(left, "left");
@@ -27,8 +26,6 @@ public record NotInAst(TermAst left, List<TermAst> candidates) implements Constr
     public void accept(AstVisitor visitor) {
         visitor.visit(this);
         this.left.accept(visitor);
-        this.candidates.forEach(termAst -> {
-            termAst.accept(visitor);
-        });
+        this.candidates.forEach(termAst -> termAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
@@ -20,5 +21,14 @@ public record NotInAst(TermAst left, List<TermAst> candidates) implements Constr
     @Override
     public String getName() {
         return "NOT IN";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.left.accept(visitor);
+        this.candidates.forEach(termAst -> {
+            termAst.accept(visitor);
+        });
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NotInAst.java
@@ -16,4 +16,9 @@ public record NotInAst(TermAst left, List<TermAst> candidates) implements Constr
         Objects.requireNonNull(candidates, "candidates");
         candidates = List.copyOf(candidates);
     }
+
+    @Override
+    public String getName() {
+        return "NOT IN";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NowAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NowAst.java
@@ -6,4 +6,9 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
  * This function takes no arguments.
  */
 public class NowAst implements XsdDateTimeExpressionAst {
+
+    @Override
+    public String getName() {
+        return "NOW";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NowAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/NowAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Function {@code NOW()} in SPARQL 1.1 — §17.4.5.1.
  * Returns the current query execution time as an {@code xsd:dateTime}.
@@ -10,5 +12,10 @@ public class NowAst implements XsdDateTimeExpressionAst {
     @Override
     public String getName() {
         return "NOW";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/OrAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/OrAst.java
@@ -16,4 +16,9 @@ public class OrAst extends AbstractChainableOperatorAst implements BooleanExpres
     protected TermAst create(List<TermAst> args) {
         return new OrAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "||";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RandAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RandAst.java
@@ -4,4 +4,9 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
  * Function {@code RAND()} in SPARQL 1.1.
  */
 public record RandAst() implements NumericExpressionAst {
+
+    @Override
+    public String getName() {
+        return "RAND";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RandAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RandAst.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
 /**
  * Function {@code RAND()} in SPARQL 1.1.
  */
@@ -8,5 +10,10 @@ public record RandAst() implements NumericExpressionAst {
     @Override
     public String getName() {
         return "RAND";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
@@ -64,6 +64,8 @@ public class ReplaceAst implements SimpleLiteralExpressionAst {
         this.stringArg.accept(visitor);
         this.patternArg.accept(visitor);
         this.replacementArg.accept(visitor);
-        this.flagsArg.accept(visitor);
+        if(flagsArg != null) {
+            this.flagsArg.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
@@ -55,5 +56,14 @@ public class ReplaceAst implements SimpleLiteralExpressionAst {
     @Override
     public String getName() {
         return "REPLACE";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.stringArg.accept(visitor);
+        this.patternArg.accept(visitor);
+        this.replacementArg.accept(visitor);
+        this.flagsArg.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ReplaceAst.java
@@ -51,4 +51,9 @@ public class ReplaceAst implements SimpleLiteralExpressionAst {
     public boolean hasFlags() {
         return flagsArg != null;
     }
+
+    @Override
+    public String getName() {
+        return "REPLACE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RoundAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/RoundAst.java
@@ -11,4 +11,9 @@ public class RoundAst extends AbstractUnaryConstraintAst implements NumericExpre
     public RoundAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "ROUND";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
@@ -20,4 +20,9 @@ public class SameTermAst extends AbstractBinaryFunctionAst implements BooleanExp
             throw new QuerySyntaxException("Unexpected number of arguments for sameTerm function");
         }
     }
+
+    @Override
+    public String getName() {
+        return "SAMETERM";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SecondsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SecondsAst.java
@@ -12,4 +12,9 @@ public class SecondsAst extends AbstractUnaryConstraintAst implements NumericExp
     public SecondsAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "SECONDS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha1Ast.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha1Ast.java
@@ -11,4 +11,9 @@ public class Sha1Ast extends AbstractUnaryConstraintAst implements SimpleLiteral
     public Sha1Ast(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "SHA1";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha256Ast.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha256Ast.java
@@ -11,4 +11,9 @@ public class Sha256Ast extends AbstractUnaryConstraintAst implements SimpleLiter
     public Sha256Ast(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "SHA256";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha384Ast.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha384Ast.java
@@ -11,4 +11,9 @@ public class Sha384Ast extends AbstractUnaryConstraintAst implements SimpleLiter
     public Sha384Ast(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "SHA384";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha512Ast.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/Sha512Ast.java
@@ -11,4 +11,9 @@ public class Sha512Ast extends AbstractUnaryConstraintAst implements SimpleLiter
     public Sha512Ast(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "SHA512";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrAfterAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrAfterAst.java
@@ -13,4 +13,9 @@ public class StrAfterAst extends AbstractBinaryFunctionAst implements SimpleLite
     public StrAfterAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRAFTER";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrAst.java
@@ -13,4 +13,9 @@ public class StrAst extends AbstractUnaryConstraintAst implements SimpleLiteralE
     public StrAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STR";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrBeforeAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrBeforeAst.java
@@ -13,4 +13,9 @@ public class StrBeforeAst extends AbstractBinaryFunctionAst implements SimpleLit
     public StrBeforeAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRBEFORE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrDtAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrDtAst.java
@@ -12,4 +12,9 @@ public class StrDtAst extends AbstractBinaryFunctionAst implements LiteralExpres
     public StrDtAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRDT";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrEndsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrEndsAst.java
@@ -13,4 +13,9 @@ public class StrEndsAst extends AbstractBinaryFunctionAst implements BooleanExpr
     public StrEndsAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRENDS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLangAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLangAst.java
@@ -12,4 +12,9 @@ public class StrLangAst extends AbstractBinaryFunctionAst implements SimpleLiter
     public StrLangAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRLANG";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
@@ -3,11 +3,21 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
+import java.util.List;
+
 /**
  * Function {@code STRLEN(string)} in SPARQL 1.1
  * Returns the length of a string.
  */
-public record StrLenAst(TermAst argument) implements ConstraintAst {
+public class StrLenAst extends AbstractUnaryConstraintAst {
+
+    public StrLenAst(TermAst arg) {
+        super(arg);
+    }
+
+    public StrLenAst(List<TermAst> args) {
+        super(args);
+    }
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Function {@code STRLEN(string)} in SPARQL 1.1

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
@@ -7,4 +7,10 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
  * Function {@code STRLEN(string)} in SPARQL 1.1
  * Returns the length of a string.
  */
-public record StrLenAst(TermAst argument) implements ConstraintAst {}
+public record StrLenAst(TermAst argument) implements ConstraintAst {
+
+    @Override
+    public String getName() {
+        return "STRLEN";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrStartsAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrStartsAst.java
@@ -13,4 +13,9 @@ public class StrStartsAst extends AbstractBinaryFunctionAst implements BooleanEx
     public StrStartsAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "STRSTARTS";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
@@ -6,4 +6,10 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
  * Function {@code STRUUID()} in SPARQL 1.1
  * Returns a string form of a UUID.
  */
-public record StrUuidAst() implements ConstraintAst {}
+public record StrUuidAst() implements ConstraintAst {
+
+    @Override
+    public String getName() {
+        return "STRUUID";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 
 /**
@@ -11,5 +12,10 @@ public record StrUuidAst() implements ConstraintAst {
     @Override
     public String getName() {
         return "STRUUID";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
@@ -39,5 +40,13 @@ public final class SubstrAst implements SimpleLiteralExpressionAst {
     @Override
     public String getName() {
         return "SUBSTR";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.stringArg.accept(visitor);
+        this.startArg.accept(visitor);
+        this.lengthArg.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
@@ -35,4 +35,9 @@ public final class SubstrAst implements SimpleLiteralExpressionAst {
     public TermAst getLength() {
         return this.lengthArg;
     }
+
+    @Override
+    public String getName() {
+        return "SUBSTR";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubstrAst.java
@@ -47,6 +47,8 @@ public final class SubstrAst implements SimpleLiteralExpressionAst {
         visitor.visit(this);
         this.stringArg.accept(visitor);
         this.startArg.accept(visitor);
-        this.lengthArg.accept(visitor);
+        if(this.lengthArg != null) {
+            this.lengthArg.accept(visitor);
+        }
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
@@ -18,4 +18,9 @@ public class SubtractAst extends AbstractChainableOperatorAst implements Numeric
     protected TermAst create(List<TermAst> args) {
         return new SubtractAst(args);
     }
+
+    @Override
+    public String getName() {
+        return "SUBSTRACT";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
@@ -1,9 +1,8 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
-import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-
 import java.util.List;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 /**
  * Operator {@code A - A}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SubtractAst.java
@@ -21,6 +21,6 @@ public class SubtractAst extends AbstractChainableOperatorAst implements Numeric
 
     @Override
     public String getName() {
-        return "SUBSTRACT";
+        return "-";
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TimezoneAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TimezoneAst.java
@@ -13,4 +13,9 @@ public class TimezoneAst extends AbstractUnaryConstraintAst implements XsdDayTim
     public TimezoneAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "TIMEZONE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TrinaryRegexAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TrinaryRegexAst.java
@@ -39,4 +39,9 @@ public class TrinaryRegexAst implements RegexAst {
     public TermAst getFlags() {
         return this.flags;
     }
+
+    @Override
+    public String getName() {
+        return "REGEX";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TrinaryRegexAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TrinaryRegexAst.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
 import java.util.List;
@@ -43,5 +44,13 @@ public class TrinaryRegexAst implements RegexAst {
     @Override
     public String getName() {
         return "REGEX";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        this.stringArg.accept(visitor);
+        this.patternArg.accept(visitor);
+        this.flags.accept(visitor);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TzAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/TzAst.java
@@ -13,4 +13,9 @@ public class TzAst extends AbstractUnaryConstraintAst implements SimpleLiteralEx
     public TzAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "TZ";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UcaseAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UcaseAst.java
@@ -11,4 +11,9 @@ public class UcaseAst extends AbstractUnaryConstraintAst implements SimpleLitera
     public UcaseAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "UCASE";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnaryMinusAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnaryMinusAst.java
@@ -11,4 +11,9 @@ public class UnaryMinusAst extends AbstractUnaryConstraintAst implements Numeric
     public UnaryMinusAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "-";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnaryPlusAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnaryPlusAst.java
@@ -11,4 +11,9 @@ public class UnaryPlusAst extends AbstractUnaryConstraintAst implements NumericE
     public UnaryPlusAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "+";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnlimitedArgumentsFunctionAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UnlimitedArgumentsFunctionAst.java
@@ -3,9 +3,8 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 
-/**
- * Interface for AST elements using one term as argument
- */
-public interface UnaryConstraintAst extends ConstraintAst {
-    TermAst argument();
+import java.util.List;
+
+public interface UnlimitedArgumentsFunctionAst extends ConstraintAst {
+    List<TermAst> arguments();
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 
 /**
@@ -11,5 +12,10 @@ public record UuidAst() implements ConstraintAst {
     @Override
     public String getName() {
         return "UUID";
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
@@ -6,4 +6,10 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
  * Function {@code UUID()} in SPARQL 1.1
  * Returns a fresh IRI from the UUID URN scheme.
  */
-public record UuidAst() implements ConstraintAst {}
+public record UuidAst() implements ConstraintAst {
+
+    @Override
+    public String getName() {
+        return "UUID";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/YearAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/YearAst.java
@@ -12,4 +12,9 @@ public class YearAst extends AbstractUnaryConstraintAst implements NumericExpres
     public YearAst(List<TermAst> args) {
         super(args);
     }
+
+    @Override
+    public String getName() {
+        return "YEAR";
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
@@ -127,25 +127,25 @@ public final class SparqlAstToExpression {
             case DivideAst divideAst ->
                     Term.create("/", convert(divideAst.getLeftArgument()), convert(divideAst.getRightArgument()));
             case UnaryPlusAst unaryPlusAst ->
-                    Term.create("+", convert(unaryPlusAst.getArgument()));
+                    Term.create("+", convert(unaryPlusAst.argument()));
             case UnaryMinusAst unaryMinusAst ->
-                    Term.create("-", convert(unaryMinusAst.getArgument()));
+                    Term.create("-", convert(unaryMinusAst.argument()));
             case BooleanNotAst booleanNotAst ->
-                    Term.create("!", convert(booleanNotAst.getArgument()));
+                    Term.create("!", convert(booleanNotAst.argument()));
             case BoundAst boundAst ->
-                    functionTerm(Processor.BOUND, convert(boundAst.getArgument()));
+                    functionTerm(Processor.BOUND, convert(boundAst.argument()));
             case IsIriAst isIriAst ->
-                    functionTerm("isIRI", convert(isIriAst.getArgument()));
+                    functionTerm("isIRI", convert(isIriAst.argument()));
             case IsBlankAst isBlankAst ->
-                    functionTerm("isBlank", convert(isBlankAst.getArgument()));
+                    functionTerm("isBlank", convert(isBlankAst.argument()));
             case IsLiteralAst isLiteralAst ->
-                    functionTerm("isLiteral", convert(isLiteralAst.getArgument()));
+                    functionTerm("isLiteral", convert(isLiteralAst.argument()));
             case StrAst strAst ->
-                    functionTerm("str", convert(strAst.getArgument()));
+                    functionTerm("str", convert(strAst.argument()));
             case LangAst langAst ->
-                    functionTerm("lang", convert(langAst.getArgument()));
+                    functionTerm("lang", convert(langAst.argument()));
             case DatatypeAst datatypeAst ->
-                    functionTerm("datatype", convert(datatypeAst.getArgument()));
+                    functionTerm("datatype", convert(datatypeAst.argument()));
             case SameTermAst sameTermAst ->
                     functionTerm("sameTerm", convert(sameTermAst.getLeftArgument()), convert(sameTermAst.getRightArgument()));
             case LangMatchesAst langMatchesAst ->
@@ -183,23 +183,23 @@ public final class SparqlAstToExpression {
             case StrDtAst strDtAst ->
                     functionTerm(Processor.STRDT, convert(strDtAst.getLeftArgument()), convert(strDtAst.getRightArgument()));
             case IriFunctionAst iriFunctionAst ->
-                    functionTerm("iri", convert(iriFunctionAst.getArgument()));
+                    functionTerm("iri", convert(iriFunctionAst.argument()));
             case LcaseAst lcaseAst ->
-                    functionTerm("lcase", convert(lcaseAst.getArgument()));
+                    functionTerm("lcase", convert(lcaseAst.argument()));
             case UcaseAst ucaseAst ->
-                    functionTerm("ucase", convert(ucaseAst.getArgument()));
+                    functionTerm("ucase", convert(ucaseAst.argument()));
             case EncodeForUriAst encodeForUriAst ->
-                    functionTerm("encode_for_uri", convert(encodeForUriAst.getArgument()));
+                    functionTerm("encode_for_uri", convert(encodeForUriAst.argument()));
             case Md5Ast md5Ast ->
-                    functionTerm("md5", convert(md5Ast.getArgument()));
+                    functionTerm("md5", convert(md5Ast.argument()));
             case Sha1Ast sha1Ast ->
-                    functionTerm("sha1", convert(sha1Ast.getArgument()));
+                    functionTerm("sha1", convert(sha1Ast.argument()));
             case Sha256Ast sha256Ast ->
-                    functionTerm("sha256", convert(sha256Ast.getArgument()));
+                    functionTerm("sha256", convert(sha256Ast.argument()));
             case Sha384Ast sha384Ast ->
-                    functionTerm("sha384", convert(sha384Ast.getArgument()));
+                    functionTerm("sha384", convert(sha384Ast.argument()));
             case Sha512Ast sha512Ast ->
-                    functionTerm("sha512", convert(sha512Ast.getArgument()));
+                    functionTerm("sha512", convert(sha512Ast.argument()));
             case ExistsAst existsAst ->
                     throw new UnsupportedOperationException(
                             "EXISTS { ... } conversion requires GroupGraphPatternAst → Exp (see CoreseAstQueryBuilder)");

--- a/src/main/java/fr/inria/corese/core/sparql/triple/api/AstVisitable.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/api/AstVisitable.java
@@ -8,7 +8,7 @@ package fr.inria.corese.core.sparql.triple.api;
  *
  * @author corby
  */
-public interface ASTVisitable {
+public interface AstVisitable {
     
     	void accept(ASTVisitor visitor);
 

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/ASTQuery.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/ASTQuery.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import fr.inria.corese.core.sparql.datatype.DatatypeMap;
-import fr.inria.corese.core.sparql.triple.api.ASTVisitable;
+import fr.inria.corese.core.sparql.triple.api.AstVisitable;
 import fr.inria.corese.core.sparql.triple.api.ASTVisitor;
 import fr.inria.corese.core.sparql.triple.cst.Keyword;
 import fr.inria.corese.core.sparql.triple.cst.KeywordPP;
@@ -48,7 +48,7 @@ import java.util.UUID;
  */
 public class ASTQuery 
         extends ASTObject 
-        implements Keyword, ASTVisitable, AST, Message {
+        implements Keyword, AstVisitable, AST, Message {
 
     public static boolean STRICT_MODE;
    

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/TopExp.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/TopExp.java
@@ -1,6 +1,6 @@
 package fr.inria.corese.core.sparql.triple.parser;
 
-import fr.inria.corese.core.sparql.triple.api.ASTVisitable;
+import fr.inria.corese.core.sparql.triple.api.AstVisitable;
 import fr.inria.corese.core.sparql.triple.api.ASTVisitor;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +11,7 @@ import java.util.List;
  * @author corby
  *
  */
-public class TopExp implements ASTVisitable {
+public class TopExp implements AstVisitable {
    
     public boolean isGenerated() {
         return generated;

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAggregateTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserAggregateTest.java
@@ -18,6 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DisplayName("SPARQL 1.1 — Parser and AST : aggregates")
 class SparqlParserAggregateTest extends AbstractSparqlParserFeatureTest {
 
+    /**
+     * gets the last Pattern of the where clause, assuming it is an Aggregate
+     */
     private static AggregateAst lastBindAggregate(WhereClauseQueryAst ast) {
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         return assertInstanceOf(AggregateAst.class, bind.expression());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBnodeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserBnodeTest.java
@@ -70,7 +70,7 @@ class SparqlParserBnodeTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         IsBlankAst isBlank = assertInstanceOf(IsBlankAst.class, filter.operator());
-        BnodeAst bnode = assertInstanceOf(BnodeAst.class, isBlank.getArgument());
+        BnodeAst bnode = assertInstanceOf(BnodeAst.class, isBlank.argument());
         assertEquals("label", assertInstanceOf(VarAst.class, bnode.getLabel()).name());
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.EqualsAst;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserCoalesceTest.java
@@ -24,15 +24,16 @@ class SparqlParserCoalesceTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(COALESCE(?s, ?p, ?o))
+                  FILTER(COALESCE(?s, ?p, ?o) = "")
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = (FilterAst) ast.whereClause().patterns().getLast();
-        assertInstanceOf(CoalesceAst.class, filter.operator());
-
-        CoalesceAst coalesce = (CoalesceAst) filter.operator();
+        assertInstanceOf(EqualsAst.class, filter.operator());
+        EqualsAst equalsAst = (EqualsAst) filter.operator();
+        assertInstanceOf(CoalesceAst.class, equalsAst.getLeftArgument());
+        CoalesceAst coalesce = (CoalesceAst) equalsAst.getLeftArgument();
         assertEquals(3, coalesce.arguments().size());
         assertInstanceOf(VarAst.class, coalesce.arguments().get(0));
         assertInstanceOf(VarAst.class, coalesce.arguments().get(1));
@@ -73,15 +74,16 @@ class SparqlParserCoalesceTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(COALESCE(?s))
+                  FILTER(COALESCE(?s) = 1)
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = (FilterAst) ast.whereClause().patterns().getLast();
-        assertInstanceOf(CoalesceAst.class, filter.operator());
-
-        CoalesceAst coalesce = (CoalesceAst) filter.operator();
+        assertInstanceOf(EqualsAst.class, filter.operator());
+        EqualsAst equalsAst = (EqualsAst) filter.operator();
+        assertInstanceOf(CoalesceAst.class, equalsAst.getLeftArgument());
+        CoalesceAst coalesce = (CoalesceAst) equalsAst.getLeftArgument();
         assertEquals(1, coalesce.arguments().size());
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDateTimeFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserDateTimeFunctionsTest.java
@@ -83,7 +83,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         YearAst year = assertInstanceOf(YearAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, year);
-        assertEquals("date", assertInstanceOf(VarAst.class, year.getArgument()).name());
+        assertEquals("date", assertInstanceOf(VarAst.class, year.argument()).name());
     }
 
     @Test
@@ -135,7 +135,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         MonthAst month = assertInstanceOf(MonthAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, month);
-        assertEquals("date", assertInstanceOf(VarAst.class, month.getArgument()).name());
+        assertEquals("date", assertInstanceOf(VarAst.class, month.argument()).name());
     }
 
     // ── DAY() ────────────────────────────────────────────────────────────────
@@ -156,7 +156,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         DayAst day = assertInstanceOf(DayAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, day);
-        assertEquals("date", assertInstanceOf(VarAst.class, day.getArgument()).name());
+        assertEquals("date", assertInstanceOf(VarAst.class, day.argument()).name());
     }
 
     // ── HOURS() ──────────────────────────────────────────────────────────────
@@ -177,7 +177,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         HoursAst hours = assertInstanceOf(HoursAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, hours);
-        assertEquals("dt", assertInstanceOf(VarAst.class, hours.getArgument()).name());
+        assertEquals("dt", assertInstanceOf(VarAst.class, hours.argument()).name());
     }
 
     // ── MINUTES() ────────────────────────────────────────────────────────────
@@ -198,7 +198,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         MinutesAst minutes = assertInstanceOf(MinutesAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, minutes);
-        assertEquals("dt", assertInstanceOf(VarAst.class, minutes.getArgument()).name());
+        assertEquals("dt", assertInstanceOf(VarAst.class, minutes.argument()).name());
     }
 
     // ── SECONDS() ────────────────────────────────────────────────────────────
@@ -219,7 +219,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         SecondsAst seconds = assertInstanceOf(SecondsAst.class, bind.expression());
         assertInstanceOf(NumericExpressionAst.class, seconds);
-        assertEquals("dt", assertInstanceOf(VarAst.class, seconds.getArgument()).name());
+        assertEquals("dt", assertInstanceOf(VarAst.class, seconds.argument()).name());
     }
 
     // ── TIMEZONE() ───────────────────────────────────────────────────────────
@@ -240,7 +240,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         TimezoneAst timezone = assertInstanceOf(TimezoneAst.class, bind.expression());
         assertInstanceOf(XsdDayTimeDurationExpressionAst.class, timezone);
-        assertEquals("dt", assertInstanceOf(VarAst.class, timezone.getArgument()).name());
+        assertEquals("dt", assertInstanceOf(VarAst.class, timezone.argument()).name());
     }
 
     // ── TZ() ─────────────────────────────────────────────────────────────────
@@ -261,7 +261,7 @@ class SparqlParserDateTimeFunctionsTest extends AbstractSparqlParserFeatureTest 
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         TzAst tz = assertInstanceOf(TzAst.class, bind.expression());
         assertInstanceOf(SimpleLiteralExpressionAst.class, tz);
-        assertEquals("dt", assertInstanceOf(VarAst.class, tz.getArgument()).name());
+        assertEquals("dt", assertInstanceOf(VarAst.class, tz.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserEncodeForUriTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserEncodeForUriTest.java
@@ -31,7 +31,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         EncodeForUriAst encode = assertInstanceOf(EncodeForUriAst.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, encode.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, encode.argument()).name());
         assertEquals("encoded", bind.variable().name());
     }
 
@@ -50,7 +50,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         EncodeForUriAst encode = assertInstanceOf(EncodeForUriAst.class, bind.expression());
-        LiteralAst literal = assertInstanceOf(LiteralAst.class, encode.getArgument());
+        LiteralAst literal = assertInstanceOf(LiteralAst.class, encode.argument());
         assertEquals("\"Los Angeles\"", literal.lexical());
         assertEquals("encoded", bind.variable().name());
     }
@@ -71,7 +71,7 @@ class SparqlParserEncodeForUriTest extends AbstractSparqlParserFeatureTest {
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         EqualsAst equals = assertInstanceOf(EqualsAst.class, filter.operator());
         EncodeForUriAst encode = assertInstanceOf(EncodeForUriAst.class, equals.getLeftArgument());
-        assertEquals("label", assertInstanceOf(VarAst.class, encode.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, encode.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -1042,7 +1042,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(+ ?s)
+                  FILTER(+ ?s > 0)
                 }
                 """);
 
@@ -1053,12 +1053,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertEquals(2, where.patterns().size(), "WHERE should contain 2 pattern (BGP + FILTER)");
 
         PatternAst p2 = where.patterns().getLast();
-        assertInstanceOf(FilterAst.class, p2, "Last pattern should be a filter");
-
-        FilterAst filterAst = (FilterAst) p2;
-        assertInstanceOf(UnaryPlusAst.class, filterAst.operator(), "Filter content should be a unary plus operator");
-
-        UnaryPlusAst t = (UnaryPlusAst) filterAst.operator();
+        FilterAst filterAst = assertInstanceOf(FilterAst.class, p2, "Last pattern should be a filter");
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filterAst.operator(), "Filter content should be a greater than comparison");
+        UnaryPlusAst t = assertInstanceOf(UnaryPlusAst.class, greaterThanAst.getLeftArgument(), "Comparison content should be a unary plus operator");
 
         assertInstanceOf(VarAst.class, t.argument());
 
@@ -1072,7 +1069,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(- ?s)
+                  FILTER(- ?s > 0)
                 }
                 """);
 
@@ -1083,12 +1080,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertEquals(2, where.patterns().size(), "WHERE should contain 2 pattern (BGP + FILTER)");
 
         PatternAst p2 = where.patterns().getLast();
-        assertInstanceOf(FilterAst.class, p2, "Last pattern should be a filter");
-
-        FilterAst filterAst = (FilterAst) p2;
-        assertInstanceOf(UnaryMinusAst.class, filterAst.operator(), "Filter content should be a unary minus operator");
-
-        UnaryMinusAst t = (UnaryMinusAst) filterAst.operator();
+        FilterAst filterAst = assertInstanceOf(FilterAst.class, p2, "Last pattern should be a filter");
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filterAst.operator(), "Filter content should be a greater than comparison");
+        UnaryMinusAst t = assertInstanceOf(UnaryMinusAst.class, greaterThanAst.getLeftArgument(), "comparison content should be a unary minus operator");
 
         assertInstanceOf(VarAst.class, t.argument());
         assertEquals("s", ((VarAst) t.argument()).name());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -155,9 +155,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         BooleanNotAst t = (BooleanNotAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -185,9 +185,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         BoundAst t = (BoundAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -215,9 +215,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         IsIriAst t = (IsIriAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -245,9 +245,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         IsIriAst t = (IsIriAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -275,9 +275,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         IsBlankAst t = (IsBlankAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -305,9 +305,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         IsLiteralAst t = (IsLiteralAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -340,8 +340,8 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         StrAst strAst = (StrAst) t.getLeftArgument();
 
-        assertInstanceOf(VarAst.class, strAst.getArgument());
-        assertEquals("s", ((VarAst) strAst.getArgument()).name());
+        assertInstanceOf(VarAst.class, strAst.argument());
+        assertEquals("s", ((VarAst) strAst.argument()).name());
     }
 
     @Test
@@ -374,8 +374,8 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         LangAst strAst = (LangAst) t.getLeftArgument();
 
-        assertInstanceOf(VarAst.class, strAst.getArgument());
-        assertEquals("s", ((VarAst) strAst.getArgument()).name());
+        assertInstanceOf(VarAst.class, strAst.argument());
+        assertEquals("s", ((VarAst) strAst.argument()).name());
     }
 
     @Test
@@ -408,8 +408,8 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         DatatypeAst strAst = (DatatypeAst) t.getLeftArgument();
 
-        assertInstanceOf(VarAst.class, strAst.getArgument());
-        assertEquals("s", ((VarAst) strAst.getArgument()).name());
+        assertInstanceOf(VarAst.class, strAst.argument());
+        assertEquals("s", ((VarAst) strAst.argument()).name());
     }
 
     @Test
@@ -948,8 +948,8 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertEquals("s", ((VarAst) addAst.getLeftArgument()).name());
         assertInstanceOf(UnaryMinusAst.class, addAst.getRightArgument());
         UnaryMinusAst rightUnaryMinusAst = (UnaryMinusAst) addAst.getRightArgument();
-        assertInstanceOf(LiteralAst.class, rightUnaryMinusAst.getArgument());
-        assertEquals("2", ((LiteralAst) rightUnaryMinusAst.getArgument()).lexical());
+        assertInstanceOf(LiteralAst.class, rightUnaryMinusAst.argument());
+        assertEquals("2", ((LiteralAst) rightUnaryMinusAst.argument()).lexical());
     }
 
     @Test
@@ -1060,9 +1060,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         UnaryPlusAst t = (UnaryPlusAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
+        assertInstanceOf(VarAst.class, t.argument());
 
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -1090,8 +1090,8 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         UnaryMinusAst t = (UnaryMinusAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getArgument());
-        assertEquals("s", ((VarAst) t.getArgument()).name());
+        assertInstanceOf(VarAst.class, t.argument());
+        assertEquals("s", ((VarAst) t.argument()).name());
     }
 
     @Test
@@ -1314,9 +1314,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertInstanceOf(BooleanNotAst.class, filterAst.operator());
 
         BooleanNotAst booleanNotAst = (BooleanNotAst) filterAst.operator();
-        assertInstanceOf(ExistsAst.class, booleanNotAst.getArgument());
+        assertInstanceOf(ExistsAst.class, booleanNotAst.argument());
 
-        ExistsAst existsAst = (ExistsAst) booleanNotAst.getArgument();
+        ExistsAst existsAst = (ExistsAst) booleanNotAst.argument();
         assertNotNull(existsAst.pattern());
         assertFalse(existsAst.pattern().patterns().isEmpty());
     }
@@ -1337,9 +1337,9 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         assertInstanceOf(BooleanNotAst.class, filterAst.operator());
 
         BooleanNotAst booleanNotAst = (BooleanNotAst) filterAst.operator();
-        assertInstanceOf(NotExistsAst.class, booleanNotAst.getArgument());
+        assertInstanceOf(NotExistsAst.class, booleanNotAst.argument());
 
-        NotExistsAst notExistsAst = (NotExistsAst) booleanNotAst.getArgument();
+        NotExistsAst notExistsAst = (NotExistsAst) booleanNotAst.argument();
         assertNotNull(notExistsAst.pattern());
         assertFalse(notExistsAst.pattern().patterns().isEmpty());
     }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserHashFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserHashFunctionsTest.java
@@ -35,7 +35,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         Md5Ast md5 = assertInstanceOf(Md5Ast.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, md5.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, md5.argument()).name());
         assertEquals("hash", bind.variable().name());
     }
 
@@ -54,7 +54,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         Sha1Ast sha1 = assertInstanceOf(Sha1Ast.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, sha1.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, sha1.argument()).name());
         assertEquals("hash", bind.variable().name());
     }
 
@@ -73,7 +73,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         Sha256Ast sha256 = assertInstanceOf(Sha256Ast.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, sha256.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, sha256.argument()).name());
         assertEquals("hash", bind.variable().name());
     }
 
@@ -92,7 +92,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         Sha384Ast sha384 = assertInstanceOf(Sha384Ast.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, sha384.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, sha384.argument()).name());
         assertEquals("hash", bind.variable().name());
     }
 
@@ -111,7 +111,7 @@ class SparqlParserHashFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         Sha512Ast sha512 = assertInstanceOf(Sha512Ast.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, sha512.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, sha512.argument()).name());
         assertEquals("hash", bind.variable().name());
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIriTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserIriTest.java
@@ -31,7 +31,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         IriFunctionAst iri = assertInstanceOf(IriFunctionAst.class, bind.expression());
-        assertEquals("lex", assertInstanceOf(VarAst.class, iri.getArgument()).name());
+        assertEquals("lex", assertInstanceOf(VarAst.class, iri.argument()).name());
         assertEquals("iri", bind.variable().name());
     }
 
@@ -50,7 +50,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         IriFunctionAst iri = assertInstanceOf(IriFunctionAst.class, bind.expression());
-        assertEquals("lex", assertInstanceOf(VarAst.class, iri.getArgument()).name());
+        assertEquals("lex", assertInstanceOf(VarAst.class, iri.argument()).name());
         assertEquals("iri", bind.variable().name());
     }
 
@@ -70,7 +70,7 @@ class SparqlParserIriTest extends AbstractSparqlParserFeatureTest {
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         EqualsAst equals = assertInstanceOf(EqualsAst.class, filter.operator());
         IriFunctionAst iri = assertInstanceOf(IriFunctionAst.class, equals.getLeftArgument());
-        assertEquals("lex", assertInstanceOf(VarAst.class, iri.getArgument()).name());
+        assertEquals("lex", assertInstanceOf(VarAst.class, iri.argument()).name());
         assertEquals("<http://example.org/resource>", assertInstanceOf(IriAst.class, equals.getRightArgument()).raw());
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLcaseTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserLcaseTest.java
@@ -31,7 +31,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         LcaseAst lcase = assertInstanceOf(LcaseAst.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, lcase.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, lcase.argument()).name());
         assertEquals("lower", bind.variable().name());
     }
 
@@ -50,7 +50,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         LcaseAst lcase = assertInstanceOf(LcaseAst.class, bind.expression());
-        LiteralAst literal = assertInstanceOf(LiteralAst.class, lcase.getArgument());
+        LiteralAst literal = assertInstanceOf(LiteralAst.class, lcase.argument());
         assertEquals("\"CORESE\"", literal.lexical());
         assertEquals("lower", bind.variable().name());
     }
@@ -71,7 +71,7 @@ class SparqlParserLcaseTest extends AbstractSparqlParserFeatureTest {
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         EqualsAst equals = assertInstanceOf(EqualsAst.class, filter.operator());
         LcaseAst lcase = assertInstanceOf(LcaseAst.class, equals.getLeftArgument());
-        assertEquals("label", assertInstanceOf(VarAst.class, lcase.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, lcase.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
@@ -34,7 +34,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         AbsAst abs = assertInstanceOf(AbsAst.class, bind.expression());
-        assertEquals("x", assertInstanceOf(VarAst.class, abs.getArgument()).name());
+        assertEquals("x", assertInstanceOf(VarAst.class, abs.argument()).name());
         assertEquals("abs", bind.variable().name());
     }
 
@@ -53,7 +53,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         RoundAst round = assertInstanceOf(RoundAst.class, filter.operator());
-        assertEquals("x", assertInstanceOf(VarAst.class, round.getArgument()).name());
+        assertEquals("x", assertInstanceOf(VarAst.class, round.argument()).name());
     }
 
     @Test
@@ -71,7 +71,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         CeilAst ceil = assertInstanceOf(CeilAst.class, filter.operator());
-        assertEquals("x", assertInstanceOf(VarAst.class, ceil.getArgument()).name());
+        assertEquals("x", assertInstanceOf(VarAst.class, ceil.argument()).name());
     }
 
     @Test
@@ -89,7 +89,7 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         FloorAst floor = assertInstanceOf(FloorAst.class, filter.operator());
-        assertEquals("x", assertInstanceOf(VarAst.class, floor.getArgument()).name());
+        assertEquals("x", assertInstanceOf(VarAst.class, floor.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserNumericFunctionsTest.java
@@ -2,11 +2,7 @@ package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AbsAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.CeilAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FloorAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.RandAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.RoundAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -46,13 +42,14 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(ROUND(?x))
+                  FILTER(ROUND(?x) > 0)
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
-        RoundAst round = assertInstanceOf(RoundAst.class, filter.operator());
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filter.operator());
+        RoundAst round = assertInstanceOf(RoundAst.class, greaterThanAst.getLeftArgument());
         assertEquals("x", assertInstanceOf(VarAst.class, round.argument()).name());
     }
 
@@ -64,13 +61,14 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(CEIL(?x))
+                  FILTER(CEIL(?x) > 0)
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
-        CeilAst ceil = assertInstanceOf(CeilAst.class, filter.operator());
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filter.operator());
+        CeilAst ceil = assertInstanceOf(CeilAst.class, greaterThanAst.getLeftArgument());
         assertEquals("x", assertInstanceOf(VarAst.class, ceil.argument()).name());
     }
 
@@ -82,13 +80,14 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(FLOOR(?x))
+                  FILTER(FLOOR(?x) > 0)
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
-        FloorAst floor = assertInstanceOf(FloorAst.class, filter.operator());
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filter.operator());
+        FloorAst floor = assertInstanceOf(FloorAst.class, greaterThanAst.getLeftArgument());
         assertEquals("x", assertInstanceOf(VarAst.class, floor.argument()).name());
     }
 
@@ -118,13 +117,14 @@ class SparqlParserNumericFunctionsTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(RAND())
+                  FILTER(RAND() > 0)
                 }
                 """);
 
         assertNotNull(ast);
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
-        assertInstanceOf(RandAst.class, filter.operator());
+        GreaterThanAst greaterThanAst = assertInstanceOf(GreaterThanAst.class, filter.operator());
+        assertInstanceOf(RandAst.class, greaterThanAst.getLeftArgument());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrUuidTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserStrUuidTest.java
@@ -50,7 +50,7 @@ class SparqlParserStrUuidTest extends AbstractSparqlParserFeatureTest {
         EqualsAst equals = assertInstanceOf(EqualsAst.class, filter.operator());
         assertInstanceOf(StrUuidAst.class, equals.getLeftArgument());
         StrAst str = assertInstanceOf(StrAst.class, equals.getRightArgument());
-        assertEquals("s", assertInstanceOf(VarAst.class, str.getArgument()).name());
+        assertEquals("s", assertInstanceOf(VarAst.class, str.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUcaseTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserUcaseTest.java
@@ -31,7 +31,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         UcaseAst ucase = assertInstanceOf(UcaseAst.class, bind.expression());
-        assertEquals("label", assertInstanceOf(VarAst.class, ucase.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, ucase.argument()).name());
         assertEquals("upper", bind.variable().name());
     }
 
@@ -50,7 +50,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
         assertNotNull(ast);
         BindAst bind = assertInstanceOf(BindAst.class, ast.whereClause().patterns().getLast());
         UcaseAst ucase = assertInstanceOf(UcaseAst.class, bind.expression());
-        LiteralAst literal = assertInstanceOf(LiteralAst.class, ucase.getArgument());
+        LiteralAst literal = assertInstanceOf(LiteralAst.class, ucase.argument());
         assertEquals("\"corese\"", literal.lexical());
         assertEquals("upper", bind.variable().name());
     }
@@ -71,7 +71,7 @@ class SparqlParserUcaseTest extends AbstractSparqlParserFeatureTest {
         FilterAst filter = assertInstanceOf(FilterAst.class, ast.whereClause().patterns().getLast());
         EqualsAst equals = assertInstanceOf(EqualsAst.class, filter.operator());
         UcaseAst ucase = assertInstanceOf(UcaseAst.class, equals.getLeftArgument());
-        assertEquals("label", assertInstanceOf(VarAst.class, ucase.getArgument()).name());
+        assertEquals("label", assertInstanceOf(VarAst.class, ucase.argument()).name());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -42,14 +42,14 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    CONSTRUCT {
-                        ?s ?p ?o
-                    }
-                    WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY ?z
-                """));
+                        CONSTRUCT {
+                            ?s ?p ?o
+                        }
+                        WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY ?z
+                    """));
 
             assertEquals(ORDER_BY_SCOPE_MESSAGE, exception.getMessage());
         }
@@ -64,12 +64,12 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    DESCRIBE ?s
-                    WHERE {
-                        ?s ?p ?o
-                    }
-                    ORDER BY ?z
-                """));
+                        DESCRIBE ?s
+                        WHERE {
+                            ?s ?p ?o
+                        }
+                        ORDER BY ?z
+                    """));
 
             assertEquals(ORDER_BY_SCOPE_MESSAGE, exception.getMessage());
         }
@@ -84,11 +84,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      BIND(?o AS ?x)
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          BIND(?o AS ?x)
+                        }
+                    """));
 
             assertEquals(BIND_SCOPE_MESSAGE, exception.getMessage());
         }
@@ -99,12 +99,12 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?s ?p ?o .
-                      BIND(?s AS ?x)
-                      BIND(?p AS ?x)
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?s ?p ?o .
+                          BIND(?s AS ?x)
+                          BIND(?p AS ?x)
+                        }
+                    """));
 
             assertEquals(BIND_SCOPE_MESSAGE, exception.getMessage());
         }
@@ -119,11 +119,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(RAND())
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(RAND())
+                        }
+                    """));
 
             assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
@@ -134,11 +134,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(DATATYPE("test"^^<http://ns.inria.fr/test>))
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(DATATYPE("test"^^<http://ns.inria.fr/test>))
+                        }
+                    """));
 
             assertEquals("DATATYPE used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
@@ -149,11 +149,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(NOW())
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(NOW())
+                        }
+                    """));
 
             assertEquals("NOW used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
@@ -164,52 +164,96 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(DAY(NOW()))
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(DAY(NOW()))
+                        }
+                    """));
 
             assertEquals("DAY used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
         @DisplayName("Should let pass FILTER with simple literal operator")
-        void shouldRejectFilterWithStringOperator() {
+        void shouldAcceptFilterWithStringOperator() {
             SparqlParser parser = newParserDefault();
 
             assertDoesNotThrow(() -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(STR("test"^^<http://ns.inria.fr/test>))
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(STR("test"^^<http://ns.inria.fr/test>))
+                        }
+                    """));
         }
 
         @Test
         @DisplayName("Should let pass FILTER with variable")
-        void shouldRejectFilterWithVariable() {
+        void shouldAcceptFilterWithVariable() {
             SparqlParser parser = newParserDefault();
 
             assertDoesNotThrow(() -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(?o)
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(?o)
+                        }
+                    """));
         }
 
         @Test
         @DisplayName("Should let pass FILTER with boolean")
-        void shouldRejectFilterWithBoolean() {
+        void shouldAcceptFilterWithBoolean() {
             SparqlParser parser = newParserDefault();
 
             assertDoesNotThrow(() -> parser.parse("""
-                    SELECT * WHERE {
-                      ?x ?p ?o .
-                      FILTER(true)
-                    }
-                """));
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(true)
+                        }
+                    """));
+        }
+
+        @Test
+        @DisplayName("Should let pass FILTER containing a IF that returns boolean or any acceptable AST type.")
+        void shouldAcceptFilterContainingIfWithCorrectType() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(IF(?s, true, ?o))
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER containing a IF that does not returns boolean or any acceptable AST type.")
+        void shouldRejectFilterContainingIfWithIncorrectType() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                       SELECT * WHERE {
+                         ?x ?p ?o .
+                         FILTER(IF(?s, 4, <http://test.inria.fr>))
+                       }
+                    """));
+
+            assertEquals("IF used in FILTER should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER containing a IF that does not returns only boolean or any acceptable AST type.")
+        void shouldRejectFilterContainingIfWithIncorrectTypeMix() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                       SELECT * WHERE {
+                         ?x ?p ?o .
+                         FILTER(IF(?s, true, <http://test.inria.fr>))
+                       }
+                    """));
+
+            assertEquals("IF used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
@@ -218,15 +262,15 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             SparqlParser parser = newParserDefault();
 
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
-                    SELECT * WHERE {
-                      {
-                          ?x ?p ?o .
-                          FILTER(RAND())
-                      } UNION {
-                          ?s ?p ?o .
-                      }
-                    }
-                """));
+                        SELECT * WHERE {
+                          {
+                              ?x ?p ?o .
+                              FILTER(RAND())
+                          } UNION {
+                              ?s ?p ?o .
+                          }
+                        }
+                    """));
 
             assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
@@ -237,75 +281,75 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
                 Arguments.of(
                         "Should reject SELECT * with ORDER BY variable not visible in WHERE",
                         """
-                        SELECT * WHERE {
-                            ?s ?p ?o
-                        }
-                        ORDER BY ?z
-                        """,
+                                SELECT * WHERE {
+                                    ?s ?p ?o
+                                }
+                                ORDER BY ?z
+                                """,
                         ORDER_BY_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject projection variable only referenced in FILTER",
                         """
-                        SELECT ?x WHERE {
-                          ?s ?p ?o .
-                          FILTER(BOUND(?x))
-                        }
-                        """,
+                                SELECT ?x WHERE {
+                                  ?s ?p ?o .
+                                  FILTER(BOUND(?x))
+                                }
+                                """,
                         SELECT_PROJECTION_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject projection variable not visible through UNION",
                         """
-                        SELECT ?cityLabel
-                        WHERE {
-                          { ?country wdt:P36 ?city. }
-                          UNION
-                          { ?city wdt:P17 ?country. }
-                        }
-                        """,
+                                SELECT ?cityLabel
+                                WHERE {
+                                  { ?country wdt:P36 ?city. }
+                                  UNION
+                                  { ?city wdt:P17 ?country. }
+                                }
+                                """,
                         CITY_LABEL_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject ORDER BY variable not visible in WHERE",
                         """
-                        SELECT ?s WHERE {
-                            ?s ?p ?o
-                        }
-                        ORDER BY ?z
-                        """,
+                                SELECT ?s WHERE {
+                                    ?s ?p ?o
+                                }
+                                ORDER BY ?z
+                                """,
                         ORDER_BY_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject multiple ORDER BY clauses when one variable is not visible in WHERE",
                         """
-                        SELECT ?s WHERE {
-                            ?s ?p ?o
-                        }
-                        ORDER BY ?s ?z
-                        """,
+                                SELECT ?s WHERE {
+                                    ?s ?p ?o
+                                }
+                                ORDER BY ?s ?z
+                                """,
                         ORDER_BY_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject ORDER BY expression using a variable not visible in WHERE",
                         """
-                        SELECT ?s WHERE {
-                            ?s ?p ?o
-                        }
-                        ORDER BY STR(?z)
-                        """,
+                                SELECT ?s WHERE {
+                                    ?s ?p ?o
+                                }
+                                ORDER BY STR(?z)
+                                """,
                         ORDER_BY_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject ORDER BY IF expression using a variable not visible in WHERE",
                         """
-                        SELECT ?s WHERE {
-                            ?s ?p ?o
-                        }
-                        ORDER BY IF(BOUND(?o), ?o, ?z)
-                        """,
+                                SELECT ?s WHERE {
+                                    ?s ?p ?o
+                                }
+                                ORDER BY IF(BOUND(?o), ?o, ?z)
+                                """,
                         ORDER_BY_SCOPE_MESSAGE),
                 Arguments.of(
                         "Should reject SELECT projection variables not visible in WHERE",
                         """
-                        SELECT ?x WHERE {
-                            ?s ?p ?o
-                        }
-                        """,
+                                SELECT ?x WHERE {
+                                    ?s ?p ?o
+                                }
+                                """,
                         SELECT_PROJECTION_SCOPE_MESSAGE));
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
@@ -108,6 +107,128 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
                 """));
 
             assertEquals(BIND_SCOPE_MESSAGE, exception.getMessage());
+        }
+    }
+
+    @Nested
+    class FilterValidationTest {
+
+        @Test
+        @DisplayName("Should reject FILTER with numeric operator")
+        void shouldRejectFilterWithNumericOperator() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(RAND())
+                    }
+                """));
+
+            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER with IRI operator")
+        void shouldRejectFilterWithIRIOperator() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(DATATYPE("test"^^<http://ns.inria.fr/test>))
+                    }
+                """));
+
+            assertEquals("DATATYPE used in FILTER should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER with datetime operator")
+        void shouldRejectFilterWithDatetime() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(NOW())
+                    }
+                """));
+
+            assertEquals("NOW used in FILTER should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER with datetime duration operator")
+        void shouldRejectFilterWithDuration() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(DAY(NOW()))
+                    }
+                """));
+
+            assertEquals("DAY used in FILTER should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should let pass FILTER with simple literal operator")
+        void shouldRejectFilterWithStringOperator() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(STR("test"^^<http://ns.inria.fr/test>))
+                    }
+                """));
+        }
+
+        @Test
+        @DisplayName("Should let pass FILTER with variable")
+        void shouldRejectFilterWithVariable() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(?o)
+                    }
+                """));
+        }
+
+        @Test
+        @DisplayName("Should let pass FILTER with boolean")
+        void shouldRejectFilterWithBoolean() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                    SELECT * WHERE {
+                      ?x ?p ?o .
+                      FILTER(true)
+                    }
+                """));
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER with numeric operator in a nested BGP")
+        void shouldRejectFilterWithNumericOperatorInNestedBGP() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                    SELECT * WHERE {
+                      {
+                          ?x ?p ?o .
+                          FILTER(RAND())
+                      } UNION {
+                          ?s ?p ?o .
+                      }
+                    }
+                """));
+
+            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -114,22 +114,20 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
     class FilterValidationTest {
 
         @Test
-        @DisplayName("Should reject FILTER with numeric operator")
-        void shouldRejectFilterWithNumericOperator() {
+        @DisplayName("Should accept FILTER with numeric operator")
+        void shouldAcceptFilterWithNumericOperator() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           ?x ?p ?o .
                           FILTER(RAND())
                         }
                     """));
-
-            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
-        @DisplayName("Should reject FILTER with IRI operator")
+        @DisplayName("Should reject FILTER with IRI-returning operator")
         void shouldRejectFilterWithIRIOperator() {
             SparqlParser parser = newParserDefault();
 
@@ -159,18 +157,57 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
 
         @Test
-        @DisplayName("Should reject FILTER with datetime duration operator")
-        void shouldRejectFilterWithDuration() {
+        @DisplayName("Should accept FILTER with numeric expression derived from datetime")
+        void shouldAcceptFilterWithDuration() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           ?x ?p ?o .
                           FILTER(DAY(NOW()))
                         }
                     """));
+        }
 
-            assertEquals("DAY used in FILTER should be resolvable to a boolean", exception.getMessage());
+        @Test
+        @DisplayName("Should accept FILTER with plain literal")
+        void shouldAcceptFilterWithPlainLiteral() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER("test")
+                        }
+                    """));
+        }
+
+        @Test
+        @DisplayName("Should accept FILTER with CONCAT result")
+        void shouldAcceptFilterWithConcat() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(CONCAT("te", "st"))
+                        }
+                    """));
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER when IF condition is not EBV-compatible")
+        void shouldRejectFilterContainingIfWithIncorrectConditionType() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(IF(NOW(), true, false))
+                        }
+                    """));
+
+            assertEquals("IF used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
@@ -257,11 +294,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
 
         @Test
-        @DisplayName("Should reject FILTER with numeric operator in a nested BGP")
-        void shouldRejectFilterWithNumericOperatorInNestedBGP() {
+        @DisplayName("Should accept FILTER with numeric operator in a nested BGP")
+        void shouldAcceptFilterWithNumericOperatorInNestedBGP() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           {
                               ?x ?p ?o .
@@ -271,8 +308,6 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
                           }
                         }
                     """));
-
-            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
Adds a visitor design pattern to ASTs to facilitate validation of rules that ned to explore recursively the patterns.

Check that the arguments of a a filter are either a boolean expression or a literal expresion that is not datetime related or numeric, or a function call, or a variable or a literal.