### PR TITLE
412 [SPARQL] Validate operand types in expressions

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/FilterArgumentsValidationRule.java
@@ -1,40 +1,19 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
 
-import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
-import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.*;
 
 /**
  * Validates that FILTER and HAVING expressions are compatible with SPARQL
  * effective boolean value evaluation.
  */
 public final class FilterArgumentsValidationRule extends AbstractSemanticValidationRule {
-
-    private static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
-    private static final String STRING_DATATYPE = XSD.xsdString.getIRI().stringValue();
-    private static final Set<String> NUMERIC_DATATYPES = Set.of(
-            XSD.xsdInteger.getIRI().stringValue(),
-            XSD.xsdNonNegativeInteger.getIRI().stringValue(),
-            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
-            XSD.xsdPositiveInteger.getIRI().stringValue(),
-            XSD.xsdNegativeInteger.getIRI().stringValue(),
-            XSD.xsdInt.getIRI().stringValue(),
-            XSD.xsdUnsignedInt.getIRI().stringValue(),
-            XSD.xsdLong.getIRI().stringValue(),
-            XSD.xsdUnsignedLong.getIRI().stringValue(),
-            XSD.xsdDecimal.getIRI().stringValue(),
-            XSD.xsdShort.getIRI().stringValue(),
-            XSD.xsdUnsignedShort.getIRI().stringValue(),
-            XSD.xsdByte.getIRI().stringValue(),
-            XSD.xsdUnsignedByte.getIRI().stringValue(),
-            XSD.xsdFloat.getIRI().stringValue(),
-            XSD.xsdDouble.getIRI().stringValue());
 
     @Override
     protected String getDiagnosticSource() {
@@ -48,52 +27,6 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
         return visitor.getResult();
     }
 
-    /**
-     * Checks whether the given term is statically compatible with SPARQL
-     * effective boolean value evaluation.
-     */
-    private static boolean isPotentiallyEbvCompatible(TermAst termAst) {
-        if (termAst instanceof BooleanExpressionAst
-                || termAst instanceof NumericExpressionAst
-                || termAst instanceof VarAst
-                || termAst instanceof FunctionCallAst
-                || termAst instanceof UnlimitedArgumentsFunctionAst) {
-            return true;
-        }
-
-        if (termAst instanceof LiteralAst literalAst) {
-            return isEbvCompatibleLiteral(literalAst);
-        }
-
-        if (termAst instanceof IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr)) {
-            return isPotentiallyEbvCompatible(condition)
-                    && isPotentiallyEbvCompatible(thenExpr)
-                    && isPotentiallyEbvCompatible(elseExpr);
-        }
-
-        if (termAst instanceof LiteralExpressionAst literalExpressionAst) {
-            return !(literalExpressionAst instanceof XsdDateTimeExpressionAst
-                    || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst);
-        }
-
-        return false;
-    }
-
-    private static boolean isEbvCompatibleLiteral(LiteralAst literalAst) {
-        if (literalAst.lang() != null && !literalAst.lang().isBlank()) {
-            return true;
-        }
-
-        String datatype = literalAst.datatype();
-        if (datatype == null) {
-            return true;
-        }
-
-        return BOOLEAN_DATATYPE.equals(datatype)
-                || STRING_DATATYPE.equals(datatype)
-                || NUMERIC_DATATYPES.contains(datatype);
-    }
-
     private class FilterArgumentsValidationVisitor extends AbstractAstVisitor {
         private final List<QueryDiagnostic> result = new ArrayList<>();
 
@@ -103,7 +36,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
 
         @Override
         public void visit(PatternAst patternAst) {
-            if (patternAst instanceof FilterAst(TermAst operator) && !isPotentiallyEbvCompatible(operator)) {
+            if (patternAst instanceof FilterAst(TermAst operator) && !isPotentialBooleanCompatible(operator)) {
                 result.add(buildIncorrectTypeDiagnostic(operator.getName(), "FILTER", "boolean"));
             }
         }
@@ -111,7 +44,7 @@ public final class FilterArgumentsValidationRule extends AbstractSemanticValidat
         @Override
         public void visit(HavingAst havingAst) {
             for (TermAst condition : havingAst.conditions()) {
-                if (!isPotentiallyEbvCompatible(condition)) {
+                if (!isPotentialBooleanCompatible(condition)) {
                     result.add(buildIncorrectTypeDiagnostic(condition.getName(), "HAVING", "boolean"));
                 }
             }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
@@ -12,7 +12,8 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.OrAst;
 import java.util.ArrayList;
 import java.util.List;
 
-import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialBoolean;
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.isPotentialBooleanCompatible;
+
 
 public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticValidationRule {
     @Override
@@ -37,17 +38,17 @@ public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticVa
         @Override
         public void visit(TermAst termAst) {
             if(termAst instanceof BooleanNotAst booleanNotAst) {
-                if(! checkTermIsPotentialBoolean( booleanNotAst.argument())) {
+                if(! isPotentialBooleanCompatible( booleanNotAst.argument())) {
                     result.add(buildIncorrectTypeDiagnostic(booleanNotAst.argument().getName(), booleanNotAst.getName(), "boolean"));
                 }
             }
             if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
                 if(binaryConstraintAst instanceof AndAst
                     || binaryConstraintAst instanceof OrAst) {
-                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getLeftArgument())) {
+                    if(! isPotentialBooleanCompatible( binaryConstraintAst.getLeftArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "boolean"));
                     }
-                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getRightArgument())) {
+                    if(! isPotentialBooleanCompatible( binaryConstraintAst.getRightArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "boolean"));
                     }
                 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
@@ -1,0 +1,57 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AndAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BinaryConstraintAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BooleanNotAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.OrAst;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialBoolean;
+
+public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticValidationRule {
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentBooleanTypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandBooleanArgumentTypeVisitor visitor = new OperandBooleanArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandBooleanArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        }
+
+        @Override
+        public void visit(TermAst termAst) {
+            if(termAst instanceof BooleanNotAst booleanNotAst) {
+                if(! checkTermIsPotentialBoolean( booleanNotAst.argument())) {
+                    result.add(buildIncorrectTypeDiagnostic(booleanNotAst.argument().getName(), booleanNotAst.getName(), "boolean"));
+                }
+            }
+            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
+                if(binaryConstraintAst instanceof AndAst
+                    || binaryConstraintAst instanceof OrAst) {
+                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "boolean"));
+                    }
+                    if(! checkTermIsPotentialBoolean( binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "boolean"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentBooleanTypeValidationRule.java
@@ -16,6 +16,8 @@ import static fr.inria.corese.core.next.query.impl.parser.semantic.support.Seman
 
 
 public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticValidationRule {
+    private static final String BOOLEAN_TYPE = "boolean";
+
     @Override
     protected String getDiagnosticSource() {
         return OperandArgumentBooleanTypeValidationRule.class.getSimpleName();
@@ -37,20 +39,27 @@ public class OperandArgumentBooleanTypeValidationRule extends AbstractSemanticVa
 
         @Override
         public void visit(TermAst termAst) {
-            if(termAst instanceof BooleanNotAst booleanNotAst) {
-                if(! isPotentialBooleanCompatible( booleanNotAst.argument())) {
-                    result.add(buildIncorrectTypeDiagnostic(booleanNotAst.argument().getName(), booleanNotAst.getName(), "boolean"));
-                }
+            if (termAst instanceof BooleanNotAst booleanNotAst
+                    && !isPotentialBooleanCompatible(booleanNotAst.argument())) {
+                result.add(buildIncorrectTypeDiagnostic(
+                        booleanNotAst.argument().getName(),
+                        booleanNotAst.getName(),
+                        BOOLEAN_TYPE));
             }
-            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
-                if(binaryConstraintAst instanceof AndAst
-                    || binaryConstraintAst instanceof OrAst) {
-                    if(! isPotentialBooleanCompatible( binaryConstraintAst.getLeftArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "boolean"));
-                    }
-                    if(! isPotentialBooleanCompatible( binaryConstraintAst.getRightArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "boolean"));
-                    }
+
+            if (termAst instanceof BinaryConstraintAst binaryConstraintAst
+                    && (binaryConstraintAst instanceof AndAst || binaryConstraintAst instanceof OrAst)) {
+                if (!isPotentialBooleanCompatible(binaryConstraintAst.getLeftArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getLeftArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            BOOLEAN_TYPE));
+                }
+                if (!isPotentialBooleanCompatible(binaryConstraintAst.getRightArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getRightArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            BOOLEAN_TYPE));
                 }
             }
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -37,17 +37,22 @@ public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValida
 
         @Override
         public void visit(TermAst termAst) {
-            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
-                if(binaryConstraintAst instanceof LowerThanAst
+            if (termAst instanceof BinaryConstraintAst binaryConstraintAst
+                    && (binaryConstraintAst instanceof LowerThanAst
                     || binaryConstraintAst instanceof LowerOrEqualThanAst
                     || binaryConstraintAst instanceof GreaterThanAst
-                    || binaryConstraintAst instanceof GreaterOrEqualThanAst) {
-                    if(isPotentialIri(binaryConstraintAst.getLeftArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
-                    }
-                    if(isPotentialIri(binaryConstraintAst.getRightArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
-                    }
+                    || binaryConstraintAst instanceof GreaterOrEqualThanAst)) {
+                if (isPotentialIri(binaryConstraintAst.getLeftArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getLeftArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            "not an IRI"));
+                }
+                if (isPotentialIri(binaryConstraintAst.getRightArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getRightArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            "not an IRI"));
                 }
             }
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -1,0 +1,56 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialIri;
+
+/**
+ * Check that the comparison operand do not compare IRIs (except for the different != operator)
+ */
+public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValidationRule {
+
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentIRITypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandIRIArgumentTypeVisitor visitor = new OperandIRIArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandIRIArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        }
+
+        @Override
+        public void visit(TermAst termAst) {
+            if(termAst instanceof BinaryConstraintAst binaryConstraintAst) {
+                if(binaryConstraintAst instanceof LowerThanAst
+                    || binaryConstraintAst instanceof LowerOrEqualThanAst
+                    || binaryConstraintAst instanceof GreaterThanAst
+                    || binaryConstraintAst instanceof GreaterOrEqualThanAst) {
+                    if(checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
+                    }
+                    if(checkTermIsPotentialIri(binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentIRITypeValidationRule.java
@@ -9,7 +9,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialIri;
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.isPotentialIri;
 
 /**
  * Check that the comparison operand do not compare IRIs (except for the different != operator)
@@ -42,10 +42,10 @@ public class OperandArgumentIRITypeValidationRule extends AbstractSemanticValida
                     || binaryConstraintAst instanceof LowerOrEqualThanAst
                     || binaryConstraintAst instanceof GreaterThanAst
                     || binaryConstraintAst instanceof GreaterOrEqualThanAst) {
-                    if(checkTermIsPotentialIri(binaryConstraintAst.getLeftArgument())) {
+                    if(isPotentialIri(binaryConstraintAst.getLeftArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
                     }
-                    if(checkTermIsPotentialIri(binaryConstraintAst.getRightArgument())) {
+                    if(isPotentialIri(binaryConstraintAst.getRightArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "not an IRI"));
                     }
                 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -9,7 +9,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialNumeric;
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.isPotentialNumeric;
 
 /**
  * Check that the operands and numeric functions use numeric arguments
@@ -45,7 +45,7 @@ public final class OperandArgumentNumericTypeValidationRule extends AbstractSema
                                 || unaryConstraintAst instanceof RoundAst
                                 || unaryConstraintAst instanceof UnaryMinusAst
                                 || unaryConstraintAst instanceof UnaryPlusAst)
-                                && !checkTermIsPotentialNumeric(unaryConstraintAst.argument())) {
+                                && !isPotentialNumeric(unaryConstraintAst.argument())) {
                     result.add(buildIncorrectTypeDiagnostic(unaryConstraintAst.argument().getName(), unaryConstraintAst.getName(), "numeric"));
                 }
             }
@@ -56,10 +56,10 @@ public final class OperandArgumentNumericTypeValidationRule extends AbstractSema
                         || binaryConstraintAst instanceof MultiplyAst
                         || binaryConstraintAst instanceof SubtractAst
                 ) {
-                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
+                    if (!isPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
                     }
-                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getRightArgument())) {
+                    if (!isPotentialNumeric(binaryConstraintAst.getRightArgument())) {
                         result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
                     }
                 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -1,0 +1,69 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.rule;
+
+import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AbstractAstVisitor;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.checkTermIsPotentialNumeric;
+
+/**
+ * Check that the operands and numeric functions use numeric arguments
+ */
+public final class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
+
+    @Override
+    protected String getDiagnosticSource() {
+        return OperandArgumentNumericTypeValidationRule.class.getSimpleName();
+    }
+
+    @Override
+    public List<QueryDiagnostic> validate(QueryAst queryAst) {
+        OperandNumericArgumentTypeVisitor visitor = new OperandNumericArgumentTypeVisitor();
+        queryAst.accept(visitor);
+        return visitor.getResult();
+    }
+
+    private class OperandNumericArgumentTypeVisitor extends AbstractAstVisitor {
+        private final List<QueryDiagnostic> result = new ArrayList<>();
+
+        public List<QueryDiagnostic> getResult() {
+            return result;
+        }
+
+        @Override
+        public void visit(TermAst termAst) {
+            if (termAst instanceof UnaryConstraintAst unaryConstraintAst) {
+                if (
+                        (unaryConstraintAst instanceof AbsAst
+                                || unaryConstraintAst instanceof CeilAst
+                                || unaryConstraintAst instanceof FloorAst
+                                || unaryConstraintAst instanceof RoundAst
+                                || unaryConstraintAst instanceof UnaryMinusAst
+                                || unaryConstraintAst instanceof UnaryPlusAst)
+                                && !checkTermIsPotentialNumeric(unaryConstraintAst.argument())) {
+                    result.add(buildIncorrectTypeDiagnostic(unaryConstraintAst.argument().getName(), unaryConstraintAst.getName(), "numeric"));
+                }
+            }
+
+            if (termAst instanceof BinaryConstraintAst binaryConstraintAst) { // Numeric only operands
+                if (binaryConstraintAst instanceof AddAst
+                        || binaryConstraintAst instanceof DivideAst
+                        || binaryConstraintAst instanceof MultiplyAst
+                        || binaryConstraintAst instanceof SubtractAst
+                ) {
+                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
+                    }
+                    if (!checkTermIsPotentialNumeric(binaryConstraintAst.getRightArgument())) {
+                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/rule/OperandArgumentNumericTypeValidationRule.java
@@ -15,6 +15,7 @@ import static fr.inria.corese.core.next.query.impl.parser.semantic.support.Seman
  * Check that the operands and numeric functions use numeric arguments
  */
 public final class OperandArgumentNumericTypeValidationRule extends AbstractSemanticValidationRule {
+    private static final String NUMERIC_TYPE = "numeric";
 
     @Override
     protected String getDiagnosticSource() {
@@ -37,31 +38,36 @@ public final class OperandArgumentNumericTypeValidationRule extends AbstractSema
 
         @Override
         public void visit(TermAst termAst) {
-            if (termAst instanceof UnaryConstraintAst unaryConstraintAst) {
-                if (
-                        (unaryConstraintAst instanceof AbsAst
-                                || unaryConstraintAst instanceof CeilAst
-                                || unaryConstraintAst instanceof FloorAst
-                                || unaryConstraintAst instanceof RoundAst
-                                || unaryConstraintAst instanceof UnaryMinusAst
-                                || unaryConstraintAst instanceof UnaryPlusAst)
-                                && !isPotentialNumeric(unaryConstraintAst.argument())) {
-                    result.add(buildIncorrectTypeDiagnostic(unaryConstraintAst.argument().getName(), unaryConstraintAst.getName(), "numeric"));
-                }
+            if (termAst instanceof UnaryConstraintAst unaryConstraintAst
+                    && (unaryConstraintAst instanceof AbsAst
+                    || unaryConstraintAst instanceof CeilAst
+                    || unaryConstraintAst instanceof FloorAst
+                    || unaryConstraintAst instanceof RoundAst
+                    || unaryConstraintAst instanceof UnaryMinusAst
+                    || unaryConstraintAst instanceof UnaryPlusAst)
+                    && !isPotentialNumeric(unaryConstraintAst.argument())) {
+                result.add(buildIncorrectTypeDiagnostic(
+                        unaryConstraintAst.argument().getName(),
+                        unaryConstraintAst.getName(),
+                        NUMERIC_TYPE));
             }
 
-            if (termAst instanceof BinaryConstraintAst binaryConstraintAst) { // Numeric only operands
-                if (binaryConstraintAst instanceof AddAst
-                        || binaryConstraintAst instanceof DivideAst
-                        || binaryConstraintAst instanceof MultiplyAst
-                        || binaryConstraintAst instanceof SubtractAst
-                ) {
-                    if (!isPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getLeftArgument().getName(), binaryConstraintAst.getName(), "numeric"));
-                    }
-                    if (!isPotentialNumeric(binaryConstraintAst.getRightArgument())) {
-                        result.add(buildIncorrectTypeDiagnostic(binaryConstraintAst.getRightArgument().getName(), binaryConstraintAst.getName(), "numeric"));
-                    }
+            if (termAst instanceof BinaryConstraintAst binaryConstraintAst
+                    && (binaryConstraintAst instanceof AddAst
+                    || binaryConstraintAst instanceof DivideAst
+                    || binaryConstraintAst instanceof MultiplyAst
+                    || binaryConstraintAst instanceof SubtractAst)) {
+                if (!isPotentialNumeric(binaryConstraintAst.getLeftArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getLeftArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            NUMERIC_TYPE));
+                }
+                if (!isPotentialNumeric(binaryConstraintAst.getRightArgument())) {
+                    result.add(buildIncorrectTypeDiagnostic(
+                            binaryConstraintAst.getRightArgument().getName(),
+                            binaryConstraintAst.getName(),
+                            NUMERIC_TYPE));
                 }
             }
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -38,6 +38,9 @@ public class SemanticValidationUtils {
             XSD.xsdFloat.getIRI().stringValue(),
             XSD.xsdDouble.getIRI().stringValue());
 
+    private SemanticValidationUtils() {
+    }
+
     public static boolean isBooleanCompatible(LiteralAst literalAst) {
         if (literalAst.lang() != null && !literalAst.lang().isBlank()) {
             return true;
@@ -115,17 +118,9 @@ public class SemanticValidationUtils {
      *
      */
     public static boolean isUnknownType(TermAst termAst) {
-        if (termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
-            return true;
-        }
-        if (termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
-            return true;
-        }
-        if(termAst instanceof SimpleLiteralExpressionAst) { // Could be a string un-typed but still representing a known type. will be filtered at resolution
-            return true;
-        }
-
-        return false;
+        return termAst instanceof VarAst
+                || termAst instanceof FunctionCallAst
+                || termAst instanceof SimpleLiteralExpressionAst;
     }
 
     /**
@@ -136,7 +131,7 @@ public class SemanticValidationUtils {
             return false;
         }
         try {
-            double d = Double.parseDouble(lexical);
+            Double.parseDouble(lexical);
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.support;
 
+import fr.inria.corese.core.next.data.impl.common.vocabulary.RDF;
 import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
@@ -7,78 +8,92 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 
-import java.util.List;
+import java.util.Set;
 
 public class SemanticValidationUtils {
+
+    public static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
+    public static final Set<String> STRING_DATATYPE = Set.of(
+            XSD.xsdString.getIRI().stringValue(),
+            RDF.langString.getIRI().stringValue());
 
     /**
      * Valid numeric datatypes as defined in https://www.w3.org/TR/sparql11-query/#operandDataTypes
      */
-    private static final List<String> validNumericDatatypes = List.of(
+    public static final Set<String> NUMERIC_DATATYPES = Set.of(
             XSD.xsdInteger.getIRI().stringValue(),
-            XSD.xsdDecimal.getIRI().stringValue(),
-            XSD.xsdFloat.getIRI().stringValue(),
-            XSD.xsdDouble.getIRI().stringValue(),
-            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
-            XSD.xsdNegativeInteger.getIRI().stringValue(),
-            XSD.xsdLong.getIRI().stringValue(),
-            XSD.xsdInt.getIRI().stringValue(),
-            XSD.xsdShort.getIRI().stringValue(),
-            XSD.xsdByte.getIRI().stringValue(),
             XSD.xsdNonNegativeInteger.getIRI().stringValue(),
-            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
+            XSD.xsdPositiveInteger.getIRI().stringValue(),
+            XSD.xsdNegativeInteger.getIRI().stringValue(),
+            XSD.xsdInt.getIRI().stringValue(),
             XSD.xsdUnsignedInt.getIRI().stringValue(),
+            XSD.xsdLong.getIRI().stringValue(),
+            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdDecimal.getIRI().stringValue(),
+            XSD.xsdShort.getIRI().stringValue(),
             XSD.xsdUnsignedShort.getIRI().stringValue(),
+            XSD.xsdByte.getIRI().stringValue(),
             XSD.xsdUnsignedByte.getIRI().stringValue(),
-            XSD.xsdPositiveInteger.getIRI().stringValue()
-    );
+            XSD.xsdFloat.getIRI().stringValue(),
+            XSD.xsdDouble.getIRI().stringValue());
+
+    public static boolean isBooleanCompatible(LiteralAst literalAst) {
+        if (literalAst.lang() != null && !literalAst.lang().isBlank()) {
+            return true;
+        }
+
+        String datatype = literalAst.datatype();
+        if (datatype == null) {
+            return true;
+        }
+
+        return BOOLEAN_DATATYPE.equals(datatype)
+                || STRING_DATATYPE.contains(datatype)
+                || NUMERIC_DATATYPES.contains(datatype);
+    }
 
     /**
-     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
+     * Checks whether the given term is statically compatible with SPARQL
+     * effective boolean value evaluation.
      */
-    public static boolean checkTermIsPotentialBoolean(TermAst termAst) {
-        if (checkTermIsUnknownType(termAst)) {
+    public static boolean isPotentialBooleanCompatible(TermAst termAst) {
+        if (termAst instanceof BooleanExpressionAst
+                || termAst instanceof NumericExpressionAst
+                || termAst instanceof VarAst
+                || termAst instanceof FunctionCallAst
+                || termAst instanceof UnlimitedArgumentsFunctionAst) {
             return true;
         }
-        if (termAst instanceof BooleanExpressionAst) {
-            return true;
+
+        if (termAst instanceof LiteralAst literalAst) {
+            return isBooleanCompatible(literalAst);
         }
-        if (termAst instanceof LiteralExpressionAst literalExpressionAst
-                && !(literalExpressionAst instanceof XsdDateTimeExpressionAst
-                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
-                || literalExpressionAst instanceof NumericExpressionAst
-        )) { // Is a literal expression that could be a boolean, we cannot know
-            return true;
+
+        if (termAst instanceof IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr)) {
+            return isPotentialBooleanCompatible(condition)
+                    && isPotentialBooleanCompatible(thenExpr)
+                    && isPotentialBooleanCompatible(elseExpr);
         }
-        if (termAst instanceof IfAst ifAst
-                && checkTermIsPotentialBoolean(ifAst.thenExpr())
-                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
-            return true;
-        }
-        if (termAst instanceof LiteralAst(
-                String lexical, String lang, String datatype
-        )) {// is a literal that is a typed as a boolean or the string representation of one
-            if (datatype != null) {
-                return datatype.equals(XSD.xsdBoolean.getIRI().stringValue());
-            } else {
-                return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
-            }
+
+        if (termAst instanceof LiteralExpressionAst literalExpressionAst) {
+            return !(literalExpressionAst instanceof XsdDateTimeExpressionAst
+                    || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst);
         }
 
         return false;
     }
 
-
     /**
      * Check that the given term is either numeric expression, literal expression typed by a standard numeric datatype, a literal that can be parsed to a numeric or a variable
      */
-    public static boolean checkTermIsPotentialNumeric(TermAst termAst) {
-        if (checkTermIsUnknownType(termAst)) {
+    public static boolean isPotentialNumeric(TermAst termAst) {
+        if (isUnknownType(termAst)) {
             return true;
         }
         if (termAst instanceof IfAst ifAst
-                && checkTermIsPotentialNumeric(ifAst.thenExpr())
-                && checkTermIsPotentialNumeric(ifAst.elseExpr())) { // Is an IF that returns potential numerics
+                && isPotentialNumeric(ifAst.thenExpr())
+                && isPotentialNumeric(ifAst.elseExpr())) { // Is an IF that returns potential numerics
             return true;
         }
         if (termAst instanceof NumericExpressionAst) { // Is a literal expression that could be a numeric, we cannot know
@@ -86,9 +101,9 @@ public class SemanticValidationUtils {
         }
         if (termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {
             if(datatype != null) {
-                return validNumericDatatypes.contains(datatype); // Datatype is an URI of an standard numeric datatype
+                return NUMERIC_DATATYPES.contains(datatype); // Datatype is an URI of an standard numeric datatype
             } else {
-                return checkStringIsNumeric(lexical); // The string value can be parsed to a numeric value
+                return isNumeric(lexical); // The string value can be parsed to a numeric value
             }
         }
 
@@ -99,7 +114,7 @@ public class SemanticValidationUtils {
      * Check if the given term type cannot be determined at query parsing, it will be checked at query resolution.
      *
      */
-    public static boolean checkTermIsUnknownType(TermAst termAst) {
+    public static boolean isUnknownType(TermAst termAst) {
         if (termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
             return true;
         }
@@ -116,7 +131,7 @@ public class SemanticValidationUtils {
     /**
      * Tries to parse the string as a Double
      */
-    public static boolean checkStringIsNumeric(String lexical) {
+    public static boolean isNumeric(String lexical) {
         if (lexical == null) {
             return false;
         }
@@ -131,13 +146,33 @@ public class SemanticValidationUtils {
     /**
      * Check if the term is either a variable or an IRI or an expression that can be resolved to an IRI
      */
-    public static boolean checkTermIsPotentialIri(TermAst termAst) {
+    public static boolean isPotentialIri(TermAst termAst) {
         if(termAst instanceof IriAst) { // Is an IRI
             return true;
         }
-        if(termAst instanceof IriExpressionAst) { // Is a function that can be resolved to an IRI
-            return true;
+        // Is a function that can be resolved to an IRI
+        return termAst instanceof IriExpressionAst;
+    }
+
+    /**
+     * Check if the term is a literal that can be considered as a string argument as defined in the SPARQL 1.1 recommendation
+     */
+    public static boolean isStringLiteral(TermAst termAst) {
+        if(termAst instanceof LiteralAst(String lexical, String lang, String datatype) && lexical != null) {
+            if(lang != null) {
+                return true;
+            }
+            if(datatype == null) {
+                return true;
+            }
+            if(STRING_DATATYPE.contains(datatype)) {
+                return true;
+            }
         }
         return false;
+    }
+
+    public static boolean isPotentialStringLiteral(TermAst termAst) {
+        return isUnknownType(termAst) || isStringLiteral(termAst) || termAst instanceof SimpleLiteralExpressionAst;
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -1,0 +1,143 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+
+import java.util.List;
+
+public class SemanticValidationUtils {
+
+    /**
+     * Valid numeric datatypes as defined in https://www.w3.org/TR/sparql11-query/#operandDataTypes
+     */
+    private static final List<String> validNumericDatatypes = List.of(
+            XSD.xsdInteger.getIRI().stringValue(),
+            XSD.xsdDecimal.getIRI().stringValue(),
+            XSD.xsdFloat.getIRI().stringValue(),
+            XSD.xsdDouble.getIRI().stringValue(),
+            XSD.xsdNonPositiveInteger.getIRI().stringValue(),
+            XSD.xsdNegativeInteger.getIRI().stringValue(),
+            XSD.xsdLong.getIRI().stringValue(),
+            XSD.xsdInt.getIRI().stringValue(),
+            XSD.xsdShort.getIRI().stringValue(),
+            XSD.xsdByte.getIRI().stringValue(),
+            XSD.xsdNonNegativeInteger.getIRI().stringValue(),
+            XSD.xsdUnsignedLong.getIRI().stringValue(),
+            XSD.xsdUnsignedInt.getIRI().stringValue(),
+            XSD.xsdUnsignedShort.getIRI().stringValue(),
+            XSD.xsdUnsignedByte.getIRI().stringValue(),
+            XSD.xsdPositiveInteger.getIRI().stringValue()
+    );
+
+    /**
+     * Check that the given term is either boolean expression, literal expression (that may return a boolean result) or a variable
+     */
+    public static boolean checkTermIsPotentialBoolean(TermAst termAst) {
+        if (checkTermIsUnknownType(termAst)) {
+            return true;
+        }
+        if (termAst instanceof BooleanExpressionAst) {
+            return true;
+        }
+        if (termAst instanceof LiteralExpressionAst literalExpressionAst
+                && !(literalExpressionAst instanceof XsdDateTimeExpressionAst
+                || literalExpressionAst instanceof XsdDayTimeDurationExpressionAst
+                || literalExpressionAst instanceof NumericExpressionAst
+        )) { // Is a literal expression that could be a boolean, we cannot know
+            return true;
+        }
+        if (termAst instanceof IfAst ifAst
+                && checkTermIsPotentialBoolean(ifAst.thenExpr())
+                && checkTermIsPotentialBoolean(ifAst.elseExpr())) { // Is a IF that returns potential booleans
+            return true;
+        }
+        if (termAst instanceof LiteralAst(
+                String lexical, String lang, String datatype
+        )) {// is a literal that is a typed as a boolean or the string representation of one
+            if (datatype != null) {
+                return datatype.equals(XSD.xsdBoolean.getIRI().stringValue());
+            } else {
+                return lexical.trim().equalsIgnoreCase("true") || lexical.trim().equalsIgnoreCase("false");
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Check that the given term is either numeric expression, literal expression typed by a standard numeric datatype, a literal that can be parsed to a numeric or a variable
+     */
+    public static boolean checkTermIsPotentialNumeric(TermAst termAst) {
+        if (checkTermIsUnknownType(termAst)) {
+            return true;
+        }
+        if (termAst instanceof IfAst ifAst
+                && checkTermIsPotentialNumeric(ifAst.thenExpr())
+                && checkTermIsPotentialNumeric(ifAst.elseExpr())) { // Is an IF that returns potential numerics
+            return true;
+        }
+        if (termAst instanceof NumericExpressionAst) { // Is a literal expression that could be a numeric, we cannot know
+            return true;
+        }
+        if (termAst instanceof LiteralAst(String lexical, String lang, String datatype)) {
+            if(datatype != null) {
+                return validNumericDatatypes.contains(datatype); // Datatype is an URI of an standard numeric datatype
+            } else {
+                return checkStringIsNumeric(lexical); // The string value can be parsed to a numeric value
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the given term type cannot be determined at query parsing, it will be checked at query resolution.
+     *
+     */
+    public static boolean checkTermIsUnknownType(TermAst termAst) {
+        if (termAst instanceof VarAst) { // Is a variable that can be resolved to a boolean
+            return true;
+        }
+        if (termAst instanceof FunctionCallAst) { // Is a function call that could return a boolean, we cannot know
+            return true;
+        }
+        if(termAst instanceof SimpleLiteralExpressionAst) { // Could be a string un-typed but still representing a known type. will be filtered at resolution
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to parse the string as a Double
+     */
+    public static boolean checkStringIsNumeric(String lexical) {
+        if (lexical == null) {
+            return false;
+        }
+        try {
+            double d = Double.parseDouble(lexical);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check if the term is either a variable or an IRI or an expression that can be resolved to an IRI
+     */
+    public static boolean checkTermIsPotentialIri(TermAst termAst) {
+        if(termAst instanceof IriAst) { // Is an IRI
+            return true;
+        }
+        if(termAst instanceof IriExpressionAst) { // Is a function that can be resolved to an IRI
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -119,8 +119,7 @@ public class SemanticValidationUtils {
      */
     public static boolean isUnknownType(TermAst termAst) {
         return termAst instanceof VarAst
-                || termAst instanceof FunctionCallAst
-                || termAst instanceof SimpleLiteralExpressionAst;
+                || termAst instanceof FunctionCallAst;
     }
 
     /**

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtils.java
@@ -12,15 +12,15 @@ import java.util.Set;
 
 public class SemanticValidationUtils {
 
-    public static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
-    public static final Set<String> STRING_DATATYPE = Set.of(
+    private static final String BOOLEAN_DATATYPE = XSD.xsdBoolean.getIRI().stringValue();
+    private static final Set<String> STRING_DATATYPE = Set.of(
             XSD.xsdString.getIRI().stringValue(),
             RDF.langString.getIRI().stringValue());
 
     /**
      * Valid numeric datatypes as defined in https://www.w3.org/TR/sparql11-query/#operandDataTypes
      */
-    public static final Set<String> NUMERIC_DATATYPES = Set.of(
+    private static final Set<String> NUMERIC_DATATYPES = Set.of(
             XSD.xsdInteger.getIRI().stringValue(),
             XSD.xsdNonNegativeInteger.getIRI().stringValue(),
             XSD.xsdNonPositiveInteger.getIRI().stringValue(),
@@ -172,6 +172,10 @@ public class SemanticValidationUtils {
         return false;
     }
 
+
+    /**
+     * Check if the term is either a variable or a literal that can be considered as a string argument as defined in the SPARQL 1.1 recommendation
+     */
     public static boolean isPotentialStringLiteral(TermAst termAst) {
         return isUnknownType(termAst) || isStringLiteral(termAst) || termAst instanceof SimpleLiteralExpressionAst;
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/semantic/validator/SparqlQuerySemanticValidator.java
@@ -3,15 +3,7 @@ package fr.inria.corese.core.next.query.impl.parser.semantic.validator;
 import fr.inria.corese.core.next.query.api.validation.QueryDiagnostic;
 import fr.inria.corese.core.next.query.api.validation.QueryValidationResult;
 import fr.inria.corese.core.next.query.api.validation.QueryValidator;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.FilterArgumentsValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.GroupByScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.GroupedHavingValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.GroupedOrderByValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.GroupedSelectProjectionValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.HavingScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.OrderByScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SelectProjectionScopeValidationRule;
-import fr.inria.corese.core.next.query.impl.parser.semantic.rule.SemanticValidationRule;
+import fr.inria.corese.core.next.query.impl.parser.semantic.rule.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
 
 import java.util.ArrayList;
@@ -34,7 +26,10 @@ public final class SparqlQuerySemanticValidator implements QueryValidator<QueryA
                 new GroupByScopeValidationRule(),
                 new HavingScopeValidationRule(),
                 new OrderByScopeValidationRule(),
-                new FilterArgumentsValidationRule()));
+                new FilterArgumentsValidationRule(),
+                new OperandArgumentNumericTypeValidationRule(),
+                new OperandArgumentBooleanTypeValidationRule(),
+                new OperandArgumentIRITypeValidationRule()));
     }
 
     /** Package-private for tests or future composition of rule sets. */

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestAst.java
@@ -20,7 +20,8 @@ public record UpdateRequestAst(QueryPrologueAst prologue, List<UpdateRequestUnit
 
     @Override
     public void accept(AstVisitor visitor) {
-        visitor.visit(this.prologue);
+        visitor.visit(this);
+        this.prologue.accept(visitor);
         this.operations.forEach(updateRequestUnitAst -> updateRequestUnitAst.accept(visitor));
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/ConcatAst.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Function {@code CONCAT(expr1, expr2, ...)} in SPARQL 1.1.
  */
-public class ConcatAst extends AbstractUnlimitedArgumentsFunctionAst {
+public class ConcatAst extends AbstractUnlimitedArgumentsFunctionAst implements SimpleLiteralExpressionAst {
 
     public ConcatAst(List<TermAst> arguments) {
         super(arguments);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
@@ -11,11 +11,9 @@ import java.util.List;
  * Function {@code sameTerm(term1, term2)}
  */
 public class SameTermAst extends AbstractBinaryFunctionAst implements BooleanExpressionAst {
-    private static final Logger logger = LoggerFactory.getLogger(SameTermAst.class);
 
     public SameTermAst(List<TermAst> args) {
         super(args);
-        logger.debug("{}", args);
         if (args.size() != 2) {
             throw new QuerySyntaxException("Unexpected number of arguments for sameTerm function");
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/SameTermAst.java
@@ -2,8 +2,6 @@ package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrLenAst.java
@@ -8,7 +8,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
  * Function {@code STRLEN(string)} in SPARQL 1.1
  * Returns the length of a string.
  */
-public class StrLenAst extends AbstractUnaryConstraintAst {
+public class StrLenAst extends AbstractUnaryConstraintAst implements NumericExpressionAst {
 
     public StrLenAst(TermAst arg) {
         super(arg);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
@@ -1,13 +1,12 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 
 /**
  * Function {@code STRUUID()} in SPARQL 1.1
  * Returns a string form of a UUID.
  */
-public record StrUuidAst() implements ConstraintAst, SimpleLiteralExpressionAst {
+public record StrUuidAst() implements SimpleLiteralExpressionAst {
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/StrUuidAst.java
@@ -7,7 +7,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
  * Function {@code STRUUID()} in SPARQL 1.1
  * Returns a string form of a UUID.
  */
-public record StrUuidAst() implements ConstraintAst {
+public record StrUuidAst() implements ConstraintAst, SimpleLiteralExpressionAst {
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
@@ -7,7 +7,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
  * Function {@code UUID()} in SPARQL 1.1
  * Returns a fresh IRI from the UUID URN scheme.
  */
-public record UuidAst() implements ConstraintAst {
+public record UuidAst() implements ConstraintAst, IriExpressionAst {
 
     @Override
     public String getName() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/UuidAst.java
@@ -1,13 +1,12 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
 
 import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
 
 /**
  * Function {@code UUID()} in SPARQL 1.1
  * Returns a fresh IRI from the UUID URN scheme.
  */
-public record UuidAst() implements ConstraintAst, IriExpressionAst {
+public record UuidAst() implements IriExpressionAst {
 
     @Override
     public String getName() {

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserFilterTest.java
@@ -483,7 +483,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s < <http://example.com>)
+                  FILTER(?s < 2)
                 }
                 """);
 
@@ -501,11 +501,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         LowerThanAst t = (LowerThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("2", literalAst.lexical());
     }
 
     @Test
@@ -515,7 +515,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s <= <http://example.com>)
+                  FILTER(?s <= 3)
                 }
                 """);
 
@@ -533,11 +533,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         LowerOrEqualThanAst t = (LowerOrEqualThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("3", literalAst.lexical());
     }
 
     @Test
@@ -547,7 +547,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s > <http://example.com>)
+                  FILTER(?s > 4)
                 }
                 """);
 
@@ -565,11 +565,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         GreaterThanAst t = (GreaterThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("4", literalAst.lexical());
     }
 
     @Test
@@ -579,7 +579,7 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse("""
                 SELECT * WHERE {
                   ?s ?p ?o .
-                  FILTER(?s >= <http://example.com>)
+                  FILTER(?s >= 5)
                 }
                 """);
 
@@ -597,11 +597,11 @@ class SparqlParserFilterTest extends AbstractSparqlParserFeatureTest {
 
         GreaterOrEqualThanAst t = (GreaterOrEqualThanAst) filterAst.operator();
 
-        assertInstanceOf(VarAst.class, t.getLeftArgument());
-        assertInstanceOf(IriAst.class, t.getRightArgument());
+        VarAst varAst = assertInstanceOf(VarAst.class, t.getLeftArgument());
+        LiteralAst literalAst = assertInstanceOf(LiteralAst.class, t.getRightArgument());
 
-        assertEquals("s", ((VarAst) t.getLeftArgument()).name());
-        assertEquals("<http://example.com>", ((IriAst) t.getRightArgument()).raw());
+        assertEquals("s", varAst.name());
+        assertEquals("5", literalAst.lexical());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -345,6 +345,274 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
         }
     }
 
+    @Nested
+    public class OperandTypeTest {
+
+        @Test
+        @DisplayName("Should accept + operator with numerics")
+        void shouldAcceptPlusWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(RAND() + 1 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept - operator with numerics")
+        void shouldAcceptMinusWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") - 1 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept * operator with numerics")
+        void shouldAcceptMultiplyWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") * RAND() = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept / operator with numerics")
+        void shouldAcceptDivideWithNumerics() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(DAY(NOW()) / 2 = ?o)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject + operator with non numerics")
+        void shouldRefusePlusWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(RAND() + "one" = ?o)
+                           }
+                        """);
+            });
+            assertEquals("\"one\" used in + should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject - operator with non numerics")
+        void shouldRejectMinusWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER((3 - STRENDS("test", "")) = ?o)
+                           }
+                        """);
+            });
+            assertEquals("STRENDS used in - should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject * operator with non numerics")
+        void shouldRejectDivideWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(<http://ns.inria.fr/test> / 2 = ?o)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in / should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject / operator with non numerics")
+        void shouldRejectMultiplyWithNonNumerics() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") * NOW() = ?o)
+                           }
+                        """);
+            });
+            assertEquals("NOW used in * should be resolvable to a numeric", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should accept || operator with booleans")
+        void shouldAcceptOrWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(IsIri(?s) || false)
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should accept && operator with booleans")
+        void shouldAcceptAndWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(NOT EXISTS { ?s ?p false } && STRSTARTS("test", "t"))
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject || operator with non booleans")
+        void shouldRejectOrWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(IsIri(?s) || "potato")
+                           }
+                        """);
+            });
+            assertEquals("\"potato\" used in || should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject && operator with non booleans")
+        void shouldRejectAndWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(<http://ns.inria.fr/test> && langMatches("potato", "fr"))
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in && should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should accept ! operator with booleans")
+        void shouldAcceptNotWithBoolean() {
+            SparqlParser parser = newParserDefault();
+            assertDoesNotThrow(() -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(! NOT EXISTS { ?s ?p false } && STRSTARTS("test", "t"))
+                           }
+                        """);
+            });
+        }
+
+        @Test
+        @DisplayName("Should reject ! operator with non booleans")
+        void shouldRejectNotWithNonBoolean() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(! <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in ! should be resolvable to a boolean", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject < operator with IRIs")
+        void shouldRejectLTWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(2 < <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in < should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject <= operator with IRIs")
+        void shouldRejectLTEWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(STRLEN("test") <= <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in <= should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject > operator with IRIs")
+        void shouldRejectGTWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER("2"^^<http://www.w3.org/2001/XMLSchema#integer> > <http://ns.inria.fr/test>)
+                           }
+                        """);
+            });
+            assertEquals("<http://ns.inria.fr/test> used in > should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should reject >= operator with IRIs")
+        void shouldRejectGTEWithIRIs() {
+            SparqlParser parser = newParserDefault();
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> {
+                parser.parse("""
+                           SELECT * WHERE {
+                             ?x ?p ?o .
+                             FILTER(datatype("2"^^<http://www.w3.org/2001/XMLSchema#integer>) >= 4)
+                           }
+                        """);
+            });
+            assertEquals("DATATYPE used in >= should be resolvable to a not an IRI", exception.getMessage());
+        }
+
+    }
+
     private static Stream<Arguments> invalidSelectQueries() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -146,6 +146,19 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
     @Nested
     class FilterValidationTest {
+        @Test
+        void shouldRejectConcatUsedAsNumericOperand() {
+            SparqlParser parser = newParserDefault();
+
+            QueryValidationException exception = assertThrows(QueryValidationException.class, () -> parser.parse("""
+            SELECT * WHERE {
+              ?x ?p ?o .
+              FILTER(CONCAT("1", "2") + 1 = ?o)
+            }
+            """));
+
+            assertEquals("CONCAT used in + should be resolvable to a numeric", exception.getMessage());
+        }
 
         @Test
         @DisplayName("Should accept FILTER with numeric operator")

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/SparqlParserValidationTest.java
@@ -500,11 +500,11 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
                 parser.parse("""
                            SELECT * WHERE {
                              ?x ?p ?o .
-                             FILTER(IsIri(?s) || "potato")
+                             FILTER(IsIri(?s) || "potato"^^<http://ns.inria.fr/vegetable>)
                            }
                         """);
             });
-            assertEquals("\"potato\" used in || should be resolvable to a boolean", exception.getMessage());
+            assertEquals("\"potato\"^^<http://ns.inria.fr/vegetable> used in || should be resolvable to a boolean", exception.getMessage());
         }
 
         @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.parser.semantic.support;
 
+import fr.inria.corese.core.next.data.impl.common.vocabulary.RDF;
 import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
 import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
@@ -16,43 +17,57 @@ class SemanticValidationUtilsTest {
 
     @Test
     void checkTermIsPotentialBooleanTest() {
-        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("true", null, null)));
-        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("potato", null, XSD.xsdBoolean.getIRI().stringValue())));
-        assertTrue(checkTermIsPotentialBoolean(new AndAst(List.of(new LiteralAst("true", null, null), new LiteralAst("true", null, null)))));
-        assertTrue(checkTermIsPotentialBoolean(new VarAst("test")));
-        assertFalse(checkTermIsPotentialBoolean(new IriAst("<http://ns.inria.de/test>")));
-        assertFalse(checkTermIsPotentialBoolean(new NowAst()));
+        assertTrue(isPotentialBooleanCompatible(new LiteralAst("true", null, null)));
+        assertTrue(isPotentialBooleanCompatible(new LiteralAst("potato", null, XSD.xsdBoolean.getIRI().stringValue())));
+        assertTrue(isPotentialBooleanCompatible(new AndAst(List.of(new LiteralAst("true", null, null), new LiteralAst("true", null, null)))));
+        assertTrue(isPotentialBooleanCompatible(new VarAst("test")));
+        assertFalse(isPotentialBooleanCompatible(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(isPotentialBooleanCompatible(new NowAst()));
     }
 
     @Test
-    void checkTermIsPotentialNumericTest() {
-        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("1", null, null)));
-        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("abc", null, XSD.xsdDouble.getIRI().stringValue())));
-        assertTrue(checkTermIsPotentialNumeric(new VarAst("test")));
-        assertFalse(checkTermIsPotentialNumeric(new IriAst("<http://ns.inria.de/test>")));
-        assertFalse(checkTermIsPotentialNumeric(new NowAst()));
-        assertTrue(checkTermIsPotentialNumeric(new AddAst(List.of(new LiteralAst("1", null, null), new LiteralAst("2", null, null)))));
+    void isPotentialNumericTest() {
+        assertTrue(isPotentialNumeric(new LiteralAst("1", null, null)));
+        assertTrue(isPotentialNumeric(new LiteralAst("abc", null, XSD.xsdDouble.getIRI().stringValue())));
+        assertTrue(isPotentialNumeric(new VarAst("test")));
+        assertFalse(isPotentialNumeric(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(isPotentialNumeric(new NowAst()));
+        assertTrue(isPotentialNumeric(new AddAst(List.of(new LiteralAst("1", null, null), new LiteralAst("2", null, null)))));
     }
 
     @Test
-    void checkTermIsUnknownTypeTest() {
-        assertTrue(checkTermIsUnknownType(new VarAst("test")));
-        assertFalse(checkTermIsUnknownType(new LiteralAst("true", null, null)));
-        assertFalse(checkTermIsUnknownType(new NowAst()));
+    void isUnknownTypeTest() {
+        assertTrue(isUnknownType(new VarAst("test")));
+        assertFalse(isUnknownType(new LiteralAst("true", null, null)));
+        assertFalse(isUnknownType(new NowAst()));
     }
 
     @Test
-    void checkStringIsNumericTest() {
-        assertTrue(checkStringIsNumeric("1"));
-        assertFalse(checkStringIsNumeric("Potato"));
+    void isNumericTest() {
+        assertTrue(isNumeric("1"));
+        assertFalse(isNumeric("Potato"));
     }
 
     @Test
-    void checkTermIsPotentialIriTest() {
-        assertTrue(checkTermIsPotentialIri(new IriAst("<http://ns.inria.de/test>")));
-        assertTrue(checkTermIsPotentialIri(new DatatypeAst(List.of(new LiteralAst("1", null, null)))));
-        assertFalse(checkTermIsPotentialIri(new VarAst("test")));
-        assertFalse(checkTermIsPotentialIri(new LiteralAst("1", null, null)));
-        assertFalse(checkTermIsPotentialIri(new NowAst()));
+    void isPotentialIriTest() {
+        assertTrue(isPotentialIri(new IriAst("<http://ns.inria.de/test>")));
+        assertTrue(isPotentialIri(new DatatypeAst(List.of(new LiteralAst("1", null, null)))));
+        assertFalse(isPotentialIri(new VarAst("test")));
+        assertFalse(isPotentialIri(new LiteralAst("1", null, null)));
+        assertFalse(isPotentialIri(new NowAst()));
+    }
+
+    @Test
+    void isPotentialStringLiteralTest() {
+        assertTrue(isPotentialStringLiteral(new LiteralAst("test", null, null)));
+        assertTrue(isPotentialStringLiteral(new LiteralAst("test", "en", null)));
+        assertTrue(isPotentialStringLiteral(new LiteralAst("test", null, RDF.langString.getIRI().stringValue())));
+        assertTrue(isPotentialStringLiteral(new LiteralAst("test", null, XSD.xsdString.getIRI().stringValue())));
+        assertTrue(isPotentialStringLiteral(new VarAst("test")));
+        assertTrue(isPotentialStringLiteral(new ConcatAst(List.of())));
+        assertFalse(isPotentialStringLiteral(new LiteralAst("test", null, XSD.xsdDouble.getIRI().stringValue())));
+        assertFalse(isPotentialStringLiteral(new DatatypeAst(List.of(new LiteralAst("1", null, null)))));
+        assertFalse(isPotentialStringLiteral(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(isPotentialStringLiteral(new NowAst()));
     }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/parser/semantic/support/SemanticValidationUtilsTest.java
@@ -1,0 +1,58 @@
+package fr.inria.corese.core.next.query.impl.parser.semantic.support;
+
+import fr.inria.corese.core.next.data.impl.common.vocabulary.XSD;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static fr.inria.corese.core.next.query.impl.parser.semantic.support.SemanticValidationUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SemanticValidationUtilsTest {
+
+    @Test
+    void checkTermIsPotentialBooleanTest() {
+        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("true", null, null)));
+        assertTrue(checkTermIsPotentialBoolean(new LiteralAst("potato", null, XSD.xsdBoolean.getIRI().stringValue())));
+        assertTrue(checkTermIsPotentialBoolean(new AndAst(List.of(new LiteralAst("true", null, null), new LiteralAst("true", null, null)))));
+        assertTrue(checkTermIsPotentialBoolean(new VarAst("test")));
+        assertFalse(checkTermIsPotentialBoolean(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(checkTermIsPotentialBoolean(new NowAst()));
+    }
+
+    @Test
+    void checkTermIsPotentialNumericTest() {
+        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("1", null, null)));
+        assertTrue(checkTermIsPotentialNumeric(new LiteralAst("abc", null, XSD.xsdDouble.getIRI().stringValue())));
+        assertTrue(checkTermIsPotentialNumeric(new VarAst("test")));
+        assertFalse(checkTermIsPotentialNumeric(new IriAst("<http://ns.inria.de/test>")));
+        assertFalse(checkTermIsPotentialNumeric(new NowAst()));
+        assertTrue(checkTermIsPotentialNumeric(new AddAst(List.of(new LiteralAst("1", null, null), new LiteralAst("2", null, null)))));
+    }
+
+    @Test
+    void checkTermIsUnknownTypeTest() {
+        assertTrue(checkTermIsUnknownType(new VarAst("test")));
+        assertFalse(checkTermIsUnknownType(new LiteralAst("true", null, null)));
+        assertFalse(checkTermIsUnknownType(new NowAst()));
+    }
+
+    @Test
+    void checkStringIsNumericTest() {
+        assertTrue(checkStringIsNumeric("1"));
+        assertFalse(checkStringIsNumeric("Potato"));
+    }
+
+    @Test
+    void checkTermIsPotentialIriTest() {
+        assertTrue(checkTermIsPotentialIri(new IriAst("<http://ns.inria.de/test>")));
+        assertTrue(checkTermIsPotentialIri(new DatatypeAst(List.of(new LiteralAst("1", null, null)))));
+        assertFalse(checkTermIsPotentialIri(new VarAst("test")));
+        assertFalse(checkTermIsPotentialIri(new LiteralAst("1", null, null)));
+        assertFalse(checkTermIsPotentialIri(new NowAst()));
+    }
+}


### PR DESCRIPTION
Adds checks on functions that will only accept numerics an booleans. Other types can be assumed to be string if reduced to their lexical values.
The argument count is already checked during the parsing step.