### PR TITLE
412 [SPARQL] Validate operand types in expressions

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/AbstractSemanticValidationRule.java
@@ -35,5 +35,5 @@ public abstract class AbstractSemanticValidationRule implements SemanticValidati
                 variableName,
                 source);
     }
-    
+
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -117,4 +117,17 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
             }
         }
     }
+
+    private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        };
+        public void visit(PatternAst patternAst) {
+            if(patternAst instanceof FilterAst filterAst) {
+                result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
+            }
+        }
+    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -118,17 +118,4 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
             }
         }
     }
-
-    private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
-        private final List<QueryDiagnostic> result = new ArrayList<>();
-
-        public List<QueryDiagnostic> getResult() {
-            return result;
-        };
-        public void visit(PatternAst patternAst) {
-            if(patternAst instanceof FilterAst filterAst && checkFilterBoolean(filterAst)) {
-                result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
-            }
-        }
-    }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -125,7 +125,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
             return result;
         };
         public void visit(PatternAst patternAst) {
-            if(patternAst instanceof FilterAst filterAst) {
+            if(patternAst instanceof FilterAst filterAst && checkFilterBoolean(filterAst)) {
                 result.add(buildIncorrectTypeDiagnostic(filterAst.operator().getName(), "FILTER", "boolean"));
             }
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
-import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
@@ -9,6 +8,8 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialBoolean;
 
 /**
  * Validates that FILTER and HAVING expressions are compatible with SPARQL

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
@@ -1,0 +1,57 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AndAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BinaryConstraintAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BooleanNotAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.OrAst;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialBoolean;
+
+public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticValidationRule {
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentBooleanTypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandBooleanArgumentTypeVisitor visitor = new OperandBooleanArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandBooleanArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        }
+
+        @Override
+        public void visit(TermAst termAst) {
+            if(termAst instanceof BooleanNotAst booleanNotAst) {
+                if(! checkTermIsPotentialBoolean( booleanNotAst.argument())) {
+                    result.add(buildIncorrectTypeDiagnostic(booleanNotAst.argument().getName(), booleanNotAst.getName(), "boolean"));
+                }
+            }
+            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
+                if(binaryConstraintAst instanceof AndAst
+                    || binaryConstraintAst instanceof OrAst) {
+                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "boolean"));
+                    }
+                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "boolean"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -7,8 +7,6 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstV
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +17,6 @@ import static fr.inria.corese.core.next.query.impl.parser.semantic.support.Seman
  * Check that the comparison operand do not compare IRIs (except for the different != operator)
  */
 public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValidationRule {
-
-    private static final Logger logger = LoggerFactory.getLogger(OperandArgumentIRITypeValidationRule.class);
 
     @Override
     protected String getDiagnosticSource() {
@@ -43,18 +39,14 @@ public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValida
 
         @Override
         public void visit(TermAst termAst) {
-            logger.debug(termAst.getName());
             if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
-                logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getRightArgument().getName());
                 if(binaryConstraintAst instanceof LowerThanAst
                     || binaryConstraintAst instanceof LowerOrEqualThanAst
                     || binaryConstraintAst instanceof GreaterThanAst
                     || binaryConstraintAst instanceof GreaterOrEqualThanAst) {
-                    logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getLeftArgument().getName(), checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument()));
                     if(checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
                     }
-                    logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getRightArgument().getName(), checkTermIsPotentialIri(binaryConstraintAst.getRightArgument()));
                     if(checkTermIsPotentialIri(binaryConstraintAst.getRightArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
                     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -1,0 +1,66 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import com.typesafe.sslconfig.ssl.LessThan;
+import com.typesafe.sslconfig.ssl.LessThanOrEqual;
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialIri;
+
+/**
+ * Check that the comparison operand do not compare IRIs (except for the different != operator)
+ */
+public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValidationRule {
+
+    private static final Logger logger = LoggerFactory.getLogger(OperandArgumentIRITypeValidationRule.class);
+
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentBooleanTypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandIRIArgumentTypeVisitor visitor = new OperandIRIArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandIRIArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        }
+
+        @Override
+        public void visit(TermAst termAst) {
+            logger.debug(termAst.getName());
+            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
+                logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getRightArgument().getName());
+                if(binaryConstraintAst instanceof LowerThanAst
+                    || binaryConstraintAst instanceof LowerOrEqualThanAst
+                    || binaryConstraintAst instanceof GreaterThanAst
+                    || binaryConstraintAst instanceof GreaterOrEqualThanAst) {
+                    logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getLeftArgument().getName(), checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument()));
+                    if(checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
+                    }
+                    logger.debug("{} {} {}", binaryConstraintAst.getName(), binaryConstraintAst.getRightArgument().getName(), checkTermIsPotentialIri(binaryConstraintAst.getRightArgument()));
+                    if(checkTermIsPotentialIri(binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -1,7 +1,5 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
-import com.typesafe.sslconfig.ssl.LessThan;
-import com.typesafe.sslconfig.ssl.LessThanOrEqual;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
@@ -20,7 +18,7 @@ public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValida
 
     @Override
     protected String getDiagnosticSource() {
-        return OperandArgumentBooleanTypeValidationRule.class.getSimpleName();
+        return OperandArgumentIRITypeValidationRule.class.getSimpleName();
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -5,13 +5,16 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstV
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialNumeric;
 
-public class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
+public final class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
+
     @Override
     protected String getDiagnosticSource() {
         return OperandArgumentNumericTypeValidationRule.class.getSimpleName();
@@ -29,33 +32,36 @@ public class OperandArgumentNumericTypeValidationRule extends AbstractSemanticVa
 
         public List<QueryDiagnostic> getResult() {
             return result;
-        };
+        }
+
+        ;
 
         @Override
         public void visit(TermAst termAst) {
             if (termAst instanceof UnaryConstraintAst unaryConstraintAst) {
                 if (
-                    (unaryConstraintAst instanceof AbsAst
-                        || unaryConstraintAst instanceof CeilAst
-                        || unaryConstraintAst instanceof FloorAst
-                        || unaryConstraintAst instanceof RoundAst
-                        || unaryConstraintAst instanceof UnaryMinusAst
-                        || unaryConstraintAst instanceof UnaryPlusAst)
-                    && ! checkTermIsPotentialNumeric( unaryConstraintAst.argument())) {
+                        (unaryConstraintAst instanceof AbsAst
+                                || unaryConstraintAst instanceof CeilAst
+                                || unaryConstraintAst instanceof FloorAst
+                                || unaryConstraintAst instanceof RoundAst
+                                || unaryConstraintAst instanceof UnaryMinusAst
+                                || unaryConstraintAst instanceof UnaryPlusAst)
+                                && !checkTermIsPotentialNumeric(unaryConstraintAst.argument())) {
                     result.add(buildIncorrectTypeDiagnostic(unaryConstraintAst.argument().getName(), unaryConstraintAst.getName(), "numeric"));
                 }
-                if(termAst instanceof BinaryConstraintAst binaryConstraintAst) { // Numeric only operands
-                    if(binaryConstraintAst instanceof AddAst
-                            || binaryConstraintAst instanceof DivideAst
-                            || binaryConstraintAst instanceof MultiplyAst
-                            || binaryConstraintAst instanceof SubtractAst
-                        ) {
-                        if(! checkTermIsPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
-                            result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
-                        }
-                        if(! checkTermIsPotentialNumeric(binaryConstraintAst.getRightArgument())) {
-                            result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
-                        }
+            }
+
+            if (termAst instanceof BinaryConstraintAst binaryConstraintAst) { // Numeric only operands
+                if (binaryConstraintAst instanceof AddAst
+                        || binaryConstraintAst instanceof DivideAst
+                        || binaryConstraintAst instanceof MultiplyAst
+                        || binaryConstraintAst instanceof SubtractAst
+                ) {
+                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
+                    }
+                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
                     }
                 }
             }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -5,14 +5,15 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstV
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialNumeric;
 
+/**
+ * Check that the operands and numeric functions use numeric arguments
+ */
 public final class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
 
     @Override
@@ -22,19 +23,17 @@ public final class OperandArgumentNumericTypeValidationRule extends AbstractSema
 
     @Override
     public List<QueryDiagnostic> validate(QueryAst queryAst) {
-        OperandArgumentTypeVisitor visitor = new OperandArgumentTypeVisitor();
+        OperandNumericArgumentTypeVisitor visitor = new OperandNumericArgumentTypeVisitor();
         queryAst.accept(visitor);
         return visitor.getResult();
     }
 
-    private class OperandArgumentTypeVisitor extends AbstractAstVisitor {
+    private class OperandNumericArgumentTypeVisitor extends AbstractAstVisitor {
         private final List<QueryDiagnostic> result = new ArrayList<>();
 
         public List<QueryDiagnostic> getResult() {
             return result;
         }
-
-        ;
 
         @Override
         public void visit(TermAst termAst) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -1,0 +1,64 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialNumeric;
+
+public class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentNumericTypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandArgumentTypeVisitor visitor = new OperandArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        };
+
+        @Override
+        public void visit(TermAst termAst) {
+            if (termAst instanceof UnaryConstraintAst unaryConstraintAst) {
+                if (
+                    (unaryConstraintAst instanceof AbsAst
+                        || unaryConstraintAst instanceof CeilAst
+                        || unaryConstraintAst instanceof FloorAst
+                        || unaryConstraintAst instanceof RoundAst
+                        || unaryConstraintAst instanceof UnaryMinusAst
+                        || unaryConstraintAst instanceof UnaryPlusAst)
+                    && ! checkTermIsPotentialNumeric( unaryConstraintAst.argument())) {
+                    result.add(buildIncorrectTypeDiagnostic(unaryConstraintAst.argument().getName(), unaryConstraintAst.getName(), "numeric"));
+                }
+                if(termAst instanceof BinaryConstraintAst binaryConstraintAst) { // Numeric only operands
+                    if(binaryConstraintAst instanceof AddAst
+                            || binaryConstraintAst instanceof DivideAst
+                            || binaryConstraintAst instanceof MultiplyAst
+                            || binaryConstraintAst instanceof SubtractAst
+                        ) {
+                        if(! checkTermIsPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
+                            result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
+                        }
+                        if(! checkTermIsPotentialNumeric(binaryConstraintAst.getRightArgument())) {
+                            result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -1,0 +1,122 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.List;
+
+public class SemanticValidationUtils {
+
+    /**
+     * Valid numeric datatypes as defined in https://www.w3.org/TR/sparql11-query/#operandDataTypes
+     */
+    private static final List<String> validNumericDatatypes = List.of(
+            XSD.xsdInteger.getIRI().stringValue(),
+            XSD.xsdDecimal.getIRI().stringValue(),
+            XSD.xsdFloat.getIRI().stringValue(),
+            XSD.xsdDouble.getIRI().stringValue(),
+            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
+            XSD.xsdNegativeInteger.getIRI().stringValue(),
+            XSD.xsdLong.getIRI().stringValue(),
+            XSD.xsdInt.getIRI().stringValue(),
+            XSD.xsdShort.getIRI().stringValue(),
+            XSD.xsdByte.getIRI().stringValue(),
+            XSD.xsdNonNegativeInteger.getIRI().stringValue(),
+            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdUnsignedInt.getIRI().stringValue(),
+            XSD.xsdUnsignedShort.getIRI().stringValue(),
+            XSD.xsdUnsignedByte.getIRI().stringValue(),
+            XSD.xsdPositiveInteger.getIRI().stringValue()
+    );
+
+    /**
+     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
+     */
+    public static boolean checkTermIsPotentialBoolean(TermAst termAst) {
+        if (checkTermIsUnknownType(termAst)) {
+            return true;
+        }
+        if (termAst instanceof BooleanExpressionAst) {
+            return true;
+        }
+        if (termAst instanceof LiteralExpressionAst literalExpressionAst
+                && !(literalExpressionAst instanceof XsdDateTimeExpressionAst
+                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
+                || literalExpressionAst instanceof NumericExpressionAst
+        )) { // Is a literal expression that could be a boolean, we cannot know
+            return true;
+        }
+        if (termAst instanceof IfAst ifAst
+                && checkTermIsPotentialBoolean(ifAst.thenExpr())
+                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
+            return true;
+        }
+        if (termAst instanceof LiteralAst(
+                String lexical, String lang, String datatype
+        )) {// is a literal that is a typed as a boolean or the string representation of one
+            if (datatype != null) {
+                return datatype.equals(XSD.xsdBoolean.getIRI().stringValue());
+            } else {
+                return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean checkTermIsPotentialNumeric(TermAst termAst) {
+        if (checkTermIsUnknownType(termAst)) {
+            return true;
+        }
+        if (termAst instanceof IfAst ifAst
+                && checkTermIsPotentialNumeric(ifAst.thenExpr())
+                && checkTermIsPotentialNumeric(ifAst.elseExpr())) { // Is a IF that returns potential numerics
+            return true;
+        }
+        if (termAst instanceof NumericExpressionAst) { // Is a literal expression that could be a numeric, we cannot know
+            return true;
+        }
+        if (termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {
+            if(datatype != null) {
+                return validNumericDatatypes.contains(datatype); // Datatype is an URI of an standard numeric datatype
+            } else {
+                return checkStringIsNumeric(lexical); // The string value can be parsed to a numeric value
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the given term type cannot be determined at query parsing, it will be checked at query resolution.
+     *
+     */
+    public static boolean checkTermIsUnknownType(TermAst termAst) {
+        if (termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
+            return true;
+        }
+        if (termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
+            return true;
+        }
+        if(termAst instanceof SimpleLiteralExpressionAst) { // Could be a string un-typed but still representing a known type. will be filtered at resolution
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean checkStringIsNumeric(String lexical) {
+        if (lexical == null) {
+            return false;
+        }
+        try {
+            double d = Double.parseDouble(lexical);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.support;
 
 import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
@@ -67,13 +68,17 @@ public class SemanticValidationUtils {
         return false;
     }
 
+
+    /**
+     * Check that the given term is either numeric expression, literal expression typed by a standard numeric datatype, a literal that can be parsed to a numeric or a variable
+     */
     public static boolean checkTermIsPotentialNumeric(TermAst termAst) {
         if (checkTermIsUnknownType(termAst)) {
             return true;
         }
         if (termAst instanceof IfAst ifAst
                 && checkTermIsPotentialNumeric(ifAst.thenExpr())
-                && checkTermIsPotentialNumeric(ifAst.elseExpr())) { // Is a IF that returns potential numerics
+                && checkTermIsPotentialNumeric(ifAst.elseExpr())) { // Is an IF that returns potential numerics
             return true;
         }
         if (termAst instanceof NumericExpressionAst) { // Is a literal expression that could be a numeric, we cannot know
@@ -108,6 +113,9 @@ public class SemanticValidationUtils {
         return false;
     }
 
+    /**
+     * Tries to parse the string as a Double
+     */
     public static boolean checkStringIsNumeric(String lexical) {
         if (lexical == null) {
             return false;
@@ -118,5 +126,24 @@ public class SemanticValidationUtils {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Check if the term is either a variable or an IRI or an expression that can be resolved to an IRI
+     */
+    public static boolean checkTermIsPotentialIri(TermAst termAst) {
+        if(termAst instanceof VarAst) {
+            return true;
+        }
+        if(termAst instanceof IriAst) { // Is an IRI
+            return true;
+        }
+        if (termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
+            return true;
+        }
+        if(termAst instanceof IriExpressionAst) { // Is a function that can be resolved to an IRI
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -132,13 +132,7 @@ public class SemanticValidationUtils {
      * Check if the term is either a variable or an IRI or an expression that can be resolved to an IRI
      */
     public static boolean checkTermIsPotentialIri(TermAst termAst) {
-        if(termAst instanceof VarAst) {
-            return true;
-        }
         if(termAst instanceof IriAst) { // Is an IRI
-            return true;
-        }
-        if (termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
             return true;
         }
         if(termAst instanceof IriExpressionAst) { // Is a function that can be resolved to an IRI

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
@@ -3,10 +3,7 @@ package fr.inria.corese.core.next.query.impl.parser.semantic.validator;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
 import fr.inria.corese.core.next.query.api.validation.QueryValidator;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.FilterArgumentsValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.OrderByScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SelectProjectionScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SemanticValidationRule;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 
 import java.util.ArrayList;
@@ -24,7 +21,8 @@ public final class SparqlQuerySemanticValidator implements QueryValidator<QueryA
         this(List.of(
                 new SelectProjectionScopeValidationRule(),
                 new OrderByScopeValidationRule(),
-                new FilterArgumentsValidationRule()));
+                new FilterArgumentsValidationRule(),
+                new OperandArgumentNumericTypeValidationRule()));
     }
 
     /** Package-private for tests or future composition of rule sets. */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
@@ -22,7 +22,9 @@ public final class SparqlQuerySemanticValidator implements QueryValidator<QueryA
                 new SelectProjectionScopeValidationRule(),
                 new OrderByScopeValidationRule(),
                 new FilterArgumentsValidationRule(),
-                new OperandArgumentNumericTypeValidationRule()));
+                new OperandArgumentNumericTypeValidationRule(),
+                new OperandArgumentBooleanTypeValidationRule(),
+                new OperandArgumentIRITypeValidationRule()));
     }
 
     /** Package-private for tests or future composition of rule sets. */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
@@ -20,7 +20,8 @@ public record UpdateRequestAst(QueryPrologueAst prologue, List<UpdateRequestUnit
 
     @Override
     public void accept(AstVisitor visitor) {
-        visitor.visit(this.prologue);
+        visitor.visit(this);
+        this.prologue.accept(visitor);
         this.operations.forEach(updateRequestUnitAst -> updateRequestUnitAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
@@ -1,8 +1,0 @@
-package fr.inria.corese.core.next.query.impl.sparql.ast;
-
-import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-
-public interface VisitableAst {
-
-    void accept(AstVisitor visitor);
-}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/VisitableAst.java
@@ -1,0 +1,8 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
+public interface VisitableAst {
+
+    void accept(AstVisitor visitor);
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Function {@code CONCAT(expr1, expr2, ...)} in SPARQL 1.1.
  */
-public class ConcatAst extends AbstractUnlimitedArgumentsFunctionAst {
+public class ConcatAst extends AbstractUnlimitedArgumentsFunctionAst implements SimpleLiteralExpressionAst {
 
     public ConcatAst(List<TermAst> arguments) {
         super(arguments);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
@@ -8,7 +8,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
  * Function {@code STRLEN(string)} in SPARQL 1.1
  * Returns the length of a string.
  */
-public class StrLenAst extends AbstractUnaryConstraintAst {
+public class StrLenAst extends AbstractUnaryConstraintAst implements NumericExpressionAst {
 
     public StrLenAst(TermAst arg) {
         super(arg);

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -483,7 +483,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s < <http://example.com>)
+                  FILTER(?s < 2)
                 }
                 """);
 
@@ -501,11 +501,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         LowerThanAst t = (LowerThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("2", literalAst.lexical());
     }
 
     @Test
@@ -515,7 +515,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s <= <http://example.com>)
+                  FILTER(?s <= 3)
                 }
                 """);
 
@@ -533,11 +533,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         LowerOrEqualThanAst t = (LowerOrEqualThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("3", literalAst.lexical());
     }
 
     @Test
@@ -547,7 +547,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s > <http://example.com>)
+                  FILTER(?s > 4)
                 }
                 """);
 
@@ -565,11 +565,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         GreaterThanAst t = (GreaterThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("4", literalAst.lexical());
     }
 
     @Test
@@ -579,7 +579,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s >= <http://example.com>)
+                  FILTER(?s >= 5)
                 }
                 """);
 
@@ -597,11 +597,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         GreaterOrEqualThanAst t = (GreaterOrEqualThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("5", literalAst.lexical());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -429,6 +429,154 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
             });
             assertEquals("NOW used in * should be resolvable to a numeric", exception.getMessage());
         }
+
+        @Test
+        @DisplayName("Should accept || operator with booleans")
+        void shouldAcceptOrWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(IsIri(?s) || false)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept && operator with booleans")
+        void shouldAcceptAndWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(NOT EXISTS { ?s ?p false } && STRSTARTS("test", "t"))
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject || operator with non booleans")
+        void shouldRejectOrWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(IsIri(?s) || "potato")
+                           }
+                        """);
+            });
+            assertEquals("\"potato\" used in || should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject && operator with non booleans")
+        void shouldRejectAndWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(<http://ns.inria.fr/test> && langMatches("potato", "fr"))
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in && should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should accept ! operator with booleans")
+        void shouldAcceptNotWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(! NOT EXISTS { ?s ?p false } && STRSTARTS("test", "t"))
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject ! operator with non booleans")
+        void shouldRejectNotWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(! <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in ! should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject < operator with IRIs")
+        void shouldRejectLTWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(2 < <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in < should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject <= operator with IRIs")
+        void shouldRejectLTEWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") <= <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in <= should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject > operator with IRIs")
+        void shouldRejectGTWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER("2"^^<http://www.w3.org/2001/XMLSchema#integer> > <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in > should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject >= operator with IRIs")
+        void shouldRejectGTEWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(datatype("2"^^<http://www.w3.org/2001/XMLSchema#integer>) >= 4)
+                           }
+                        """);
+            });
+            assertEquals("DATATYPE used in >= should be resolvable to a not an IRI", exception.getMessage());
+        }
+
     }
 
     private static Stream<Arguments> invalidSelectQueries() {

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -387,7 +387,7 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
         @Test
         @DisplayName("Should reject - operator with non numerics")
-        void shouldAcceptMinusWithNonNumerics() {
+        void shouldRejectMinusWithNonNumerics() {
             SparqlParser parser = newParserDefault();
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
                 parser.parse("""
@@ -402,7 +402,7 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
         @Test
         @DisplayName("Should reject * operator with non numerics")
-        void shouldAcceptDivideWithNonNumerics() {
+        void shouldRejectDivideWithNonNumerics() {
             SparqlParser parser = newParserDefault();
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
                 parser.parse("""
@@ -417,7 +417,7 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
         @Test
         @DisplayName("Should reject / operator with non numerics")
-        void shouldAcceptMultiplyWithNonNumerics() {
+        void shouldRejectMultiplyWithNonNumerics() {
             SparqlParser parser = newParserDefault();
             QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
                 parser.parse("""

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -311,6 +311,126 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
     }
 
+    @Nested
+    public class OperandTypeTest {
+
+        @Test
+        @DisplayName("Should accept + operator with numerics")
+        void shouldAcceptPlusWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(RAND() + 1 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept - operator with numerics")
+        void shouldAcceptMinusWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") - 1 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept * operator with numerics")
+        void shouldAcceptMultiplyWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") * RAND() = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept / operator with numerics")
+        void shouldAcceptDivideWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(DAY(NOW()) / 2 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject + operator with non numerics")
+        void shouldRefusePlusWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(RAND() + "one" = ?o)
+                           }
+                        """);
+            });
+            assertEquals("\"one\" used in + should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject - operator with non numerics")
+        void shouldAcceptMinusWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER((3 - STRENDS("test", "")) = ?o)
+                           }
+                        """);
+            });
+            assertEquals("STRENDS used in - should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject * operator with non numerics")
+        void shouldAcceptDivideWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(<http://ns.inria.fr/test> / 2 = ?o)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in / should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject / operator with non numerics")
+        void shouldAcceptMultiplyWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") * NOW() = ?o)
+                           }
+                        """);
+            });
+            assertEquals("NOW used in * should be resolvable to a numeric", exception.getMessage());
+        }
+    }
+
     private static Stream<Arguments> invalidSelectQueries() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
@@ -1,0 +1,57 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SemanticValidationUtilsTest {
+
+    @Test
+    void checkTermIsPotentialBooleanTest() {
+        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("true", null, null)));
+        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("potato", null, XSD.xsdBoolean.getIRI().stringValue())));
+        assertTrue(checkTermIsPotentialBoolean(new AndAst(List.of(new LiteralAst("true", null, null), new LiteralAst("true", null, null)))));
+        assertTrue(checkTermIsPotentialBoolean(new VarAst("test")));
+        assertFalse(checkTermIsPotentialBoolean(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(checkTermIsPotentialBoolean(new NowAst()));
+    }
+
+    @Test
+    void checkTermIsPotentialNumericTest() {
+        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("1", null, null)));
+        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("abc", null, XSD.xsdDouble.getIRI().stringValue())));
+        assertTrue(checkTermIsPotentialNumeric(new VarAst("test")));
+        assertFalse(checkTermIsPotentialNumeric(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(checkTermIsPotentialNumeric(new NowAst()));
+        assertTrue(checkTermIsPotentialNumeric(new AddAst(List.of(new LiteralAst("1", null, null), new LiteralAst("2", null, null)))));
+    }
+
+    @Test
+    void checkTermIsUnknownTypeTest() {
+        assertTrue(checkTermIsUnknownType(new VarAst("test")));
+        assertFalse(checkTermIsUnknownType(new LiteralAst("true", null, null)));
+        assertFalse(checkTermIsUnknownType(new NowAst()));
+    }
+
+    @Test
+    void checkStringIsNumericTest() {
+        assertTrue(checkStringIsNumeric("1"));
+        assertFalse(checkStringIsNumeric("Potato"));
+    }
+
+    @Test
+    void checkTermIsPotentialIriTest() {
+        assertTrue(checkTermIsPotentialIri(new IriAst("<http://ns.inria.de/test>")));
+        assertTrue(checkTermIsPotentialIri(new VarAst("test")));
+        assertFalse(checkTermIsPotentialIri(new LiteralAst("1", null, null)));
+        assertFalse(checkTermIsPotentialIri(new NowAst()));
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
@@ -50,7 +50,8 @@ class SemanticValidationUtilsTest {
     @Test
     void checkTermIsPotentialIriTest() {
         assertTrue(checkTermIsPotentialIri(new IriAst("<http://ns.inria.de/test>")));
-        assertTrue(checkTermIsPotentialIri(new VarAst("test")));
+        assertTrue(checkTermIsPotentialIri(new DatatypeAst(List.of(new LiteralAst("1", null, null)))));
+        assertFalse(checkTermIsPotentialIri(new VarAst("test")));
         assertFalse(checkTermIsPotentialIri(new LiteralAst("1", null, null)));
         assertFalse(checkTermIsPotentialIri(new NowAst()));
     }


### PR DESCRIPTION
Adds checks on functions that will only accept numerics an booleans. Other types can be assumed to be string if reduced to their lexical values.
The argument count is already check during the parsing step.