### PR TITLE
fixing a problem with gradle build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,8 +54,7 @@ javacc {
 sourceSets {
     main {
         java {
-            srcDir(javaccGeneratedDir)
-            srcDir(antlrGeneratedDir)
+            setSrcDirs(listOf("src/main/java", javaccGeneratedDir, antlrPackageDir))
         }
     }
 }
@@ -309,9 +308,9 @@ tasks.named("compileJava") {
 
 // Ensure sources JAR includes generated sources and depends on code generation
 tasks.named<Jar>("sourcesJar") {
-    dependsOn("generateGrammarSource", "generateTestGrammarSource", "javaccSparqlCorese")
+    dependsOn("generateGrammarSource", "javaccSparqlCorese")
     from(javaccGeneratedDir)
-    from(antlrGeneratedDir)
+    from(antlrPackageDir)
     includeEmptyDirs = false
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -309,7 +309,7 @@ tasks.named("compileJava") {
 
 // Ensure sources JAR includes generated sources and depends on code generation
 tasks.named<Jar>("sourcesJar") {
-    dependsOn("generateGrammarSource", "javaccSparqlCorese")
+    dependsOn("generateGrammarSource", "generateTestGrammarSource", "javaccSparqlCorese")
     from(javaccGeneratedDir)
     from(antlrGeneratedDir)
     includeEmptyDirs = false


### PR DESCRIPTION
`gradlew build` gave me an error:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':generateTestGrammarSource' (type 'AntlrTask').
  - Gradle detected a problem with the following location: '/home/nanqueti/Documents/RMod/Tools/Moose/Examples/Corese-stack/Corese-core/build/generated-src/antlr/test'.
    
    Reason: Task ':sourcesJar' uses this output of task ':generateTestGrammarSource' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':generateTestGrammarSource' as an input of ':sourcesJar'.
      2. Declare an explicit dependency on ':generateTestGrammarSource' from ':sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':generateTestGrammarSource' from ':sourcesJar' using Task#mustRunAfter.
```
so I did the first suggestion...