### PR TITLE
Fix/455 filter ebv validation

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -8,11 +8,33 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
- * This rule checks the operators used in Filter asts
+ * Validates that FILTER and HAVING expressions are compatible with SPARQL
+ * effective boolean value evaluation.
  */
 public final class FilterArgumentsValidationRule extends AbstractSemanticValidationRule {
+
+    private static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
+    private static final String STRING_DATATYPE = XSD.xsdString.getIRI().stringValue();
+    private static final Set<String> NUMERIC_DATATYPES = Set.of(
+            XSD.xsdInteger.getIRI().stringValue(),
+            XSD.xsdNonNegativeInteger.getIRI().stringValue(),
+            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
+            XSD.xsdPositiveInteger.getIRI().stringValue(),
+            XSD.xsdNegativeInteger.getIRI().stringValue(),
+            XSD.xsdInt.getIRI().stringValue(),
+            XSD.xsdUnsignedInt.getIRI().stringValue(),
+            XSD.xsdLong.getIRI().stringValue(),
+            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdDecimal.getIRI().stringValue(),
+            XSD.xsdShort.getIRI().stringValue(),
+            XSD.xsdUnsignedShort.getIRI().stringValue(),
+            XSD.xsdByte.getIRI().stringValue(),
+            XSD.xsdUnsignedByte.getIRI().stringValue(),
+            XSD.xsdFloat.getIRI().stringValue(),
+            XSD.xsdDouble.getIRI().stringValue());
 
     @Override
     protected String getDiagnosticSource() {
@@ -27,41 +49,49 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
     }
 
     /**
-     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
+     * Checks whether the given term is statically compatible with SPARQL
+     * effective boolean value evaluation.
      */
-    private static boolean checkTermIsPotentialBoolean(TermAst termAst) {
-        if(termAst instanceof BooleanExpressionAst) {
-            return true;
-        }
-        if(termAst instanceof LiteralExpressionAst literalExpressionAst
-                && ! ( literalExpressionAst instanceof XsdDateTimeExpressionAst
-                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
-                || literalExpressionAst instanceof NumericExpressionAst
-            )) { // Is a literal expression that could be a boolean, we cannot know
-            return true;
-        }
-        if(termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
-            return true;
-        }
-        if(termAst instanceof IfAst ifAst
-                && checkTermIsPotentialBoolean(ifAst.thenExpr())
-                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
-            return true;
-        }
-        if(termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {// is a literal that is a typed as a boolean or the string representation of one
-                if(datatype != null) {
-                    if(datatype.equals(XSD.xsdBoolean.getIRI().stringValue())) {
-                        return true;
-                    }
-                } else {
-                    return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
-                }
-        }
-        if(termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
+    private static boolean isPotentiallyEbvCompatible(TermAst termAst) {
+        if (termAst instanceof BooleanExpressionAst
+                || termAst instanceof NumericExpressionAst
+                || termAst instanceof VarAst
+                || termAst instanceof FunctionCallAst
+                || termAst instanceof UnlimitedArgumentsFunctionAst) {
             return true;
         }
 
+        if (termAst instanceof LiteralAst literalAst) {
+            return isEbvCompatibleLiteral(literalAst);
+        }
+
+        if (termAst instanceof IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr)) {
+            return isPotentiallyEbvCompatible(condition)
+                    && isPotentiallyEbvCompatible(thenExpr)
+                    && isPotentiallyEbvCompatible(elseExpr);
+        }
+
+        if (termAst instanceof LiteralExpressionAst literalExpressionAst) {
+            return !(literalExpressionAst instanceof XsdDateTimeExpressionAst
+                    || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst);
+        }
+
         return false;
+    }
+
+    private static boolean isEbvCompatibleLiteral(LiteralAst literalAst) {
+        if (literalAst.lang() != null && !literalAst.lang().isBlank()) {
+            return true;
+        }
+
+        String datatype = literalAst.datatype();
+        if (datatype == null) {
+            return true;
+        }
+
+        return BOOLEAN_DATATYPE.equals(datatype)
+                || STRING_DATATYPE.equals(datatype)
+                || NUMERIC_DATATYPES.contains(datatype);
     }
 
     private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
@@ -73,7 +103,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
 
         @Override
         public void visit(PatternAst patternAst) {
-            if (patternAst instanceof FilterAst(TermAst operator) && !checkTermIsPotentialBoolean(operator)) {
+            if (patternAst instanceof FilterAst(TermAst operator) && !isPotentiallyEbvCompatible(operator)) {
                 result.add(buildIncorrectTypeDiagnostic(operator.getName(), "FILTER", "boolean"));
             }
         }
@@ -81,11 +111,10 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
         @Override
         public void visit(HavingAst havingAst) {
             for (TermAst condition : havingAst.conditions()) {
-                if (!checkTermIsPotentialBoolean(condition)) {
+                if (!isPotentiallyEbvCompatible(condition)) {
                     result.add(buildIncorrectTypeDiagnostic(condition.getName(), "HAVING", "boolean"));
                 }
             }
         }
     }
 }
-

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -114,22 +114,20 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
     class FilterValidationTest {
 
         @Test
-        @DisplayName("Should reject FILTER with numeric operator")
-        void shouldRejectFilterWithNumericOperator() {
+        @DisplayName("Should accept FILTER with numeric operator")
+        void shouldAcceptFilterWithNumericOperator() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           ?x ?p ?o .
                           FILTER(RAND())
                         }
                     """));
-
-            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
-        @DisplayName("Should reject FILTER with IRI operator")
+        @DisplayName("Should reject FILTER with IRI-returning operator")
         void shouldRejectFilterWithIRIOperator() {
             SparqlParser parser = newParserDefault();
 
@@ -159,18 +157,57 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
 
         @Test
-        @DisplayName("Should reject FILTER with datetime duration operator")
-        void shouldRejectFilterWithDuration() {
+        @DisplayName("Should accept FILTER with numeric expression derived from datetime")
+        void shouldAcceptFilterWithDuration() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           ?x ?p ?o .
                           FILTER(DAY(NOW()))
                         }
                     """));
+        }
 
-            assertEquals("DAY used in FILTER should be resolvable to a boolean", exception.getMessage());
+        @Test
+        @DisplayName("Should accept FILTER with plain literal")
+        void shouldAcceptFilterWithPlainLiteral() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER("test")
+                        }
+                    """));
+        }
+
+        @Test
+        @DisplayName("Should accept FILTER with CONCAT result")
+        void shouldAcceptFilterWithConcat() {
+            SparqlParser parser = newParserDefault();
+
+            assertDoesNotThrow(() -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(CONCAT("te", "st"))
+                        }
+                    """));
+        }
+
+        @Test
+        @DisplayName("Should reject FILTER when IF condition is not EBV-compatible")
+        void shouldRejectFilterContainingIfWithIncorrectConditionType() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+                        SELECT * WHERE {
+                          ?x ?p ?o .
+                          FILTER(IF(NOW(), true, false))
+                        }
+                    """));
+
+            assertEquals("IF used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test
@@ -257,11 +294,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
 
         @Test
-        @DisplayName("Should reject FILTER with numeric operator in a nested BGP")
-        void shouldRejectFilterWithNumericOperatorInNestedBGP() {
+        @DisplayName("Should accept FILTER with numeric operator in a nested BGP")
+        void shouldAcceptFilterWithNumericOperatorInNestedBGP() {
             SparqlParser parser = newParserDefault();
 
-            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            assertDoesNotThrow(() -> parser.parse("""
                         SELECT * WHERE {
                           {
                               ?x ?p ?o .
@@ -271,8 +308,6 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
                           }
                         }
                     """));
-
-            assertEquals("RAND used in FILTER should be resolvable to a boolean", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
I think this validation rule is currently stricter than SPARQL 1.1, because it relies on a closed list of AST node types instead of SPARQL Effective Boolean Value (EBV) rules.

According to the W3C SPARQL 1.1 spec, `FILTER` evaluation is based on EBV:
https://www.w3.org/TR/sparql11-query/#ebv

In section 17.2.2, the spec defines EBV for:
- boolean literals
- numeric values
- plain literals and `xsd:string` literals

Other kinds of terms produce a type error at evaluation time.

Because of that, some expressions seem to be rejected too early by the current rule, even though they are EBV-compatible according to the spec. For example:
- `FILTER("abc")`
- `FILTER(RAND())`
- `FILTER(DAY(NOW()))`
- `FILTER(CONCAT("a", "b"))`

These cases are supported by the function definitions in the spec:
- `RAND()` returns `xsd:double` (section 17.4.4.5)
- `DAY()` returns `xsd:integer` (section 17.4.5.4)
- `CONCAT()` returns a string literal (section 17.4.3.12, with string literal return type defined in section 17.4.3.1.3)

There is also one correctness issue with `IF`: the current implementation checks `thenExpr` and `elseExpr`, but not the condition itself. However, section 17.4.1.2 defines the first argument of `IF` as an effective boolean value, so the condition should also be validated for EBV compatibility.

So I think this rule should be aligned with EBV compatibility rather than with a hardcoded list of “boolean-like” AST node classes.