### PR TITLE
Feature/473 autonomous next query pipeline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.compile.JavaCompile
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -54,7 +55,7 @@ javacc {
 sourceSets {
     main {
         java {
-            setSrcDirs(listOf("src/main/java", javaccGeneratedDir, antlrPackageDir))
+            setSrcDirs(listOf("src/main/java", javaccGeneratedDir, antlrGeneratedDir))
         }
     }
 }
@@ -306,11 +307,15 @@ tasks.named("compileJava") {
     dependsOn("generateGrammarSource", "javaccSparqlCorese")
 }
 
+tasks.named<JavaCompile>("compileJava") {
+    source(antlrPackageDir)
+}
+
 // Ensure sources JAR includes generated sources and depends on code generation
 tasks.named<Jar>("sourcesJar") {
     dependsOn("generateGrammarSource", "generateTestGrammarSource", "javaccSparqlCorese")
     from(javaccGeneratedDir)
-    from(antlrPackageDir)
+    from(antlrGeneratedDir)
     includeEmptyDirs = false
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/next-pipeline-issue-roadmap.md
+++ b/next-pipeline-issue-roadmap.md
@@ -1,0 +1,910 @@
+# Roadmap des futures PR Corese-next
+
+Ce document sert de carte de travail pour organiser les prochaines PR autour de
+la pipeline Corese-next.
+
+Il relie trois sources :
+
+- les PR et issues ouvertes dans `corese-stack/corese-core` ;
+- le travail deja fait dans la branche `feature/472-bridge-storage-manager-producer` ;
+- les limites visibles dans le code `next` actuel.
+
+## 1. Contexte actuel
+
+### Branche d'integration
+
+La branche de travail / integration du chantier est :
+
+```text
+feature/corese-next
+```
+
+Les PR de feature doivent donc viser `feature/corese-next`, sauf quand une PR
+est volontairement empilee sur une autre PR en cours.
+
+### PR actuellement ouvertes
+
+| PR | Branche | Base | Role |
+| --- | --- | --- | --- |
+| [#482](https://github.com/corese-stack/corese-core/pull/482) | `feature/472-bridge-storage-manager-producer` | `feature/corese-next` | Connecter KGRAM next au nouveau `StorageManager` pour SPO/BGP (Fusionnée / Merged) |
+| [#484](https://github.com/corese-stack/corese-core/pull/484) | `feature/473-autonomous-next-query-pipeline` | `feature/corese-next` | Premiere pipeline autonome next, réalignée sur `feature/corese-next` après merge de #482 (draft/review pédagogique en cours) |
+| [#483](https://github.com/corese-stack/corese-core/pull/483) | `feature/470-bridge-add-minusoptional-conversion` | `feature/corese-next` | Conversion bridge de `MINUS` / `OPTIONAL` (Fusionnée / Merged) |
+| [#463](https://github.com/corese-stack/corese-core/pull/463) | `feature/335-property-path-parser-and-ast` | `feature/corese-next` | Parser/AST des property paths (En cours de review / merge par Abdessamad, non bloquante pour le rebase de #484) |
+
+### Issues ouvertes liees a la roadmap
+
+| Issue | Sujet | Role dans cette roadmap |
+| --- | --- | --- |
+| [#472](https://github.com/corese-stack/corese-core/issues/472) | Producer KGRAM -> StorageManager | Couverte par #482, correspond a `A1` |
+| [#473](https://github.com/corese-stack/corese-core/issues/473) | Execution autonome des types de requetes via next | Couverte par #484, correspond a `B1`, `B2`, debut `B3`, `B5`, `E1`, `F2` |
+| [#470](https://github.com/corese-stack/corese-core/issues/470) | Conversion `MINUS` / `OPTIONAL` | Couverte par #483, prepare `C2` et `C4` |
+| [#453](https://github.com/corese-stack/corese-core/issues/453) | `EXISTS` / `NOT EXISTS` dans les filtres | Liee a `C1` |
+| [#474](https://github.com/corese-stack/corese-core/issues/474) | Mecanisme d'appel de fonctions | Liee a `C1`, `C5`, `D1` |
+| [#335](https://github.com/corese-stack/corese-core/issues/335) | Parser/AST des property paths | Couverte par #463 cote parser/AST, prepare `C8` |
+| [#328](https://github.com/corese-stack/corese-core/issues/328) | Parser/AST `INSERT` / `DELETE` | Liee a `E1` et `E4` |
+| [#373](https://github.com/corese-stack/corese-core/issues/373) | Parser/AST `DROP` | Liee a `E2` |
+| [#374](https://github.com/corese-stack/corese-core/issues/374) | Parser/AST `COPY` | Liee a `E3` |
+| [#375](https://github.com/corese-stack/corese-core/issues/375) | Parser/AST `MOVE` | Liee a `E3` |
+| [#376](https://github.com/corese-stack/corese-core/issues/376) | Parser/AST `ADD` | Liee a `E3` |
+
+### Travail deja fait dans #482
+
+La branche courante contient notamment :
+
+- `feat(next): connect KGRAM producer to StorageManager`
+- `fix(next): restore KGRAM fail semantics`
+- `fix(next): honor named dataset for graph patterns`
+- `refactor(next): centralize storage KGRAM value conversion`
+- `test(next): cover storage producer edge cases`
+- `test(next): avoid order-dependent storage assertion`
+
+Ces commits apportent :
+
+- un `StorageManagerProducer` pour interroger le nouveau storage depuis KGRAM ;
+- un `StorageManagerEdge` pour exposer les `Statement` storage comme `Edge`
+  KGRAM next ;
+- un helper `StorageManagerKgramValues` pour centraliser les conversions entre
+  `Value`, `IDatatype` et `Node` ;
+- le support SPO/BGP simple, y compris les bindings deja presents ;
+- le respect de `GRAPH <g>` et des restrictions `FROM` / dataset nomme ;
+- un fail-fast explicite pour paths/regex non supportes ;
+- des tests sur SPO, BGP, graphes, dataset, conversions et cas RDF impossibles.
+
+### Limites visibles dans le code
+
+Le code actuel montre encore plusieurs zones explicitement non supportees :
+
+- paths/regex dans `StorageManagerProducer#getEdges(... Regex ...)` ;
+- `VALUES`, `SELECT` expressions, `GROUP BY`, `HAVING`, `REDUCED` dans
+  `CoreseAstQueryBuilder` ;
+- execution runtime complete de `FILTER`, `OPTIONAL`, `UNION`, `BIND`,
+  `SERVICE`, `MINUS` selon le niveau attendu ;
+- updates plus larges que le support minimal ;
+- hooks `Producer` encore a clarifier : `start`, `finish`, `getGraph`,
+  conversions, `isBindable` ;
+- dependances legacy encore presentes : `IDatatype`, legacy `Binding`,
+  legacy-backed values.
+
+## 2. Plan operationnel dans l'ordre
+
+Cette section donne l'ordre concret des actions a executer. Les epics detailles
+sont plus bas.
+
+### Phase 1 - Terminer #482
+
+- [x] Attendre que les checks de #482 soient verts.
+- [x] Verifier que le commentaire Copilot sur l'assertion dependante de l'ordre est bien corrige par le commit `0cffbf617`.
+- [x] Resoudre manuellement la conversation Copilot si GitHub ne le fait pas tout seul.
+- [x] Demander ou reprendre la review humaine finale sur #482.
+- [x] Merger #482 dans `feature/corese-next`.
+
+### Phase 2 - Realigner les PR existantes
+
+- [x] Mettre a jour localement `feature/corese-next`.
+- [x] Rebaser #483 sur `feature/corese-next` si necessaire.
+- [x] Rebaser #484 sur `feature/corese-next`, car elle etait basee
+  sur la branche #482.
+- [x] Rebaser #463 sur `feature/corese-next` si necessaire.
+
+### Phase 3 - Traiter #483
+
+- [x] Verifier #483 : conversion `MINUS` / `OPTIONAL` (PR approuvée).
+- [x] Relancer les tests bridge/parser concernes.
+- [x] Verifier que #483 compile l'AST vers KGRAM sans promettre encore
+  l'execution runtime complete.
+- [x] Merger #483 dans `feature/corese-next`.
+
+### Phase 4 - Reprendre #484
+
+- [x] Relancer les tests de #484 apres rebase.
+- [x] Relire le diff de #484 apres disparition du diff de #482.
+- [x] Nettoyer les erreurs unsupported et les placeholders locaux au scope #484
+      apres rebase.
+- [ ] Decider si #484 reste une seule PR ou si elle doit etre decoupee.
+- [ ] Si #484 reste une seule PR, garder le scope "premiere pipeline autonome
+  next" et clarifier dans la PR que ce n'est pas encore l'API publique finale.
+- [ ] Si #484 est trop grosse, la decouper en PR plus petites :
+  - configuration Gradle/ANTLR ;
+  - `UnsupportedQueryFeatureException` ;
+  - `INSERT DATA` / `DELETE DATA` ;
+  - `CONSTRUCT` / `DESCRIBE` ;
+  - `NextSparqlPipelineExecutor`.
+- [ ] Faire la review finale de #484.
+- [ ] Merger #484 dans `feature/corese-next`.
+
+### Phase 5 - Traiter #463
+
+- [x] Verifier #463 : parser/AST des property paths (PR approuvée).
+- [x] S'assurer que la PR ne promet que parser/AST, pas runtime.
+- [x] Ajouter ou verifier les tests parser/AST.
+- [ ] Merger #463 dans `feature/corese-next` (Demandé à Abdessamad).
+
+### Phase 6 - Creer les nouvelles issues structurantes
+
+- [ ] Creer l'issue `[NEXT][KGRAM] Clarifier le comportement des hooks Producer`.
+- [ ] Creer l'issue `[NEXT][KGRAM] Supporter les graphes variables`.
+- [ ] Creer l'issue `[NEXT][SPARQL API] Definir l'API haut niveau`.
+- [ ] Creer l'issue `[NEXT][RUNTIME] Decouper l'executor temporaire`.
+- [ ] Creer l'issue `[NEXT][TESTS] Creer une suite end-to-end SPARQL next`.
+
+### Phase 7 - Etendre le runtime SPARQL
+
+- [ ] Faire une PR `GRAPH ?g` / graphes variables.
+- [ ] Faire une PR `FILTER` end to end.
+- [ ] Faire une PR `OPTIONAL` runtime end to end.
+- [ ] Faire une PR `MINUS` runtime end to end.
+- [ ] Faire une PR `UNION` runtime end to end.
+- [ ] Faire une PR `BIND` runtime end to end.
+- [ ] Faire une PR `VALUES` runtime end to end.
+- [ ] Faire une PR `ORDER BY / LIMIT / OFFSET` end to end.
+- [ ] Faire une PR `CONSTRUCT` avance avec blank nodes.
+- [ ] Faire une PR `DESCRIBE` stabilise.
+- [ ] Faire une PR `property paths` runtime.
+
+### Phase 8 - SPARQL Update
+
+- [ ] Stabiliser `INSERT DATA` / `DELETE DATA`.
+- [ ] Ajouter `CLEAR`, `CREATE`, `DROP`, `LOAD`.
+- [ ] Ajouter `COPY`, `MOVE`, `ADD`.
+- [ ] Ajouter `DELETE/INSERT WHERE`.
+- [ ] Ajouter une strategie transactionnelle si necessaire.
+
+### Phase 9 - Dette technique
+
+- [ ] Remplacer progressivement les RDF values legacy-backed.
+- [ ] Reduire la dependance a `IDatatype` dans KGRAM next.
+- [ ] Nettoyer les placeholders `return null` / `Not supported yet` restants
+      hors scope #484, notamment dans la dette KGRAM-next historique.
+- [ ] Isoler `GraphStorageManager` comme backend de compatibilite legacy.
+- [ ] Corriger l'erreur JaCoCo / Java major version 70 en CI.
+
+### Resume court
+
+```text
+1. Finaliser #482
+2. Merger #482 dans feature/corese-next
+3. Rebaser #484 sur feature/corese-next
+4. Reprendre #483 et #463
+5. Decider si #484 reste entiere ou est decoupee
+6. Creer les nouvelles issues runtime/API/tests
+7. Avancer feature par feature
+```
+
+## 3. Strategie pour #484
+
+La PR [#484](https://github.com/corese-stack/corese-core/pull/484) contient deja
+beaucoup du travail de l'issue [#473](https://github.com/corese-stack/corese-core/issues/473).
+Elle ne doit pas etre jetee : elle doit etre traitee comme une PR empilee.
+
+Contenu actuel repere :
+
+- configuration Gradle/IDE des sources ANTLR generees ;
+- `UnsupportedQueryFeatureException` ;
+- AST/parser pour `INSERT DATA` et `DELETE DATA` ;
+- support `CONSTRUCT` dans `CoreseAstQueryBuilder` ;
+- `NextSparqlPipelineExecutor` ;
+- tests end-to-end SELECT, ASK, CONSTRUCT, DESCRIBE, INSERT DATA, DELETE DATA.
+
+Plan conseille :
+
+1. Garder #484 en draft tant que le scope n'est pas stabilise.
+2. Merger #482 dans `feature/corese-next`. (fait)
+3. Rebaser #484 sur `feature/corese-next`. (fait)
+4. Relancer les tests end-to-end. (fait localement)
+5. Decider si #484 reste une seule PR de demonstration autonome ou si elle est
+   decoupee avant revue finale.
+
+Decoupage possible si #484 est jugee trop large :
+
+- PR courte 1 : configuration Gradle/IDE des sources ANTLR generees.
+- PR courte 2 : `UnsupportedQueryFeatureException` et erreurs unsupported propres.
+- PR courte 3 : `INSERT DATA` / `DELETE DATA` parser + AST + execution minimale.
+- PR courte 4 : `CONSTRUCT` / `DESCRIBE` end-to-end minimal.
+- PR courte 5 : `NextSparqlPipelineExecutor` comme executor interne temporaire.
+
+Decision recommandee :
+Garder #484 comme PR stacked pour l'instant, puis reevaluer apres rebase sur
+`feature/corese-next`. Si le diff reste lisible et coherent avec #473, on peut
+la garder. Si la revue devient difficile, on splitte selon les blocs ci-dessus.
+
+## 4. Backlog organise par epics
+
+### Epic A - Stabiliser la pipeline StorageManager/KGRAM
+
+#### A1. `[NEXT][KGRAM] Finaliser le producer StorageManager SPO/BGP`
+
+References :
+
+- Issue existante : [#472](https://github.com/corese-stack/corese-core/issues/472)
+- PR existante : [#482](https://github.com/corese-stack/corese-core/pull/482)
+
+Description courte :
+Stabiliser la PR actuelle : KGRAM peut lire des triples depuis `StorageManager`
+et produire des `Mappings` pour des BGP simples.
+
+Sous-issues :
+
+- Valider les commentaires de review.
+- Garder les tests non dependants de l'ordre des resultats storage.
+- Documenter clairement les limites actuelles : BGP uniquement, pas paths,
+  pas service, pas values.
+
+Critere de sortie :
+La PR #482 est mergee et les tests `StorageManagerProducerTest` /
+`StorageManagerEdgeTest` passent en CI.
+
+#### A2. `[NEXT][KGRAM] Clarifier le comportement des hooks Producer`
+
+Description courte :
+Faire une passe dediee sur les methodes heritees de `Producer` qui retournent
+encore `null` ou des implementations minimales.
+
+Sous-issues :
+
+- Revoir `start(Query)` et `finish(Query)` : confirmer qu'ils ne portent pas
+  encore de transaction.
+- Revoir `getGraph()` : decider s'il doit rester `null`, exposer une facade,
+  ou etre explicitement unsupported.
+- Revoir `getNode`, `getValue`, `getDatatypeValue`, `isBindable`.
+- Ajouter des tests quand un comportement est attendu par KGRAM.
+
+Pourquoi :
+Ces methodes viennent en partie de l'ancien contrat Producer. Elles ne bloquent
+pas le SPO/BGP, mais elles doivent etre explicites avant d'elargir la pipeline.
+
+#### A3. `[NEXT][KGRAM] Supporter les graphes variables`
+
+Description courte :
+Stabiliser `GRAPH ?g { ... }` de bout en bout avec `getGraphNodes(...)`.
+
+Sous-issues :
+
+- Tester `GRAPH ?g { ?s ?p ?o }`.
+- Verifier l'interaction avec `FROM NAMED`.
+- Verifier l'interaction avec les graphes par defaut.
+- Confirmer le comportement avec graphes nommes IRI et blank nodes selon le
+  modele RDF/SPARQL supporte.
+
+Critere de sortie :
+Les graphes variables retournent des mappings corrects et respectent le dataset
+actif.
+
+### Epic B - Executer les formes de requetes SPARQL end to end
+
+#### B1. `[NEXT][QUERY] Executer SELECT via parser -> AST -> KGRAM -> StorageManager`
+
+References :
+
+- Issue existante : [#473](https://github.com/corese-stack/corese-core/issues/473)
+- PR existante : [#484](https://github.com/corese-stack/corese-core/pull/484)
+
+Description courte :
+Faire de `SELECT` la premiere forme de requete end-to-end stable.
+
+Sous-issues :
+
+- `SELECT * WHERE { ?s ?p ?o }`
+- projection explicite simple : `SELECT ?s ?o`
+- projection avec variables absentes : erreur claire
+- `DISTINCT`
+- `ORDER BY`, `LIMIT`, `OFFSET`
+- dataset `FROM` / `FROM NAMED`
+
+Critere de sortie :
+Une API interne peut executer SELECT sans fallback `QueryProcess`.
+
+#### B2. `[NEXT][QUERY] Executer ASK end to end`
+
+References :
+
+- Issue existante : [#473](https://github.com/corese-stack/corese-core/issues/473)
+- PR existante : [#484](https://github.com/corese-stack/corese-core/pull/484)
+
+Description courte :
+Executer les requetes ASK avec la nouvelle pipeline.
+
+Sous-issues :
+
+- ASK vrai/faux sur BGP simple.
+- ASK avec dataset.
+- ASK avec BGP vide.
+- Verifier les clauses actuellement rejetees : values, group by, having,
+  distinct/reduced.
+
+Critere de sortie :
+ASK retourne un booleen coherent avec les mappings produits par KGRAM.
+
+#### B3. `[NEXT][QUERY] Executer CONSTRUCT end to end`
+
+References :
+
+- Issue existante : [#473](https://github.com/corese-stack/corese-core/issues/473)
+- PR existante : [#484](https://github.com/corese-stack/corese-core/pull/484),
+  selon son scope final.
+
+Description courte :
+Produire un resultat graphe depuis un template CONSTRUCT.
+
+Sous-issues :
+
+- Template triple simple.
+- Template avec plusieurs triples.
+- Variables non bindees dans le template.
+- Graphes nommes si supportes dans la forme actuelle.
+- Conversion `Mappings -> Statement`.
+
+Critere de sortie :
+CONSTRUCT retourne un `GraphQueryResult`/modele next sans fallback legacy.
+
+#### B4. `[NEXT][CONSTRUCT] Supporter les blank nodes dans les templates`
+
+Description courte :
+Respecter la regle SPARQL : les blank nodes du template CONSTRUCT doivent etre
+recrees par solution mapping.
+
+Sous-issues :
+
+- Identifier les blank nodes du template.
+- Allouer des blank nodes frais par mapping.
+- Tester plusieurs solutions qui utilisent le meme blank node de template.
+
+Pourquoi :
+Ce point est assez specifique pour meriter une PR separee de CONSTRUCT simple.
+
+#### B5. `[NEXT][QUERY] Definir et stabiliser DESCRIBE`
+
+References :
+
+- Issue existante : [#473](https://github.com/corese-stack/corese-core/issues/473)
+- PR existante : [#484](https://github.com/corese-stack/corese-core/pull/484),
+  selon son scope final.
+
+Description courte :
+Remplacer la strategie minimale actuelle de DESCRIBE par un comportement decide
+et teste.
+
+Sous-issues :
+
+- `DESCRIBE <iri>`.
+- `DESCRIBE ?s WHERE { ... }`.
+- `DESCRIBE *`.
+- Triples sortants seulement ou sortants + entrants.
+- Comportement avec graphes nommes.
+
+Critere de sortie :
+La semantique DESCRIBE est documentee et stable.
+
+### Epic C - Ajouter les patterns SPARQL 1.1 dans le runtime
+
+#### C1. `[NEXT][FILTER] Executer FILTER end to end`
+
+References :
+
+- Issue liee : [#453](https://github.com/corese-stack/corese-core/issues/453)
+  pour `EXISTS` / `NOT EXISTS` dans les filtres.
+- Issue liee : [#474](https://github.com/corese-stack/corese-core/issues/474)
+  pour le mecanisme d'appel de fonctions.
+
+Description courte :
+Faire fonctionner les filtres compiles par `WhereCompiler` et
+`SparqlAstToExpression` dans la pipeline StorageManager.
+
+Sous-issues :
+
+- Comparaisons simples : `=`, `!=`, `<`, `>`.
+- `BOUND`, `isIRI`, `isBlank`, `isLiteral`.
+- operations booleennes `&&`, `||`, `!`.
+- fonctions string simples : `STR`, `LANG`, `DATATYPE`.
+- erreurs d'evaluation SPARQL.
+
+Critere de sortie :
+Un BGP filtre produit les memes mappings attendus que la semantique SPARQL.
+
+#### C2. `[NEXT][OPTIONAL] Executer OPTIONAL end to end`
+
+References :
+
+- Issue existante : [#470](https://github.com/corese-stack/corese-core/issues/470)
+- PR existante : [#483](https://github.com/corese-stack/corese-core/pull/483)
+  pour la conversion bridge.
+
+Description courte :
+Activer le left join KGRAM pour `OPTIONAL`.
+
+Sous-issues :
+
+- optional simple.
+- optional qui matche.
+- optional qui ne matche pas.
+- optional avec variable deja bindee.
+- optional + filter.
+
+#### C3. `[NEXT][UNION] Executer UNION end to end`
+
+Description courte :
+Executer les branches `UNION` compilees par `WhereCompiler`.
+
+Sous-issues :
+
+- deux branches simples.
+- variables communes.
+- variables presentes dans une seule branche.
+- interaction avec projection explicite.
+
+#### C4. `[NEXT][MINUS] Executer MINUS end to end`
+
+References :
+
+- Issue existante : [#470](https://github.com/corese-stack/corese-core/issues/470)
+- PR existante : [#483](https://github.com/corese-stack/corese-core/pull/483)
+  pour la conversion bridge.
+
+Description courte :
+Verifier et stabiliser le comportement de `MINUS`.
+
+Sous-issues :
+
+- minus simple.
+- variables partagees.
+- absence de variables partagees.
+- interaction avec graphes nommes.
+
+#### C5. `[NEXT][BIND] Executer BIND end to end`
+
+References :
+
+- Issue liee : [#474](https://github.com/corese-stack/corese-core/issues/474)
+  pour le mecanisme d'appel de fonctions.
+
+Description courte :
+Produire de nouvelles bindings depuis une expression SPARQL.
+
+Sous-issues :
+
+- expression constante.
+- expression dependante d'une variable.
+- variable deja bindee : comportement d'erreur.
+- interaction avec projection.
+
+#### C6. `[NEXT][VALUES] Executer VALUES end to end`
+
+Description courte :
+Remplacer les rejets actuels `VALUES is not supported yet` par une vraie
+integration runtime.
+
+Sous-issues :
+
+- values inline dans WHERE.
+- values clause hors WHERE.
+- `UNDEF`.
+- plusieurs lignes de values.
+- interaction avec BGP et FILTER.
+
+Pourquoi :
+`CoreseAstQueryBuilder` rejette explicitement `VALUES` aujourd'hui.
+
+#### C7. `[NEXT][SERVICE] Definir le support SERVICE`
+
+Description courte :
+Decider si `SERVICE` est supporte dans next maintenant, et sous quelle forme.
+
+Sous-issues :
+
+- `SERVICE <endpoint>`.
+- `SERVICE SILENT`.
+- erreurs reseau.
+- streaming ou materialisation.
+- politique de securite/configuration.
+
+Critere de sortie :
+Soit SERVICE fonctionne, soit l'erreur unsupported est explicite et testee.
+
+#### C8. `[NEXT][PROPERTY PATHS] Supporter les property paths`
+
+References :
+
+- Issue existante : [#335](https://github.com/corese-stack/corese-core/issues/335)
+- PR existante : [#463](https://github.com/corese-stack/corese-core/pull/463)
+  pour parser/AST.
+- Nouvelle issue runtime conseillee : execution KGRAM/storage des property
+  paths.
+
+Description courte :
+Implementer le chemin `Regex`/path aujourd'hui explicitement unsupported dans
+`StorageManagerProducer#getEdges(... Regex ...)`.
+
+Sous-issues :
+
+- paths simples `/`.
+- alternatives `|`.
+- inverse `^`.
+- cardinalites `*`, `+`, `?`.
+- detection de cycles.
+- tests de non-regression sur le fail-fast actuel.
+
+Pourquoi :
+Copilot avait raison sur ce point dans la PR #482 : mieux vaut fail-fast tant
+que ce n'est pas implemente. La prochaine etape est de le supporter vraiment.
+
+### Epic D - Solution modifiers et expressions avancees
+
+#### D1. `[NEXT][SELECT] Supporter les expressions de projection`
+
+References :
+
+- Issue liee : [#474](https://github.com/corese-stack/corese-core/issues/474)
+  pour le mecanisme d'appel de fonctions.
+
+Description courte :
+Supporter `SELECT (expr AS ?x)` aujourd'hui rejete par
+`CoreseAstQueryBuilder`.
+
+Sous-issues :
+
+- alias simple.
+- reutilisation de variables.
+- erreur si alias deja visible.
+- interaction avec ORDER BY.
+
+#### D2. `[NEXT][ORDER] Stabiliser ORDER BY, LIMIT, OFFSET`
+
+Description courte :
+Verifier les modifiers deja copies dans `Query` et ajouter les tests runtime
+end-to-end.
+
+Sous-issues :
+
+- order ascendant.
+- order descendant.
+- order sur variable non projetee.
+- limit seul.
+- offset seul.
+- limit + offset.
+
+#### D3. `[NEXT][AGGREGATES] Supporter GROUP BY / HAVING / aggregates`
+
+Description courte :
+Ajouter les agregats SPARQL dans la pipeline next.
+
+Sous-issues :
+
+- `COUNT`.
+- `SUM`, `MIN`, `MAX`, `AVG`.
+- `GROUP BY`.
+- `HAVING`.
+- projection d'agregats.
+- erreurs de scope.
+
+Pourquoi :
+Le parser et les validations existent deja en partie, mais le bridge/runtime
+rejette encore `GROUP BY` et `HAVING`.
+
+#### D4. `[NEXT][REDUCED] Decider la politique REDUCED`
+
+Description courte :
+Decider si `REDUCED` est implemente, ignore de facon documentee, ou rejete.
+
+Sous-issues :
+
+- politique compatible SPARQL.
+- tests.
+- documentation dans l'API.
+
+### Epic E - Updates SPARQL
+
+#### E1. `[NEXT][UPDATE] Stabiliser INSERT DATA / DELETE DATA`
+
+References :
+
+- Issue existante : [#328](https://github.com/corese-stack/corese-core/issues/328)
+- PR partiellement liee : [#484](https://github.com/corese-stack/corese-core/pull/484)
+  contient deja un debut de support `INSERT DATA` / `DELETE DATA`.
+
+Description courte :
+Consolider le support minimal d'updates sur le nouveau storage.
+
+Sous-issues :
+
+- IRI absolus.
+- prefixed names.
+- `BASE` et IRI relatifs.
+- literals types.
+- literals avec langue.
+- `GRAPH` blocks.
+- tests de mutation storage.
+
+#### E2. `[NEXT][UPDATE] Supporter CLEAR / CREATE / DROP / LOAD`
+
+References :
+
+- Issue existante liee a `DROP` :
+  [#373](https://github.com/corese-stack/corese-core/issues/373)
+
+Description courte :
+Ajouter les operations de gestion de graphes.
+
+Sous-issues :
+
+- `CREATE GRAPH`.
+- `DROP GRAPH`.
+- `CLEAR GRAPH`.
+- `CLEAR DEFAULT`.
+- `CLEAR ALL`.
+- `LOAD`.
+
+#### E3. `[NEXT][UPDATE] Supporter COPY / MOVE / ADD`
+
+References :
+
+- Issue existante liee a `COPY` :
+  [#374](https://github.com/corese-stack/corese-core/issues/374)
+- Issue existante liee a `MOVE` :
+  [#375](https://github.com/corese-stack/corese-core/issues/375)
+- Issue existante liee a `ADD` :
+  [#376](https://github.com/corese-stack/corese-core/issues/376)
+
+Description courte :
+Ajouter les operations entre graphes.
+
+Sous-issues :
+
+- source/destination graph.
+- default graph.
+- graph absent.
+- operations no-op.
+
+#### E4. `[NEXT][UPDATE] Supporter DELETE/INSERT WHERE`
+
+Description courte :
+Executer les updates qui combinent une evaluation WHERE et une mutation.
+
+Sous-issues :
+
+- `DELETE WHERE`.
+- `DELETE { ... } INSERT { ... } WHERE { ... }`.
+- blank nodes dans templates.
+- atomicite.
+- interaction avec transactions futures.
+
+### Epic F - API publique et orchestration
+
+#### F1. `[NEXT][SPARQL API] Definir l'API haut niveau`
+
+Description courte :
+Definir l'entree utilisateur stable au-dessus du parser, du bridge, de KGRAM et
+du storage.
+
+Sous-issues :
+
+- `prepareTupleQuery`.
+- `prepareBooleanQuery`.
+- `prepareGraphQuery`.
+- `prepareUpdate`.
+- initial bindings.
+- options de requete.
+- modele d'erreur.
+- lifecycle des resultats.
+
+Pourquoi :
+La pipeline interne avance, mais il faut une facade stable pour l'utiliser sans
+connaitre les details KGRAM.
+
+#### F2. `[NEXT][RUNTIME] Decouper l'executor temporaire`
+
+References :
+
+- PR existante : [#484](https://github.com/corese-stack/corese-core/pull/484)
+  introduit `NextSparqlPipelineExecutor` comme integration executor.
+
+Description courte :
+Eviter qu'un futur `NextSparqlPipelineExecutor` concentre toutes les
+responsabilites.
+
+Sous-issues :
+
+- `QueryEvaluationService`.
+- `GraphResultMaterializer`.
+- `DescribeEvaluator`.
+- `UpdateExecutionService`.
+- `TermValueMapper`.
+- `NextRuntimeFactory`.
+
+#### F3. `[NEXT][RESULTS] Stabiliser les resultats Tuple/Boolean/Graph`
+
+Description courte :
+Garantir que les resultats exposes par l'API next ne dependent pas des classes
+legacy.
+
+Sous-issues :
+
+- tuple bindings.
+- graph statements.
+- close/lifecycle.
+- streaming vs materialisation.
+- tests API.
+
+### Epic G - Storage et transactions
+
+#### G1. `[NEXT][STORAGE] Clarifier les capacites de MemoryStorageManager`
+
+Description courte :
+Rendre explicites les limites du storage memoire actuel.
+
+Sous-issues :
+
+- transactions non supportees.
+- bulk operations non supportees.
+- ordre non garanti.
+- contexts / named graphs.
+- metadata operations.
+
+#### G2. `[NEXT][STORAGE] Ajouter une vraie strategie de transactions`
+
+Description courte :
+Preparer les updates atomiques et les futures operations complexes.
+
+Sous-issues :
+
+- interface transaction stable.
+- implementation memory.
+- comportement rollback.
+- interaction avec updates.
+- tests d'erreur.
+
+#### G3. `[NEXT][STORAGE] Isoler GraphStorageManager comme backend legacy`
+
+Description courte :
+Faire de `GraphStorageManager` une compatibilite explicite, pas le coeur de la
+pipeline next.
+
+Sous-issues :
+
+- documenter le role compatibility backend.
+- limiter les fuites de types legacy.
+- tests comparatifs avec MemoryStorageManager.
+
+### Epic H - Reduction de la dette legacy
+
+#### H1. `[NEXT][DATA] Remplacer les RDF values legacy-backed`
+
+Description courte :
+Creer des valeurs RDF next-native au lieu d'adapter constamment les types
+legacy.
+
+Sous-issues :
+
+- `NextIRI`.
+- `NextBNode`.
+- `NextLiteral`.
+- `NextStatement`.
+- `NextValueFactory`.
+- compatibilite temporaire avec `CoreseAdaptedValueFactory`.
+
+#### H2. `[NEXT][KGRAM] Reduire la dependance a IDatatype`
+
+Description courte :
+Preparer KGRAM next a ne plus transporter directement `IDatatype` partout.
+
+Sous-issues :
+
+- identifier les points d'entree obligatoires.
+- isoler les conversions dans des helpers.
+- remplacer progressivement dans `NodeImpl`.
+- garder les tests de compatibilite.
+
+#### H3. `[NEXT][KGRAM] Nettoyer les implementations placeholder`
+
+Description courte :
+Remplacer les `return null`, `TODO Auto-generated method stub` et
+`UnsupportedOperationException("Not supported yet")` generiques par des
+comportements documentes.
+
+Sous-issues :
+
+- `ProducerDefault`.
+- `EnvironmentImpl`.
+- `NodeImpl`.
+- classes path/approx/search si encore utiles.
+
+#### H4. `[NEXT][PARSER] Refactorer les grosses methodes d'expressions`
+
+Description courte :
+Reduire la complexite dans le parser/bridge d'expressions.
+
+Sous-issues :
+
+- `createConstraint`.
+- conversion des builtins.
+- termes additifs/multiplicatifs.
+- erreurs de type.
+- tests de non-regression.
+
+### Epic I - Qualite, tests et validation croisee
+
+#### I1. `[NEXT][TESTS] Creer une suite end-to-end SPARQL next`
+
+Description courte :
+Centraliser les tests de la pipeline complete.
+
+Sous-issues :
+
+- helper de dataset.
+- helper de requete.
+- assertions order-independent.
+- SELECT/ASK/CONSTRUCT/DESCRIBE.
+- tests de features unsupported.
+
+#### I2. `[NEXT][TESTS] Comparer next avec legacy sur un sous-ensemble`
+
+Description courte :
+Pour chaque feature stabilisee, comparer le resultat next avec l'ancien moteur
+sur des cas simples.
+
+Sous-issues :
+
+- memes donnees.
+- meme requete.
+- normalisation des resultats.
+- differences documentees.
+
+#### I3. `[NEXT][CI] Corriger l'erreur JaCoCo / Java major version 70`
+
+Description courte :
+L'erreur JaCoCo n'empeche pas les tests de passer, mais elle pollue les logs et
+doit etre corrigee proprement.
+
+Sous-issues :
+
+- confirmer la version Java utilisee en CI.
+- confirmer la version JaCoCo compatible.
+- desactiver l'instrumentation des classes JDK si necessaire.
+- documenter le comportement attendu.
+
+## 5. Decoupage conseille
+
+### Prochaine vague de PR
+
+1. Finaliser et merger #482.
+2. Rebaser #484 sur `feature/corese-next`.
+3. Traiter #483.
+4. Traiter #463.
+5. Creer `A2 - Clarifier les hooks Producer`.
+6. Creer `A3 - Supporter GRAPH ?g`.
+7. Creer `F1 - API haut niveau`.
+
+### Vague suivante
+
+1. `B1 - SELECT end to end` si #484 est splittee.
+2. `B2 - ASK end to end` si #484 est splittee.
+3. `C1 - FILTER`.
+4. `C2 - OPTIONAL`.
+5. `C3 - UNION`.
+6. `D2 - ORDER BY / LIMIT / OFFSET`.
+7. `B3 - CONSTRUCT`.
+
+### Plus tard
+
+1. `C8 - Property paths`.
+2. `D3 - Aggregates`.
+3. `E* - Updates`.
+4. `H* - Dette legacy`.

--- a/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
@@ -1,0 +1,16 @@
+package fr.inria.corese.core.next.query.api.exception;
+
+/**
+ * Thrown when a syntactically valid query uses a feature not implemented by the current next pipeline.
+ */
+@SuppressWarnings("java:S110")
+public class UnsupportedQueryFeatureException extends QueryEvaluationException {
+
+    public UnsupportedQueryFeatureException(String message) {
+        super(message);
+    }
+
+    public UnsupportedQueryFeatureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
@@ -4,7 +4,7 @@ package fr.inria.corese.core.next.query.api.exception;
  * Thrown when a syntactically valid query uses a feature not implemented by the current next pipeline.
  */
 @SuppressWarnings("java:S110")
-public class UnsupportedQueryFeatureException extends QueryEvaluationException {
+public class UnsupportedQueryFeatureException extends QueryException {
 
     public UnsupportedQueryFeatureException(String message) {
         super(message);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlAstBuilder.java
@@ -285,6 +285,10 @@ public abstract class SparqlAstBuilder {
         bgpStack.push(new ArrayList<>());
     }
 
+    public boolean hasCurrentBgp() {
+        return !bgpStack.isEmpty();
+    }
+
     /**
      * Exit a TriplesBlock -> finalize into BgpAst and attach it to the current group.
      * Empty triples blocks produce no pattern.
@@ -1204,9 +1208,9 @@ public abstract class SparqlAstBuilder {
                             case SparqlParser.MultiplicativeExpressionContext multiplicativeExpressionContext ->
                                     termFromMultiplicative(multiplicativeExpressionContext);
                             case SparqlParser.NumericLiteralPositiveContext numericLiteralPositiveContext ->
-                                    (ExprAst) termFromNumericLiteralPositive(numericLiteralPositiveContext);
+                                    termFromNumericLiteralPositive(numericLiteralPositiveContext);
                             case SparqlParser.NumericLiteralNegativeContext numericLiteralNegativeContext ->
-                                    (ExprAst) termFromNumericLiteralNegative(numericLiteralNegativeContext);
+                                    termFromNumericLiteralNegative(numericLiteralNegativeContext);
                             case null, default ->
                                     throw new QueryEvaluationException(
                                             "Unexpected left hand termFromExpression in additive termFromExpression "

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlListener.java
@@ -8,9 +8,8 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * SPARQL listener multiplexer: forwards to delegates only the events needed for
- * triple patterns (?s ?p ?o) and BGPs (GroupGraphPattern, TriplesBlock, TriplesSameSubject).
- * Additional rules can be added later if needed.
+ * SPARQL listener multiplexer: forwards the grammar events supported by the
+ * next AST builders to their feature-specific delegates.
  */
 public final class SparqlListener extends SparqlParserBaseListener {
 
@@ -77,6 +76,16 @@ public final class SparqlListener extends SparqlParserBaseListener {
     @Override
     public void exitLoad(SparqlParser.LoadContext ctx) {
         for (var d : delegates) d.exitLoad(ctx);
+    }
+
+    @Override
+    public void exitInsertData(SparqlParser.InsertDataContext ctx) {
+        for (var d : delegates) d.exitInsertData(ctx);
+    }
+
+    @Override
+    public void exitDeleteData(SparqlParser.DeleteDataContext ctx) {
+        for (var d : delegates) d.exitDeleteData(ctx);
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlParser.java
@@ -11,6 +11,7 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
 import fr.inria.corese.core.next.query.api.base.io.AbstractQueryParser;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryException;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.exception.QueryValidationException;
 import fr.inria.corese.core.next.query.api.io.parser.QueryOptions;
@@ -81,7 +82,7 @@ public class SparqlParser extends AbstractQueryParser implements QueryTextValida
             }
 
             return analysisResult.ast();
-        } catch (QuerySyntaxException | QueryValidationException | QueryEvaluationException e) {
+        } catch (QueryException e) {
             throw e;
         } catch (IOException e) {
             throw new QueryEvaluationException("Failed to parse SPARQL query: " + e.getMessage(), e);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlQueryAnalyzer.java
@@ -160,6 +160,8 @@ final class SparqlQueryAnalyzer {
             SparqlListener updateListener = new SparqlListener(List.of(
                     new ClearRequestFeature(updateBuilder),
                     new CreateRequestFeature(updateBuilder),
+                    new DeleteDataRequestFeature(updateBuilder),
+                    new InsertDataRequestFeature(updateBuilder),
                     new LoadRequestFeature(updateBuilder),
                     new BgpFeature(updateBuilder),
                     new BindFeature(updateBuilder),

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlUpdateAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/SparqlUpdateAstBuilder.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.next.query.impl.parser;
 
 import fr.inria.corese.core.next.impl.parser.antlr.SparqlParser;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 
 import java.util.ArrayList;
@@ -65,6 +66,62 @@ public class SparqlUpdateAstBuilder extends SparqlAstBuilder{
             return new CreateRequestAst(targetGraphRef, silentFlag);
         }
         throw new QueryEvaluationException("No target graph reference found in CREATE query");
+    }
+
+    public InsertDataRequestAst insertDataToAst(SparqlParser.InsertDataContext ctx) {
+        return new InsertDataRequestAst(triplesFromQuadData(ctx.quadData()));
+    }
+
+    public DeleteDataRequestAst deleteDataToAst(SparqlParser.DeleteDataContext ctx) {
+        return new DeleteDataRequestAst(triplesFromQuadData(ctx.quadData()));
+    }
+
+    private List<TriplePatternAst> triplesFromQuadData(SparqlParser.QuadDataContext ctx) {
+        if (ctx == null || ctx.quads() == null) {
+            return List.of();
+        }
+        return triplesFromQuads(ctx.quads());
+    }
+
+    private List<TriplePatternAst> triplesFromQuads(SparqlParser.QuadsContext ctx) {
+        if (ctx.quadsNotTriples() != null && !ctx.quadsNotTriples().isEmpty()) {
+            throw new UnsupportedQueryFeatureException(
+                    "GRAPH blocks in INSERT DATA / DELETE DATA are not supported yet by the next pipeline");
+        }
+
+        List<TriplePatternAst> triples = new ArrayList<>();
+        if (ctx.triplesTemplate() != null) {
+            for (SparqlParser.TriplesTemplateContext template : ctx.triplesTemplate()) {
+                collectTriplesTemplate(template, triples);
+            }
+        }
+        return List.copyOf(triples);
+    }
+
+    private void collectTriplesTemplate(SparqlParser.TriplesTemplateContext ctx, List<TriplePatternAst> triples) {
+        if (ctx == null) {
+            return;
+        }
+        if (ctx.triplesSameSubject() != null) {
+            collectTriplesSameSubject(ctx.triplesSameSubject(), triples);
+        }
+        if (ctx.triplesTemplate() != null) {
+            collectTriplesTemplate(ctx.triplesTemplate(), triples);
+        }
+    }
+
+    private void collectTriplesSameSubject(SparqlParser.TriplesSameSubjectContext ctx, List<TriplePatternAst> triples) {
+        if (ctx.varOrTerm() == null || ctx.propertyListNotEmpty() == null) {
+            return;
+        }
+        TermAst subject = termFromVarOrTerm(ctx.varOrTerm());
+        var propertyList = ctx.propertyListNotEmpty();
+        for (int verbIndex = 0; verbIndex < propertyList.verb().size(); verbIndex++) {
+            TermAst predicate = termFromVerb(propertyList.verb(verbIndex));
+            for (TermAst object : termListFromObjectList(propertyList.objectList(verbIndex))) {
+                triples.add(new TriplePatternAst(subject, predicate, object));
+            }
+        }
     }
 
     public void addRequest(UpdateRequestUnitAst ast) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/BgpFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/BgpFeature.java
@@ -67,6 +67,9 @@ public class BgpFeature extends AbstractSparqlFeature {
         if (ctx.getParent() instanceof SparqlParser.ConstructTriplesContext) {
             return;
         }
+        if (!builder().hasCurrentBgp()) {
+            return;
+        }
         if (ctx.varOrTerm() == null || ctx.propertyListNotEmpty() == null) {
             return;
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/DeleteDataRequestFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/DeleteDataRequestFeature.java
@@ -1,0 +1,19 @@
+package fr.inria.corese.core.next.query.impl.parser.listener;
+
+import fr.inria.corese.core.next.impl.parser.antlr.SparqlParser;
+import fr.inria.corese.core.next.query.impl.parser.SparqlUpdateAstBuilder;
+
+/**
+ * AST feature listener for the minimal {@code DELETE DATA} update operation.
+ */
+public class DeleteDataRequestFeature extends AbstractSparqlRequestFeature {
+
+    public DeleteDataRequestFeature(SparqlUpdateAstBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void exitDeleteData(SparqlParser.DeleteDataContext ctx) {
+        updateBuilder().addRequest(updateBuilder().deleteDataToAst(ctx));
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/InsertDataRequestFeature.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/parser/listener/InsertDataRequestFeature.java
@@ -1,0 +1,19 @@
+package fr.inria.corese.core.next.query.impl.parser.listener;
+
+import fr.inria.corese.core.next.impl.parser.antlr.SparqlParser;
+import fr.inria.corese.core.next.query.impl.parser.SparqlUpdateAstBuilder;
+
+/**
+ * AST feature listener for the minimal {@code INSERT DATA} update operation.
+ */
+public class InsertDataRequestFeature extends AbstractSparqlRequestFeature {
+
+    public InsertDataRequestFeature(SparqlUpdateAstBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void exitInsertData(SparqlParser.InsertDataContext ctx) {
+        updateBuilder().addRequest(updateBuilder().insertDataToAst(ctx));
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DeleteDataRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/DeleteDataRequestAst.java
@@ -1,0 +1,21 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
+import java.util.List;
+
+/**
+ * Minimal AST representation of {@code DELETE DATA} for concrete triples.
+ */
+public record DeleteDataRequestAst(List<TriplePatternAst> triples) implements UpdateRequestUnitAst {
+
+    public DeleteDataRequestAst {
+        triples = triples != null ? List.copyOf(triples) : List.of();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        triples.forEach(triple -> triple.accept(visitor));
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/InsertDataRequestAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/InsertDataRequestAst.java
@@ -1,0 +1,21 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import fr.inria.corese.core.next.query.impl.parser.semantic.support.AstVisitor;
+
+import java.util.List;
+
+/**
+ * Minimal AST representation of {@code INSERT DATA} for concrete triples.
+ */
+public record InsertDataRequestAst(List<TriplePatternAst> triples) implements UpdateRequestUnitAst {
+
+    public InsertDataRequestAst {
+        triples = triples != null ? List.copyOf(triples) : List.of();
+    }
+
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        triples.forEach(triple -> triple.accept(visitor));
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestUnitAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/UpdateRequestUnitAst.java
@@ -5,5 +5,5 @@ import fr.inria.corese.core.next.query.impl.parser.semantic.support.VisitableAst
 /**
  * Root interface for all operations related to the SPARQL Update operations listed in <a href="https://www.w3.org/TR/sparql11-update/">SPARQL 1.1 Update</a>.
  */
-public sealed interface UpdateRequestUnitAst extends VisitableAst permits LoadRequestAst, ClearRequestAst, CreateRequestAst {
+public sealed interface UpdateRequestUnitAst extends VisitableAst permits LoadRequestAst, ClearRequestAst, CreateRequestAst, InsertDataRequestAst, DeleteDataRequestAst {
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Builds KGRAM {@code Exp} / {@code Query} structures from Corese-next query AST nodes.
@@ -204,24 +205,24 @@ public final class CoreseAstQueryBuilder {
                         + term.getClass().getSimpleName());
     }
 
-    static TermAst simplePredicate(PathAst path) {
+    public static TermAst simplePredicate(PathAst path) {
         if (path instanceof PredicatePathAst(TermAst predicate)) {
             return predicate;
         }
-        throw new UnsupportedOperationException(
-                "Property path bridge compilation is not supported yet for: "
+        throw new UnsupportedQueryFeatureException(
+                "Property path bridge compilation is not supported yet by the next pipeline for: "
                         + path.getClass().getSimpleName());
     }
 
     private static void rejectUnsupportedAskClauses(AskQueryAst askQueryAst) {
         if (!askQueryAst.valuesClause().mappings().isEmpty()) {
             throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet for ASK (values handling is a follow-up)");
+                    "Inline VALUES is not supported yet by the next pipeline for ASK");
         }
         SolutionModifierAst mod = askQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for ASK");
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for ASK");
         }
         // TODO(#388): inline VALUES needs a dedicated runtime mapping.
         // TODO(#388): GROUP BY / HAVING would require aggregate-aware ASK semantics, not just field copying.
@@ -230,22 +231,23 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedSelectClauses(SelectQueryAst selectQueryAst) {
         if (!selectQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedQueryFeatureException("VALUES is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet by the next pipeline for SELECT");
         }
         ProjectionAst projection = selectQueryAst.projection();
         if (!projection.expressionTerms().isEmpty() || !projection.expressionBoundVariables().isEmpty()) {
             throw new UnsupportedQueryFeatureException(
-                    "SELECT expressions are not supported yet when building a next Query");
+                    "SELECT expressions and aliases are not supported yet by the next pipeline");
         }
         SolutionModifierAst solutionModifier = selectQueryAst.solutionModifier();
         if (solutionModifier.reduced()) {
-            throw new UnsupportedQueryFeatureException("REDUCED is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("REDUCED is not supported yet by the next pipeline for SELECT");
         }
         if (solutionModifier.hasGroupBy()) {
-            throw new UnsupportedQueryFeatureException("GROUP BY is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("GROUP BY is not supported yet by the next pipeline for SELECT");
         }
         if (solutionModifier.hasHaving()) {
-            throw new UnsupportedQueryFeatureException("HAVING is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("HAVING is not supported yet by the next pipeline for SELECT");
         }
         // TODO(#387): inline VALUES needs a dedicated runtime mapping.
         // TODO(#387): SELECT expressions need a clear runtime story for aliases and reuse in later clauses.
@@ -256,12 +258,12 @@ public final class CoreseAstQueryBuilder {
     private static void rejectUnsupportedDescribeClauses(DescribeQueryAst describeQueryAst) {
         if (!describeQueryAst.valuesClause().mappings().isEmpty()) {
             throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet for DESCRIBE (values handling is a follow-up)");
+                    "Inline VALUES is not supported yet by the next pipeline for DESCRIBE");
         }
         SolutionModifierAst mod = describeQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for DESCRIBE");
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for DESCRIBE");
         }
         // TODO(#390): inline VALUES needs a dedicated runtime mapping.
         // TODO(#390): GROUP BY / HAVING would require aggregate-aware DESCRIBE semantics, not just field copying.
@@ -271,12 +273,12 @@ public final class CoreseAstQueryBuilder {
     private static void rejectUnsupportedConstructClauses(ConstructQueryAst constructQueryAst) {
         if (!constructQueryAst.valuesClause().mappings().isEmpty()) {
             throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet for CONSTRUCT (values handling is a follow-up)");
+                    "Inline VALUES is not supported yet by the next pipeline for CONSTRUCT");
         }
         SolutionModifierAst mod = constructQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for CONSTRUCT");
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for CONSTRUCT");
         }
         // TODO(#473): blank nodes in CONSTRUCT templates need per-solution allocation.
         // TODO(#473): inline VALUES needs a dedicated runtime mapping.
@@ -318,7 +320,7 @@ public final class CoreseAstQueryBuilder {
     private static void rejectUnsupportedConstructTemplateTerm(TermAst term, String role) {
         if (term instanceof IriAst(String raw) && isBlankNodeLabel(raw)) {
             throw new UnsupportedQueryFeatureException(
-                    "Blank nodes in CONSTRUCT " + role + " templates are not supported yet");
+                    "Blank nodes in CONSTRUCT " + role + " templates are not supported yet by the next pipeline");
         }
     }
 
@@ -340,11 +342,10 @@ public final class CoreseAstQueryBuilder {
         } else {
             selectExpressions = new ArrayList<>();
             for (VarAst variable : projection.variables()) {
-                Node node = visibleBodyNode(query, variable.name());
-                if (node == null) {
-                    throw new IllegalArgumentException(
-                            "Projected variable ?" + variable.name() + " is not visible in the compiled query body");
-                }
+                Node node = visibleBodyNode(query, variable.name())
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "Projected variable ?" + variable.name()
+                                        + " is not visible in the compiled query body"));
                 selectExpressions.add(Exp.create(Type.NODE, node));
             }
         }
@@ -366,11 +367,9 @@ public final class CoreseAstQueryBuilder {
         List<Node> nodes = new ArrayList<>();
         for (TermAst term : describeQueryAst.described()) {
             if (term instanceof VarAst(String name)) {
-                Node node = visibleBodyNode(query, name);
-                if (node == null) {
-                    throw new IllegalArgumentException(
-                            "DESCRIBE variable ?" + name + " is not visible in the compiled query body");
-                }
+                Node node = visibleBodyNode(query, name)
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "DESCRIBE variable ?" + name + " is not visible in the compiled query body"));
                 nodes.add(node);
             } else {
                 nodes.add(toNode(term));
@@ -450,11 +449,9 @@ public final class CoreseAstQueryBuilder {
             Exp selectExpression = query.getSelectExp(name);
             Node node = selectExpression != null
                     ? selectExpression.getNode()
-                    : visibleBodyNode(query, name);
-            if (node == null) {
-                throw new IllegalArgumentException(
-                        "ORDER BY variable ?" + name + " is not visible in the compiled query");
-            }
+                    : visibleBodyNode(query, name)
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "ORDER BY variable ?" + name + " is not visible in the compiled query"));
             return Exp.create(Type.NODE, node);
         }
         Filter filter = SparqlAstToExpression.toNextFilter(expression);
@@ -488,13 +485,13 @@ public final class CoreseAstQueryBuilder {
      * excludes nodes collected from MINUS/EXISTS bodies, which KGRAM stores as query
      * nodes for internal evaluation but which are not projectable SPARQL bindings.
      */
-    private Node visibleBodyNode(Query query, String name) {
+    private Optional<Node> visibleBodyNode(Query query, String name) {
         for (Node node : query.selectNodesFromPattern()) {
             if (node.getLabel().equals(name)) {
-                return node;
+                return Optional.of(node);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     private void applyLimitOffset(Query query, SolutionModifierAst solutionModifier) {
@@ -530,8 +527,7 @@ public final class CoreseAstQueryBuilder {
     private Node constructNode(Query query, TermAst term, String role) {
         rejectUnsupportedConstructTemplateTerm(term, role);
         if (term instanceof VarAst(String name)) {
-            Node bound = visibleBodyNode(query, name);
-            return bound != null ? bound : toNode(term);
+            return visibleBodyNode(query, name).orElseGet(() -> toNode(term));
         }
         return toNode(term);
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -1,6 +1,23 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ASTConstants;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ConstraintAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructTemplateAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.DatasetClauseAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.DescribeQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.OrderConditionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ProjectionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SolutionModifierAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PathAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PredicatePathAst;
 import fr.inria.corese.core.next.query.kgram.api.core.ExpType.Type;
@@ -198,12 +215,12 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedAskClauses(AskQueryAst askQueryAst) {
         if (!askQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedQueryFeatureException(
                     "Inline VALUES is not supported yet for ASK (values handling is a follow-up)");
         }
         SolutionModifierAst mod = askQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedQueryFeatureException(
                     "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for ASK");
         }
         // TODO(#388): inline VALUES needs a dedicated runtime mapping.
@@ -213,22 +230,22 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedSelectClauses(SelectQueryAst selectQueryAst) {
         if (!selectQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException("VALUES is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("VALUES is not supported yet when building a next Query");
         }
         ProjectionAst projection = selectQueryAst.projection();
         if (!projection.expressionTerms().isEmpty() || !projection.expressionBoundVariables().isEmpty()) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedQueryFeatureException(
                     "SELECT expressions are not supported yet when building a next Query");
         }
         SolutionModifierAst solutionModifier = selectQueryAst.solutionModifier();
         if (solutionModifier.reduced()) {
-            throw new UnsupportedOperationException("REDUCED is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("REDUCED is not supported yet when building a next Query");
         }
         if (solutionModifier.hasGroupBy()) {
-            throw new UnsupportedOperationException("GROUP BY is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("GROUP BY is not supported yet when building a next Query");
         }
         if (solutionModifier.hasHaving()) {
-            throw new UnsupportedOperationException("HAVING is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("HAVING is not supported yet when building a next Query");
         }
         // TODO(#387): inline VALUES needs a dedicated runtime mapping.
         // TODO(#387): SELECT expressions need a clear runtime story for aliases and reuse in later clauses.
@@ -238,17 +255,31 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedDescribeClauses(DescribeQueryAst describeQueryAst) {
         if (!describeQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedQueryFeatureException(
                     "Inline VALUES is not supported yet for DESCRIBE (values handling is a follow-up)");
         }
         SolutionModifierAst mod = describeQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
+            throw new UnsupportedQueryFeatureException(
                     "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for DESCRIBE");
         }
         // TODO(#390): inline VALUES needs a dedicated runtime mapping.
         // TODO(#390): GROUP BY / HAVING would require aggregate-aware DESCRIBE semantics, not just field copying.
         // TODO(#390): REDUCED support should be aligned with the final query-form policy for the next pipeline.
+    }
+
+    private static void rejectUnsupportedConstructClauses(ConstructQueryAst constructQueryAst) {
+        if (!constructQueryAst.valuesClause().mappings().isEmpty()) {
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet for CONSTRUCT (values handling is a follow-up)");
+        }
+        SolutionModifierAst mod = constructQueryAst.solutionModifier();
+        if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
+            throw new UnsupportedQueryFeatureException(
+                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for CONSTRUCT");
+        }
+        // TODO(#473): blank nodes in CONSTRUCT templates need per-solution allocation.
+        // TODO(#473): inline VALUES needs a dedicated runtime mapping.
     }
 
     /**
@@ -282,6 +313,17 @@ public final class CoreseAstQueryBuilder {
             nodes.add(toNode(iri));
         }
         return nodes;
+    }
+
+    private static void rejectUnsupportedConstructTemplateTerm(TermAst term, String role) {
+        if (term instanceof IriAst(String raw) && isBlankNodeLabel(raw)) {
+            throw new UnsupportedQueryFeatureException(
+                    "Blank nodes in CONSTRUCT " + role + " templates are not supported yet");
+        }
+    }
+
+    private static boolean isBlankNodeLabel(String raw) {
+        return raw.startsWith("_:") || raw.equals("[]") || raw.startsWith("[");
     }
 
     /**
@@ -352,7 +394,8 @@ public final class CoreseAstQueryBuilder {
             // KGRAM-next currently represents DESCRIBE with outgoing and incoming construct triples.
             constructTemplate.add(describePattern.outgoing().getEdge());
             constructTemplate.add(describePattern.incoming().getEdge());
-            query.getBody().add(Exp.create(Type.OPTIONAL, Exp.create(Type.AND), describePattern.optionalBody()));
+            Exp optional = Exp.create(Type.OPTIONAL, Exp.create(Type.AND), describePattern.optionalBody());
+            query.getBody().add(optional);
         }
         query.setConstruct(constructTemplate);
         query.setConstruct(true);
@@ -463,21 +506,6 @@ public final class CoreseAstQueryBuilder {
         }
     }
 
-    private static void rejectUnsupportedConstructClauses(ConstructQueryAst constructQueryAst) {
-        if (!constructQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "Inline VALUES is not supported yet for CONSTRUCT (values handling is a follow-up)");
-        }
-        SolutionModifierAst mod = constructQueryAst.solutionModifier();
-        if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for CONSTRUCT");
-        }
-        // TODO(#389): inline VALUES needs a dedicated runtime mapping.
-        // TODO(#389): GROUP BY / HAVING would require aggregate-aware CONSTRUCT semantics, not just field copying.
-        // TODO(#389): DISTINCT / REDUCED are SELECT-only in the grammar; kept as a defensive guard.
-    }
-
     /**
      * Compiles a {@code CONSTRUCT} template into a KGRAM {@link Exp} (a BGP of edges), kept separate
      * from the {@code WHERE} body and carried by {@link Query#setConstruct(Exp)}.
@@ -485,9 +513,9 @@ public final class CoreseAstQueryBuilder {
     private Exp compileConstructTemplate(Query query, ConstructTemplateAst template) {
         Exp bgp = Exp.create(Type.BGP);
         for (TriplePatternAst triple : template.triplePatternAsts()) {
-            Node subject = constructNode(query, triple.subject());
-            Node predicate = constructNode(query, simplePredicate(triple.predicate()));
-            Node object = constructNode(query, triple.object());
+            Node subject = constructNode(query, triple.subject(), "subject");
+            Node predicate = constructNode(query, simplePredicate(triple.predicate()), "predicate");
+            Node object = constructNode(query, triple.object(), "object");
             bgp.add(new AstBackedEdge(subject, predicate, object));
         }
         return bgp;
@@ -499,7 +527,8 @@ public final class CoreseAstQueryBuilder {
      * valid SPARQL and simply skips its triple at instantiation, so this does not throw). IRIs, blank
      * nodes and literals become fresh constant nodes.
      */
-    private Node constructNode(Query query, TermAst term) {
+    private Node constructNode(Query query, TermAst term, String role) {
+        rejectUnsupportedConstructTemplateTerm(term, role);
         if (term instanceof VarAst(String name)) {
             Node bound = visibleBodyNode(query, name);
             return bound != null ? bound : toNode(term);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import fr.inria.corese.core.next.query.kgram.api.core.Filter;
@@ -10,6 +11,7 @@ import fr.inria.corese.core.sparql.triple.parser.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -21,6 +23,58 @@ import java.util.Optional;
  */
 public final class SparqlAstToExpression {
 
+    private static final Map<Class<?>, String> BINARY_OPERATORS =
+            Map.ofEntries(
+                    Map.entry(AndAst.class, KeywordHolder.SEAND),
+                    Map.entry(OrAst.class, KeywordHolder.SEOR),
+                    Map.entry(EqualsAst.class, "="),
+                    Map.entry(DifferentAst.class, "!="),
+                    Map.entry(LowerThanAst.class, "<"),
+                    Map.entry(LowerOrEqualThanAst.class, "<="),
+                    Map.entry(GreaterThanAst.class, ">"),
+                    Map.entry(GreaterOrEqualThanAst.class, ">="),
+                    Map.entry(AddAst.class, "+"),
+                    Map.entry(SubtractAst.class, "-"),
+                    Map.entry(MultiplyAst.class, "*"),
+                    Map.entry(DivideAst.class, "/"));
+
+    private static final Map<Class<?>, String> UNARY_OPERATORS =
+            Map.ofEntries(
+                    Map.entry(UnaryPlusAst.class, "+"),
+                    Map.entry(UnaryMinusAst.class, "-"),
+                    Map.entry(BooleanNotAst.class, "!"));
+
+    private static final Map<Class<?>, String> UNARY_FUNCTIONS =
+            Map.ofEntries(
+                    Map.entry(BoundAst.class, Processor.BOUND),
+                    Map.entry(IsIriAst.class, "isIRI"),
+                    Map.entry(IsBlankAst.class, "isBlank"),
+                    Map.entry(IsLiteralAst.class, "isLiteral"),
+                    Map.entry(StrAst.class, "str"),
+                    Map.entry(LangAst.class, "lang"),
+                    Map.entry(DatatypeAst.class, "datatype"),
+                    Map.entry(IriFunctionAst.class, "iri"),
+                    Map.entry(LcaseAst.class, "lcase"),
+                    Map.entry(UcaseAst.class, "ucase"),
+                    Map.entry(EncodeForUriAst.class, "encode_for_uri"),
+                    Map.entry(Md5Ast.class, "md5"),
+                    Map.entry(Sha1Ast.class, "sha1"),
+                    Map.entry(Sha256Ast.class, "sha256"),
+                    Map.entry(Sha384Ast.class, "sha384"),
+                    Map.entry(Sha512Ast.class, "sha512"));
+
+    private static final Map<Class<?>, String> BINARY_FUNCTIONS =
+            Map.ofEntries(
+                    Map.entry(SameTermAst.class, "sameTerm"),
+                    Map.entry(LangMatchesAst.class, "langMatches"),
+                    Map.entry(StrStartsAst.class, "strstarts"),
+                    Map.entry(StrEndsAst.class, "strends"),
+                    Map.entry(ContainsAst.class, "contains"),
+                    Map.entry(StrBeforeAst.class, "strbefore"),
+                    Map.entry(StrAfterAst.class, "strafter"),
+                    Map.entry(StrLangAst.class, "strlang"),
+                    Map.entry(StrDtAst.class, Processor.STRDT));
+
     private SparqlAstToExpression() {
     }
 
@@ -29,9 +83,9 @@ public final class SparqlAstToExpression {
      */
     public static Expression convert(TermAst term) {
         return switch (term) {
-            case VarAst v -> Variable.create(v.name());
-            case LiteralAst l -> literalToConstant(l);
-            case IriAst i -> iriToConstant(i);
+            case VarAst(String name) -> Variable.create(name);
+            case LiteralAst(String lexical, String lang, String datatype) -> literalToConstant(lexical, lang, datatype);
+            case IriAst(String raw) -> iriToConstant(raw);
             case ConstraintAst c -> constraintToExpression(c);
             default -> throw new IllegalStateException("Unhandled TermAst: " + term.getClass());
         };
@@ -74,14 +128,14 @@ public final class SparqlAstToExpression {
         }
     }
 
-    private static Constant literalToConstant(LiteralAst l) {
-        if (l.lang() != null && !l.lang().isEmpty()) {
-            return Constant.create(unquoteLexical(l.lexical()), RDF.rdflangString, l.lang());
+    private static Constant literalToConstant(String lexical, String lang, String datatype) {
+        if (lang != null && !lang.isEmpty()) {
+            return Constant.create(unquoteLexical(lexical), RDF.rdflangString, lang);
         }
-        if (l.datatype() != null && !l.datatype().isEmpty()) {
-            return Constant.create(unquoteLexical(l.lexical()), normalizeDatatypeIri(l.datatype()), null);
+        if (datatype != null && !datatype.isEmpty()) {
+            return Constant.create(unquoteLexical(lexical), normalizeDatatypeIri(datatype), null);
         }
-        return Constant.createString(unquoteLexical(l.lexical()));
+        return Constant.createString(unquoteLexical(lexical));
     }
 
     private static String unquoteLexical(String lexical) {
@@ -102,8 +156,8 @@ public final class SparqlAstToExpression {
         return fr.inria.corese.core.sparql.triple.parser.NSManager.nsm().toNamespace(d);
     }
 
-    private static Constant iriToConstant(IriAst i) {
-        String raw = StringUtils.trimChevronIRIs(i.raw());
+    private static Constant iriToConstant(String rawIri) {
+        String raw = StringUtils.trimChevronIRIs(rawIri);
         if (raw.startsWith(IOConstants.BLANK_NODE_PREFIX)) {
             return Constant.createBlank(raw.substring(IOConstants.BLANK_NODE_PREFIX.length()));
         }
@@ -111,115 +165,68 @@ public final class SparqlAstToExpression {
     }
 
     private static Expression constraintToExpression(ConstraintAst constraint) {
+        String binaryOperator = BINARY_OPERATORS.get(constraint.getClass());
+        if (binaryOperator != null && constraint instanceof BinaryConstraintAst binary) {
+            return binaryOperatorTerm(binaryOperator, binary);
+        }
+
+        String unaryOperator = UNARY_OPERATORS.get(constraint.getClass());
+        if (unaryOperator != null && constraint instanceof UnaryConstraintAst unary) {
+            return Term.create(unaryOperator, convert(unary.argument()));
+        }
+
+        String unaryFunction = UNARY_FUNCTIONS.get(constraint.getClass());
+        if (unaryFunction != null && constraint instanceof UnaryConstraintAst unary) {
+            return functionTerm(unaryFunction, convert(unary.argument()));
+        }
+
+        String binaryFunction = BINARY_FUNCTIONS.get(constraint.getClass());
+        if (binaryFunction != null && constraint instanceof BinaryConstraintAst binary) {
+            return binaryFunctionTerm(binaryFunction, binary);
+        }
+
+        return specialConstraintToExpression(constraint);
+    }
+
+    private static Expression specialConstraintToExpression(ConstraintAst constraint) {
         return switch (constraint) {
-            case AndAst andAst ->
-                    Term.create(KeywordHolder.SEAND, convert(andAst.getLeftArgument()), convert(andAst.getRightArgument()));
-            case OrAst orAst ->
-                    Term.create(KeywordHolder.SEOR, convert(orAst.getLeftArgument()), convert(orAst.getRightArgument()));
-            case EqualsAst equalsAst ->
-                    Term.create("=", convert(equalsAst.getLeftArgument()), convert(equalsAst.getRightArgument()));
-            case DifferentAst differentAst ->
-                    Term.create("!=", convert(differentAst.getLeftArgument()), convert(differentAst.getRightArgument()));
-            case LowerThanAst lowerThanAst ->
-                    Term.create("<", convert(lowerThanAst.getLeftArgument()), convert(lowerThanAst.getRightArgument()));
-            case LowerOrEqualThanAst lowerOrEqualThanAst ->
-                    Term.create("<=", convert(lowerOrEqualThanAst.getLeftArgument()), convert(lowerOrEqualThanAst.getRightArgument()));
-            case GreaterThanAst greaterThanAst ->
-                    Term.create(">", convert(greaterThanAst.getLeftArgument()), convert(greaterThanAst.getRightArgument()));
-            case GreaterOrEqualThanAst greaterOrEqualThanAst ->
-                    Term.create(">=", convert(greaterOrEqualThanAst.getLeftArgument()), convert(greaterOrEqualThanAst.getRightArgument()));
-            case AddAst addAst ->
-                    Term.create("+", convert(addAst.getLeftArgument()), convert(addAst.getRightArgument()));
-            case SubtractAst subtractAst ->
-                    Term.create("-", convert(subtractAst.getLeftArgument()), convert(subtractAst.getRightArgument()));
-            case MultiplyAst multiplyAst ->
-                    Term.create("*", convert(multiplyAst.getLeftArgument()), convert(multiplyAst.getRightArgument()));
-            case DivideAst divideAst ->
-                    Term.create("/", convert(divideAst.getLeftArgument()), convert(divideAst.getRightArgument()));
-            case UnaryPlusAst unaryPlusAst ->
-                    Term.create("+", convert(unaryPlusAst.argument()));
-            case UnaryMinusAst unaryMinusAst ->
-                    Term.create("-", convert(unaryMinusAst.argument()));
-            case BooleanNotAst booleanNotAst ->
-                    Term.create("!", convert(booleanNotAst.argument()));
-            case BoundAst boundAst ->
-                    functionTerm(Processor.BOUND, convert(boundAst.argument()));
-            case IsIriAst isIriAst ->
-                    functionTerm("isIRI", convert(isIriAst.argument()));
-            case IsBlankAst isBlankAst ->
-                    functionTerm("isBlank", convert(isBlankAst.argument()));
-            case IsLiteralAst isLiteralAst ->
-                    functionTerm("isLiteral", convert(isLiteralAst.argument()));
-            case StrAst strAst ->
-                    functionTerm("str", convert(strAst.argument()));
-            case LangAst langAst ->
-                    functionTerm("lang", convert(langAst.argument()));
-            case DatatypeAst datatypeAst ->
-                    functionTerm("datatype", convert(datatypeAst.argument()));
-            case SameTermAst sameTermAst ->
-                    functionTerm("sameTerm", convert(sameTermAst.getLeftArgument()), convert(sameTermAst.getRightArgument()));
-            case LangMatchesAst langMatchesAst ->
-                    functionTerm("langMatches", convert(langMatchesAst.getLeftArgument()), convert(langMatchesAst.getRightArgument()));
-            case BinaryRegexAst binaryRegexAst ->
-                    regexTerm(convert(binaryRegexAst.getString()), convert(binaryRegexAst.getPattern()));
-            case TrinaryRegexAst trinaryRegexAst ->
-                    regexTerm(convert(trinaryRegexAst.getString()), convert(trinaryRegexAst.getPattern()), convert(trinaryRegexAst.getFlags()));
-            case FunctionCallAst callAst ->
-                    functionCallAst(callAst);
-            case ConcatAst concatAst ->
-                    variadicTerm("concat", concatAst.arguments());
-            case CoalesceAst coalesceAst ->
-                    variadicTerm(Processor.COALESCE, coalesceAst.arguments());
-            case IfAst ifAst ->
-                    Term.function(Processor.IF, convert(ifAst.condition()), convert(ifAst.thenExpr()), convert(ifAst.elseExpr()));
-            case ReplaceAst replaceAst ->
-                    replaceToTerm(replaceAst);
-            case SubstrAst substrAst ->
-                    substrToTerm(substrAst);
-            case BnodeAst bnodeAst ->
-                    bnodeToTerm(bnodeAst);
-            case StrStartsAst strStartsAst ->
-                    functionTerm("strstarts", convert(strStartsAst.getLeftArgument()), convert(strStartsAst.getRightArgument()));
-            case StrEndsAst strEndsAst ->
-                    functionTerm("strends", convert(strEndsAst.getLeftArgument()), convert(strEndsAst.getRightArgument()));
-            case ContainsAst containsAst ->
-                    functionTerm("contains", convert(containsAst.getLeftArgument()), convert(containsAst.getRightArgument()));
-            case StrBeforeAst strBeforeAst ->
-                    functionTerm("strbefore", convert(strBeforeAst.getLeftArgument()), convert(strBeforeAst.getRightArgument()));
-            case StrAfterAst strAfterAst ->
-                    functionTerm("strafter", convert(strAfterAst.getLeftArgument()), convert(strAfterAst.getRightArgument()));
-            case StrLangAst strLangAst ->
-                    functionTerm("strlang", convert(strLangAst.getLeftArgument()), convert(strLangAst.getRightArgument()));
-            case StrDtAst strDtAst ->
-                    functionTerm(Processor.STRDT, convert(strDtAst.getLeftArgument()), convert(strDtAst.getRightArgument()));
-            case IriFunctionAst iriFunctionAst ->
-                    functionTerm("iri", convert(iriFunctionAst.argument()));
-            case LcaseAst lcaseAst ->
-                    functionTerm("lcase", convert(lcaseAst.argument()));
-            case UcaseAst ucaseAst ->
-                    functionTerm("ucase", convert(ucaseAst.argument()));
-            case EncodeForUriAst encodeForUriAst ->
-                    functionTerm("encode_for_uri", convert(encodeForUriAst.argument()));
-            case Md5Ast md5Ast ->
-                    functionTerm("md5", convert(md5Ast.argument()));
-            case Sha1Ast sha1Ast ->
-                    functionTerm("sha1", convert(sha1Ast.argument()));
-            case Sha256Ast sha256Ast ->
-                    functionTerm("sha256", convert(sha256Ast.argument()));
-            case Sha384Ast sha384Ast ->
-                    functionTerm("sha384", convert(sha384Ast.argument()));
-            case Sha512Ast sha512Ast ->
-                    functionTerm("sha512", convert(sha512Ast.argument()));
-            case ExistsAst existsAst ->
-                    throw new UnsupportedOperationException(
-                            "EXISTS { ... } conversion requires GroupGraphPatternAst → Exp (see CoreseAstQueryBuilder)");
-            case NotExistsAst notExistsAst ->
-                    throw new UnsupportedOperationException(
-                            "NOT EXISTS { ... } conversion requires GroupGraphPatternAst → Exp (see CoreseAstQueryBuilder)");
+            case BinaryRegexAst regex ->
+                    regexTerm(convert(regex.getString()), convert(regex.getPattern()));
+            case TrinaryRegexAst regex ->
+                    regexTerm(convert(regex.getString()), convert(regex.getPattern()), convert(regex.getFlags()));
+            case FunctionCallAst call ->
+                    functionCallAst(call);
+            case ConcatAst concat ->
+                    variadicTerm("concat", concat.arguments());
+            case CoalesceAst coalesce ->
+                    variadicTerm(Processor.COALESCE, coalesce.arguments());
+            case IfAst(TermAst condition, TermAst thenExpr, TermAst elseExpr) ->
+                    Term.function(Processor.IF, convert(condition), convert(thenExpr), convert(elseExpr));
+            case ReplaceAst replace ->
+                    replaceToTerm(replace);
+            case SubstrAst substr ->
+                    substrToTerm(substr);
+            case BnodeAst bnode ->
+                    bnodeToTerm(bnode);
+            case ExistsAst ignored ->
+                    throw new UnsupportedQueryFeatureException(
+                            "EXISTS filters are not supported yet by the next pipeline");
+            case NotExistsAst ignored ->
+                    throw new UnsupportedQueryFeatureException(
+                            "NOT EXISTS filters are not supported yet by the next pipeline");
             default ->
-                    throw new UnsupportedOperationException(
-                            "Unsupported constraint AST: " + constraint.getClass().getName());
+                    throw new UnsupportedQueryFeatureException(
+                            "Filter expression is not supported yet by the next pipeline: "
+                                    + constraint.getClass().getSimpleName());
         };
+    }
+
+    private static Term binaryOperatorTerm(String operator, BinaryConstraintAst binary) {
+        return Term.create(operator, convert(binary.getLeftArgument()), convert(binary.getRightArgument()));
+    }
+
+    private static Term binaryFunctionTerm(String name, BinaryConstraintAst binary) {
+        return functionTerm(name, convert(binary.getLeftArgument()), convert(binary.getRightArgument()));
     }
 
     private static Term functionTerm(String name, Expression arg) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
@@ -57,8 +58,9 @@ public final class WhereCompiler {
             case BindAst bind -> compileBind(bind);
             case ServiceAst service -> compileService(service);
             case GroupGraphPatternAst group -> compileGroup(group);
-            default -> throw new UnsupportedOperationException(
-                    "WHERE compilation not yet supported for: " + pattern.getClass().getSimpleName());
+            default -> throw new UnsupportedQueryFeatureException(
+                    "WHERE pattern is not supported yet by the next pipeline: "
+                            + pattern.getClass().getSimpleName());
         };
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
@@ -50,6 +50,7 @@ import fr.inria.corese.core.sparql.api.IDatatype;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Internal integration executor for the autonomous next SPARQL pipeline.
@@ -152,10 +153,9 @@ public final class NextSparqlPipelineExecutor {
                 if (!template.isEdge()) {
                     throw new UnsupportedQueryFeatureException("Only EDGE expressions are supported in graph templates");
                 }
-                Statement statement = statementFromTemplate(template.getEdge(), mapping);
-                if (statement != null && !statements.contains(statement)) {
-                    statements.add(statement);
-                }
+                statementFromTemplate(template.getEdge(), mapping)
+                        .filter(statement -> !statements.contains(statement))
+                        .ifPresent(statements::add);
             }
         }
         return statements;
@@ -188,12 +188,12 @@ public final class NextSparqlPipelineExecutor {
         for (Mapping mapping : mappings) {
             if (describe.isDescribeAll()) {
                 for (String variable : mapping.getVariableNames()) {
-                    addResource(resources, nullableValue(mapping.getNode(variable)));
+                    addResource(resources, valueFromNode(mapping.getNode(variable)));
                 }
             } else {
                 for (TermAst term : describe.described()) {
                     if (term instanceof VarAst(String variableName)) {
-                        addResource(resources, nullableValue(mapping.getNode(variableName)));
+                        addResource(resources, valueFromNode(mapping.getNode(variableName)));
                     } else {
                         addResource(resources, termValue(term));
                     }
@@ -209,16 +209,20 @@ public final class NextSparqlPipelineExecutor {
         }
     }
 
-    private Statement statementFromTemplate(Edge edge, Mapping mapping) {
-        Value subjectValue = nullableValue(resolve(edge.getNode(0), mapping));
-        Value predicateValue = nullableValue(resolve(predicateNode(edge), mapping));
-        Value object = nullableValue(resolve(edge.getNode(1), mapping));
-        if (subjectValue == null || predicateValue == null || object == null) {
-            return null;
+    private void addResource(List<Resource> resources, Optional<Value> value) {
+        value.ifPresent(resolved -> addResource(resources, resolved));
+    }
+
+    private Optional<Statement> statementFromTemplate(Edge edge, Mapping mapping) {
+        Optional<Value> subjectValue = valueFromNode(resolve(edge.getNode(0), mapping));
+        Optional<Value> predicateValue = valueFromNode(resolve(predicateNode(edge), mapping));
+        Optional<Value> object = valueFromNode(resolve(edge.getNode(1), mapping));
+        if (subjectValue.isEmpty() || predicateValue.isEmpty() || object.isEmpty()) {
+            return Optional.empty();
         }
-        Resource subject = asResource(subjectValue, "subject");
-        IRI predicate = asIri(predicateValue, "predicate");
-        return valueFactory.createStatement(subject, predicate, object);
+        Resource subject = asResource(subjectValue.get(), "subject");
+        IRI predicate = asIri(predicateValue.get(), "predicate");
+        return Optional.of(valueFactory.createStatement(subject, predicate, object.get()));
     }
 
     private Node resolve(Node node, Mapping mapping) {
@@ -248,7 +252,7 @@ public final class NextSparqlPipelineExecutor {
 
     private Statement statementFromAst(TriplePatternAst triple) {
         Resource subject = asResource(termValue(triple.subject()), "subject");
-        IRI predicate = asIri(termValue(triple.predicate()), "predicate");
+        IRI predicate = asIri(termValue(CoreseAstQueryBuilder.simplePredicate(triple.predicate())), "predicate");
         Value object = termValue(triple.object());
         return valueFactory.createStatement(subject, predicate, object);
     }
@@ -293,25 +297,26 @@ public final class NextSparqlPipelineExecutor {
         throw new QueryEvaluationException("Constructed " + role + " is not an IRI");
     }
 
-    private Value nullableValue(Node node) {
+    private Optional<Value> valueFromNode(Node node) {
         if (node == null) {
-            return null;
+            return Optional.empty();
         }
         IDatatype datatype = node.getDatatypeValue();
         if (datatype.isURI()) {
-            return valueFactory.createIRI(datatype.getLabel());
+            return Optional.of(valueFactory.createIRI(datatype.getLabel()));
         }
         if (datatype.isBlank()) {
-            return valueFactory.createBNode(datatype.getLabel());
+            return Optional.of(valueFactory.createBNode(datatype.getLabel()));
         }
         if (datatype.isLiteral()) {
             if (datatype.getLang() != null && !datatype.getLang().isBlank()) {
-                return valueFactory.createLiteral(datatype.getLabel(), datatype.getLang());
+                return Optional.of(valueFactory.createLiteral(datatype.getLabel(), datatype.getLang()));
             }
             if (datatype.getDatatypeURI() != null && !datatype.getDatatypeURI().isBlank()) {
-                return valueFactory.createLiteral(datatype.getLabel(), valueFactory.createIRI(datatype.getDatatypeURI()));
+                return Optional.of(
+                        valueFactory.createLiteral(datatype.getLabel(), valueFactory.createIRI(datatype.getDatatypeURI())));
             }
-            return valueFactory.createLiteral(datatype.getLabel());
+            return Optional.of(valueFactory.createLiteral(datatype.getLabel()));
         }
         throw new QueryEvaluationException("Unsupported KGRAM node datatype: " + datatype);
     }
@@ -356,13 +361,13 @@ public final class NextSparqlPipelineExecutor {
             String unquoted = lexical.substring(1, lexical.length() - 1);
             if (unquoted.contains("\\")) {
                 throw new UnsupportedQueryFeatureException(
-                        "Escaped string literals are not supported yet by the minimal next update executor");
+                        "Escaped string literals are not supported yet by the next pipeline update executor");
             }
             return unquoted;
         }
         if (lexical.contains("\\")) {
             throw new UnsupportedQueryFeatureException(
-                    "Escaped string literals are not supported yet by the minimal next update executor");
+                    "Escaped string literals are not supported yet by the next pipeline update executor");
         }
         return lexical;
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
@@ -1,0 +1,446 @@
+package fr.inria.corese.core.next.query.impl.sparql.execution;
+
+import fr.inria.corese.core.next.data.api.IRI;
+import fr.inria.corese.core.next.data.api.Resource;
+import fr.inria.corese.core.next.data.api.Statement;
+import fr.inria.corese.core.next.data.api.Value;
+import fr.inria.corese.core.next.data.api.ValueFactory;
+import fr.inria.corese.core.next.data.impl.temp.CoreseAdaptedValueFactory;
+import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
+import fr.inria.corese.core.next.query.impl.result.CoreseGraphQueryResult;
+import fr.inria.corese.core.next.query.impl.result.CoreseTupleQueryResult;
+import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.DeleteDataRequestAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.DescribeQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.InsertDataRequestAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ProjectionAsts;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.UpdateRequestAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.UpdateRequestUnitAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.bridge.CoreseAstQueryBuilder;
+import fr.inria.corese.core.next.query.kgram.api.core.Edge;
+import fr.inria.corese.core.next.query.kgram.api.core.Node;
+import fr.inria.corese.core.next.query.kgram.api.query.Environment;
+import fr.inria.corese.core.next.query.kgram.api.query.Evaluator;
+import fr.inria.corese.core.next.query.kgram.api.query.Matcher;
+import fr.inria.corese.core.next.query.kgram.api.query.ProcessVisitor;
+import fr.inria.corese.core.next.query.kgram.api.query.Producer;
+import fr.inria.corese.core.next.query.kgram.core.Eval;
+import fr.inria.corese.core.next.query.kgram.core.Mapping;
+import fr.inria.corese.core.next.query.kgram.core.Mappings;
+import fr.inria.corese.core.next.query.kgram.core.Query;
+import fr.inria.corese.core.next.query.kgram.core.SparqlException;
+import fr.inria.corese.core.next.query.kgram.tool.StorageManagerProducer;
+import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.api.result.GraphQueryResult;
+import fr.inria.corese.core.next.query.api.result.TupleQueryResult;
+import fr.inria.corese.core.next.storagemanager.api.StorageManager;
+import fr.inria.corese.core.next.storagemanager.api.support.model.MutationResult;
+import fr.inria.corese.core.next.storagemanager.api.support.model.StatementPattern;
+import fr.inria.corese.core.sparql.api.IDatatype;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Internal integration executor for the autonomous next SPARQL pipeline.
+ *
+ * <p>This class is deliberately not the final public SPARQL API. It exists for
+ * #473 to exercise the complete next-only path from a SPARQL string to results:</p>
+ *
+ * <pre>
+ * SPARQL string -> next parser -> next AST -> next KGRAM -> StorageManagerProducer -> StorageManager
+ * </pre>
+ *
+ * <p>It is acceptable for this class to gather parsing, runtime creation,
+ * graph materialization, and minimal update execution while the autonomous path
+ * is being proven. Those responsibilities should be split into dedicated
+ * services before this becomes a stable user-facing query API.</p>
+ *
+ * <p>UPDATE support is intentionally minimal for #473: only concrete {@code INSERT DATA}
+ * and {@code DELETE DATA} triples with explicit absolute IRIs are accepted. Unsupported
+ * SPARQL 1.1 forms fail explicitly instead of falling back to the legacy engine.</p>
+ */
+public final class NextSparqlPipelineExecutor {
+
+    private final StorageManager storage;
+    private final SparqlParser parser;
+    private final CoreseAstQueryBuilder queryBuilder;
+    private final ValueFactory valueFactory;
+
+    public NextSparqlPipelineExecutor(StorageManager storage) {
+        this(storage, new SparqlParser(), new CoreseAstQueryBuilder(), new CoreseAdaptedValueFactory());
+    }
+
+    NextSparqlPipelineExecutor(
+            StorageManager storage,
+            SparqlParser parser,
+            CoreseAstQueryBuilder queryBuilder,
+            ValueFactory valueFactory) {
+        this.storage = Objects.requireNonNull(storage, "storage");
+        this.parser = Objects.requireNonNull(parser, "parser");
+        this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
+        this.valueFactory = Objects.requireNonNull(valueFactory, "valueFactory");
+    }
+
+    public TupleQueryResult evaluateTuple(String sparql) {
+        QueryAst ast = parser.parse(sparql);
+        if (!(ast instanceof SelectQueryAst select)) {
+            throw new UnsupportedQueryFeatureException("Expected SELECT query, got: " + ast.getClass().getSimpleName());
+        }
+        return new CoreseTupleQueryResult(evaluate(queryBuilder.toNextQuery(select)));
+    }
+
+    public boolean evaluateBoolean(String sparql) {
+        QueryAst ast = parser.parse(sparql);
+        if (!(ast instanceof AskQueryAst ask)) {
+            throw new UnsupportedQueryFeatureException("Expected ASK query, got: " + ast.getClass().getSimpleName());
+        }
+        return evaluate(queryBuilder.toNextQuery(ask)).size() > 0;
+    }
+
+    public GraphQueryResult evaluateGraph(String sparql) {
+        QueryAst ast = parser.parse(sparql);
+        return switch (ast) {
+            case ConstructQueryAst construct -> {
+                Query query = queryBuilder.toNextQuery(construct);
+                yield new CoreseGraphQueryResult(materialize(query, evaluate(query)).iterator());
+            }
+            case DescribeQueryAst describe -> new CoreseGraphQueryResult(describe(describe).iterator());
+            default -> throw new UnsupportedQueryFeatureException(
+                    "Expected CONSTRUCT or DESCRIBE query, got: " + ast.getClass().getSimpleName());
+        };
+    }
+
+    public void executeUpdate(String sparql) {
+        QueryAst ast = parser.parse(sparql);
+        if (!(ast instanceof UpdateRequestAst update)) {
+            throw new UnsupportedQueryFeatureException("Expected SPARQL UPDATE request, got: " + ast.getClass().getSimpleName());
+        }
+        for (UpdateRequestUnitAst operation : update.operations()) {
+            executeOperation(operation);
+        }
+    }
+
+    private Mappings evaluate(Query query) {
+        try {
+            Eval eval = Eval.create(new StorageManagerProducer(storage), new NoOpEvaluator(), new BasicMatcher());
+            eval.setVisitor(new ProcessVisitor() {
+            });
+            return eval.query(query);
+        } catch (SparqlException e) {
+            throw new QueryEvaluationException("Failed to evaluate query with the next pipeline: " + e.getMessage(), e);
+        }
+    }
+
+    private List<Statement> materialize(Query query, Mappings mappings) {
+        if (query.getConstruct() == null) {
+            throw new UnsupportedQueryFeatureException("Graph query has no construct template to materialize");
+        }
+        List<Statement> statements = new ArrayList<>();
+        for (Mapping mapping : mappings) {
+            for (var template : query.getConstruct()) {
+                if (!template.isEdge()) {
+                    throw new UnsupportedQueryFeatureException("Only EDGE expressions are supported in graph templates");
+                }
+                Statement statement = statementFromTemplate(template.getEdge(), mapping);
+                if (statement != null && !statements.contains(statement)) {
+                    statements.add(statement);
+                }
+            }
+        }
+        return statements;
+    }
+
+    private List<Statement> describe(DescribeQueryAst describe) {
+        SelectQueryAst select = new SelectQueryAst(
+                ProjectionAsts.selectAll(),
+                describe.datasetClause(),
+                describe.whereClause(),
+                describe.solutionModifier(),
+                describe.prologue(),
+                describe.valuesClause());
+        Mappings mappings = evaluate(queryBuilder.toNextQuery(select));
+        List<Resource> resources = describedResources(describe, mappings);
+        List<Statement> statements = new ArrayList<>();
+        for (Resource resource : resources) {
+            try (var outgoing = storage.getQueryOperations().query(StatementPattern.of(resource, null, null))) {
+                outgoing.filter(statement -> !statements.contains(statement)).forEach(statements::add);
+            }
+            try (var incoming = storage.getQueryOperations().query(StatementPattern.of(null, null, resource))) {
+                incoming.filter(statement -> !statements.contains(statement)).forEach(statements::add);
+            }
+        }
+        return statements;
+    }
+
+    private List<Resource> describedResources(DescribeQueryAst describe, Mappings mappings) {
+        List<Resource> resources = new ArrayList<>();
+        for (Mapping mapping : mappings) {
+            if (describe.isDescribeAll()) {
+                for (String variable : mapping.getVariableNames()) {
+                    addResource(resources, nullableValue(mapping.getNode(variable)));
+                }
+            } else {
+                for (TermAst term : describe.described()) {
+                    if (term instanceof VarAst(String variableName)) {
+                        addResource(resources, nullableValue(mapping.getNode(variableName)));
+                    } else {
+                        addResource(resources, termValue(term));
+                    }
+                }
+            }
+        }
+        return resources;
+    }
+
+    private void addResource(List<Resource> resources, Value value) {
+        if (value instanceof Resource resource && !resources.contains(resource)) {
+            resources.add(resource);
+        }
+    }
+
+    private Statement statementFromTemplate(Edge edge, Mapping mapping) {
+        Value subjectValue = nullableValue(resolve(edge.getNode(0), mapping));
+        Value predicateValue = nullableValue(resolve(predicateNode(edge), mapping));
+        Value object = nullableValue(resolve(edge.getNode(1), mapping));
+        if (subjectValue == null || predicateValue == null || object == null) {
+            return null;
+        }
+        Resource subject = asResource(subjectValue, "subject");
+        IRI predicate = asIri(predicateValue, "predicate");
+        return valueFactory.createStatement(subject, predicate, object);
+    }
+
+    private Node resolve(Node node, Mapping mapping) {
+        if (node != null && node.isVariable()) {
+            return mapping.getNode(node);
+        }
+        return node;
+    }
+
+    private void executeOperation(UpdateRequestUnitAst operation) {
+        switch (operation) {
+            case InsertDataRequestAst(List<TriplePatternAst> triples) -> {
+                for (TriplePatternAst triple : triples) {
+                    checkMutation(storage.getMutationOperations().insertStatement(statementFromAst(triple)));
+                }
+            }
+            case DeleteDataRequestAst(List<TriplePatternAst> triples) -> {
+                for (TriplePatternAst triple : triples) {
+                    checkMutation(storage.getMutationOperations().deleteStatement(statementFromAst(triple)));
+                }
+            }
+            default -> throw new UnsupportedQueryFeatureException(
+                    "SPARQL update operation is not supported yet by the next pipeline: "
+                            + operation.getClass().getSimpleName());
+        }
+    }
+
+    private Statement statementFromAst(TriplePatternAst triple) {
+        Resource subject = asResource(termValue(triple.subject()), "subject");
+        IRI predicate = asIri(termValue(triple.predicate()), "predicate");
+        Value object = termValue(triple.object());
+        return valueFactory.createStatement(subject, predicate, object);
+    }
+
+    private Value termValue(TermAst term) {
+        return switch (term) {
+            case VarAst(String variableName) -> throw new UnsupportedQueryFeatureException(
+                    "Variables are not allowed in INSERT DATA / DELETE DATA: ?" + variableName);
+            case IriAst(String rawIri) -> valueFactory.createIRI(normalizeExplicitIri(rawIri, "IRI term"));
+            case LiteralAst(String lexical, String language, String datatype) -> {
+                String label = unquote(lexical);
+                if (language != null && !language.isBlank()) {
+                    yield valueFactory.createLiteral(label, language);
+                }
+                if (datatype != null && !datatype.isBlank()) {
+                    yield valueFactory.createLiteral(label, valueFactory.createIRI(normalizeDatatypeIri(datatype)));
+                }
+                yield valueFactory.createLiteral(label);
+            }
+            default -> throw new UnsupportedQueryFeatureException(
+                    "Unsupported RDF term in update data: " + term.getClass().getSimpleName());
+        };
+    }
+
+    private void checkMutation(MutationResult result) {
+        if (result.isFailure()) {
+            throw new QueryEvaluationException("Storage mutation failed: " + result.getMessage());
+        }
+    }
+
+    private Resource asResource(Value value, String role) {
+        if (value instanceof Resource resource) {
+            return resource;
+        }
+        throw new QueryEvaluationException("Constructed " + role + " is not an RDF resource");
+    }
+
+    private IRI asIri(Value value, String role) {
+        if (value instanceof IRI iri) {
+            return iri;
+        }
+        throw new QueryEvaluationException("Constructed " + role + " is not an IRI");
+    }
+
+    private Value nullableValue(Node node) {
+        if (node == null) {
+            return null;
+        }
+        IDatatype datatype = node.getDatatypeValue();
+        if (datatype.isURI()) {
+            return valueFactory.createIRI(datatype.getLabel());
+        }
+        if (datatype.isBlank()) {
+            return valueFactory.createBNode(datatype.getLabel());
+        }
+        if (datatype.isLiteral()) {
+            if (datatype.getLang() != null && !datatype.getLang().isBlank()) {
+                return valueFactory.createLiteral(datatype.getLabel(), datatype.getLang());
+            }
+            if (datatype.getDatatypeURI() != null && !datatype.getDatatypeURI().isBlank()) {
+                return valueFactory.createLiteral(datatype.getLabel(), valueFactory.createIRI(datatype.getDatatypeURI()));
+            }
+            return valueFactory.createLiteral(datatype.getLabel());
+        }
+        throw new QueryEvaluationException("Unsupported KGRAM node datatype: " + datatype);
+    }
+
+    private static Node predicateNode(Edge edge) {
+        return edge.getEdgeVariable() == null ? edge.getEdgeNode() : edge.getEdgeVariable();
+    }
+
+    private static String normalizeExplicitIri(String raw, String role) {
+        if (raw.startsWith("<") && raw.endsWith(">")) {
+            String iri = raw.substring(1, raw.length() - 1);
+            if (isAbsoluteIri(iri)) {
+                return iri;
+            }
+            throw new UnsupportedQueryFeatureException(role + " must be absolute, got: " + raw);
+        }
+        throw new UnsupportedQueryFeatureException(
+                role + " must be an explicit absolute IRI between <...>; prefixed names are not resolved here: " + raw);
+    }
+
+    private static String normalizeDatatypeIri(String raw) {
+        if (raw.startsWith("<") && raw.endsWith(">")) {
+            String iri = raw.substring(1, raw.length() - 1);
+            if (isAbsoluteIri(iri)) {
+                return iri;
+            }
+            throw new UnsupportedQueryFeatureException("Literal datatype must be absolute, got: " + raw);
+        }
+        if (isAbsoluteIri(raw)) {
+            return raw;
+        }
+        throw new UnsupportedQueryFeatureException(
+                "Literal datatype must be an explicit absolute IRI; prefixed datatypes are not resolved here: " + raw);
+    }
+
+    private static boolean isAbsoluteIri(String iri) {
+        return iri.startsWith("http://") || iri.startsWith("https://") || iri.startsWith("urn:");
+    }
+
+    private static String unquote(String lexical) {
+        if (lexical.length() >= 2 && lexical.startsWith("\"") && lexical.endsWith("\"")) {
+            String unquoted = lexical.substring(1, lexical.length() - 1);
+            if (unquoted.contains("\\")) {
+                throw new UnsupportedQueryFeatureException(
+                        "Escaped string literals are not supported yet by the minimal next update executor");
+            }
+            return unquoted;
+        }
+        if (lexical.contains("\\")) {
+            throw new UnsupportedQueryFeatureException(
+                    "Escaped string literals are not supported yet by the minimal next update executor");
+        }
+        return lexical;
+    }
+
+    private static final class BasicMatcher implements Matcher {
+        private int mode = Matcher.UNDEF;
+
+        @Override
+        public boolean match(Edge query, Edge target, Environment environment) {
+            return match(query.getNode(0), target.getNode(0), environment)
+                    && match(query.getNode(1), target.getNode(1), environment)
+                    && match(predicateNode(query), target.getEdgeNode(), environment);
+        }
+
+        @Override
+        public boolean match(Node query, Node target, Environment environment) {
+            if (query == null || target == null) {
+                return query == target;
+            }
+            if (query.isVariable()) {
+                Node bound = environment == null ? null : environment.getNode(query);
+                return bound == null || bound.match(target);
+            }
+            return query.match(target);
+        }
+
+        @Override
+        public boolean same(Node queryNode, Node left, Node right, Environment environment) {
+            return left != null && left.same(right);
+        }
+
+        @Override
+        public int getMode() {
+            return mode;
+        }
+
+        @Override
+        public void setMode(int mode) {
+            this.mode = mode;
+        }
+    }
+
+    private static final class NoOpEvaluator implements Evaluator {
+        private Mode mode = Mode.KGRAM_MODE;
+
+        @Override
+        public Mode getMode() {
+            return mode;
+        }
+
+        @Override
+        public void setMode(Mode mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public void setProducer(Producer producer) {
+            // No producer state is needed by this minimal evaluator.
+        }
+
+        @Override
+        public void setKGRAM(Eval eval) {
+            // The executor drives Eval directly, so there is no evaluator-side KGRAM state to keep.
+        }
+
+        @Override
+        public void start(Environment environment) {
+            // No per-query initialization is needed for the supported #473 query subset.
+        }
+
+        @Override
+        public void finish(Environment environment) {
+            // No per-query cleanup is needed for the supported #473 query subset.
+        }
+
+        @Override
+        public void init(Environment environment) {
+            // No per-environment initialization is needed by this no-op evaluator.
+        }
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
@@ -112,14 +113,14 @@ class CoreseAstQueryBuilderAskTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet → UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("s"), new IriAst("http://example.org/x")))));
         AskQueryAst ask = new AskQueryAst(
                 DatasetClauseAst.none(), whereOneTriple(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(ask));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(ask));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.kgram.api.core.Edge;
 import fr.inria.corese.core.next.query.kgram.api.core.Node;
@@ -156,12 +157,12 @@ class CoreseAstQueryBuilderConstructTest extends AbstractSparqlParserFeatureTest
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet -> UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         ConstructQueryAst construct = new ConstructQueryAst(template(new TriplePatternAst(new VarAst("x"), new VarAst("p"), new VarAst("o"))), DatasetClauseAst.none(), whereSPO(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(construct));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(construct));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.kgram.api.core.Node;
@@ -160,25 +161,25 @@ class CoreseAstQueryBuilderDescribeTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet → UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         DescribeQueryAst describe = new DescribeQueryAst(
                 DatasetClauseAst.none(), List.of(new VarAst("x")), whereBindingX(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(describe));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(describe));
     }
 
     @Test
-    @DisplayName("Unsupported solution modifier (e.g. DISTINCT) → UnsupportedOperationException")
+    @DisplayName("Unsupported solution modifier (e.g. DISTINCT) -> UnsupportedQueryFeatureException")
     void rejectsUnsupportedModifier() {
         SolutionModifierAst mod = SolutionModifierAst.withoutGroupBy(
                 true, false, List.of(), null, null);
         DescribeQueryAst describe = new DescribeQueryAst(
                 DatasetClauseAst.none(), List.of(new VarAst("x")), whereBindingX(), mod);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(describe));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(describe));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpressionTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpressionTest.java
@@ -1,138 +1,71 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-import fr.inria.corese.core.kgram.api.core.Edge;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.ExistsAst;
 import fr.inria.corese.core.sparql.triple.parser.Constant;
 import fr.inria.corese.core.sparql.triple.parser.Expression;
 import fr.inria.corese.core.sparql.triple.parser.Variable;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
-public class SparqlAstToExpressionTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SparqlAstToExpressionTest {
 
     @Test
-    void queryAstToQuery() {
-    }
-
-    @Test
-    void iriAstToExpression() {
+    @DisplayName("IRI terms convert to Corese constant URI expressions")
+    void convertsIriAstToConstantUri() {
         IriAst iri = new IriAst("<http://ns.inria.fr/test/iri");
-        Expression iriNode = SparqlAstToExpression.convert(iri);
-        assertNotNull(iriNode);
-        assertInstanceOf(Constant.class, iriNode);
-        assertTrue(iriNode.isURI());
-        assertEquals("http://ns.inria.fr/test/iri", ((Constant)iriNode).getLabel());
+
+        Expression expression = SparqlAstToExpression.convert(iri);
+
+        Constant constant = assertInstanceOf(Constant.class, expression);
+        assertTrue(constant.isURI());
+        assertEquals("http://ns.inria.fr/test/iri", constant.getLabel());
     }
 
     @Test
-    void literalAstToExpression() {
-        LiteralAst lit = new LiteralAst("1234", "fr", null);
-        Expression litNode = SparqlAstToExpression.convert(lit);
-        assertNotNull(litNode);
-        assertInstanceOf(Constant.class, litNode);
-        assertTrue(litNode.isLiteral());
-        assertEquals("1234", litNode.getLabel());
-        assertEquals("fr", litNode.getLang());
+    @DisplayName("Literal terms preserve lexical value and language tag")
+    void convertsLiteralAstToConstantLiteral() {
+        LiteralAst literal = new LiteralAst("1234", "fr", null);
+
+        Expression expression = SparqlAstToExpression.convert(literal);
+
+        Constant constant = assertInstanceOf(Constant.class, expression);
+        assertTrue(constant.isLiteral());
+        assertEquals("1234", constant.getLabel());
+        assertEquals("fr", constant.getLang());
     }
 
     @Test
-    void varAstToExpression() {
-        VarAst var = new VarAst("var1");
-        Expression varNode = SparqlAstToExpression.convert(var);
-        assertNotNull(varNode);
-        assertInstanceOf(Variable.class, varNode);
-        assertEquals("var1", varNode.getLabel());
+    @DisplayName("Variable terms convert to Corese variable expressions")
+    void convertsVarAstToVariable() {
+        VarAst variable = new VarAst("var1");
+
+        Expression expression = SparqlAstToExpression.convert(variable);
+
+        Variable converted = assertInstanceOf(Variable.class, expression);
+        assertEquals("var1", converted.getLabel());
     }
 
-//    @Test
-//    void triplePatternAstIriIriIriToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//
-//        TriplePatternAst iriiriiri = new TriplePatternAst(iri, iri, iri);
-//        Edge iriiriiriEdge = SparqlAstToExpression.convert(iriiriiri);
-//        assertNotNull(iriiriiriEdge);
-//        assertInstanceOf(Edge.class, iriiriiriEdge);
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstIriIriLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst iriirilit = new TriplePatternAst(iri, iri, lit);
-//        Edge iriirilitEdge = SparqlAstToExpression.convert(iriirilit);
-//        assertNotNull(iriirilitEdge);
-//        assertInstanceOf(Edge.class, iriirilitEdge);
-//        assertInstanceOf(Constant.class, iriirilitEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, iriirilitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, iriirilitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarIriLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst varirilit = new TriplePatternAst(var, iri, lit);
-//        Edge varirilitEdge = SparqlAstToExpression.convert(varirilit);
-//        assertNotNull(varirilitEdge);
-//        assertInstanceOf(Edge.class, varirilitEdge);
-//        assertInstanceOf(Variable.class, varirilitEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, varirilitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, varirilitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstIriVarLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst irivarlit = new TriplePatternAst(iri, var, lit);
-//        Edge irivarlitEdge = SparqlAstToExpression.convert(irivarlit);
-//        assertNotNull(irivarlitEdge);
-//        assertInstanceOf(Edge.class, irivarlitEdge);
-//        assertInstanceOf(Constant.class, irivarlitEdge.getSubjectNode());
-//        assertInstanceOf(Variable.class, irivarlitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, irivarlitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarIriVarToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        VarAst var1 = new VarAst("var1");
-//        VarAst var2 = new VarAst("var2");
-//
-//        TriplePatternAst varirivar = new TriplePatternAst(var1, iri, var2);
-//        Edge varirivarEdge = SparqlAstToExpression.convert(varirivar);
-//        assertNotNull(varirivarEdge);
-//        assertInstanceOf(Edge.class, varirivarEdge);
-//        assertInstanceOf(Variable.class, varirivarEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, varirivarEdge.getPropertyNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarVarVarToEdge() {
-//        VarAst var1 = new VarAst("var1");
-//        VarAst var2 = new VarAst("var2");
-//        VarAst var3 = new VarAst("var3");
-//
-//        TriplePatternAst varirivar = new TriplePatternAst(var1, var2, var3);
-//        Edge varirivarEdge = SparqlAstToExpression.convert(varirivar);
-//        assertNotNull(varirivarEdge);
-//        assertInstanceOf(Edge.class, varirivarEdge);
-//        assertInstanceOf(Variable.class, varirivarEdge.getSubjectNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getPropertyNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getObjectNode());
-//    }
+    @Test
+    @DisplayName("EXISTS filters fail explicitly until graph-pattern expression conversion exists")
+    void existsFilterFailsWithUnsupportedFeatureException() {
+        ExistsAst exists = new ExistsAst(new GroupGraphPatternAst(List.of()));
+
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> SparqlAstToExpression.convert(exists));
+
+        assertTrue(error.getMessage().contains("EXISTS filters"));
+    }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FunctionCallAst;
@@ -184,6 +185,18 @@ class WhereCompilerTest extends AbstractSparqlParserFeatureTest {
 
         assertTrue(bindExp.getFilter().isFunctional());
         assertTrue(bindExp.isFunctional(), "BIND exp should propagate functional flag");
+    }
+
+    @Test
+    @DisplayName("Unsupported WHERE pattern kinds fail with UnsupportedQueryFeatureException")
+    void unsupportedPatternFailsWithTypedException() {
+        SubQueryAst subQuery = new SubQueryAst(new SelectQueryAst(group(bgp("s", "p", "o"))));
+
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> compiler.compile(subQuery));
+
+        assertTrue(error.getMessage().contains("WHERE pattern"));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
@@ -1,0 +1,224 @@
+package fr.inria.corese.core.next.query.impl.sparql.execution;
+
+import fr.inria.corese.core.next.data.api.IRI;
+import fr.inria.corese.core.next.data.api.Resource;
+import fr.inria.corese.core.next.data.api.Statement;
+import fr.inria.corese.core.next.data.api.Value;
+import fr.inria.corese.core.next.data.api.ValueFactory;
+import fr.inria.corese.core.next.data.impl.temp.CoreseAdaptedValueFactory;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.api.result.GraphQueryResult;
+import fr.inria.corese.core.next.query.api.result.TupleQueryResult;
+import fr.inria.corese.core.next.storagemanager.api.support.model.StatementPattern;
+import fr.inria.corese.core.next.storagemanager.impl.memory.MemoryStorageManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NextSparqlPipelineExecutorTest {
+
+    private static final String ALICE = "http://example.org/alice";
+    private static final String BOB = "http://example.org/bob";
+    private static final String KNOWS = "http://example.org/knows";
+
+    private ValueFactory valueFactory;
+    private MemoryStorageManager storage;
+    private NextSparqlPipelineExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        valueFactory = new CoreseAdaptedValueFactory();
+        storage = MemoryStorageManager.builder().build();
+        executor = new NextSparqlPipelineExecutor(storage);
+
+        insert(iri(ALICE), iri(KNOWS), iri(BOB));
+    }
+
+    @Test
+    @DisplayName("SELECT * WHERE { ?s ?p ?o } runs through the next pipeline")
+    void selectSpoRunsEndToEnd() {
+        TupleQueryResult result = executor.evaluateTuple("SELECT * WHERE { ?s ?p ?o }");
+
+        assertEquals(List.of("s", "p", "o"), result.getBindingNames());
+        assertTrue(result.hasNext());
+        var binding = result.next();
+        assertEquals(ALICE, binding.getValue("s").stringValue());
+        assertEquals(KNOWS, binding.getValue("p").stringValue());
+        assertEquals(BOB, binding.getValue("o").stringValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("ASK WHERE { ?s ?p ?o } returns true when data exists")
+    void askSpoReturnsTrueWhenDataExists() {
+        assertTrue(executor.evaluateBoolean("ASK WHERE { ?s ?p ?o }"));
+    }
+
+    @Test
+    @DisplayName("ASK WHERE { <s> <p> <missing> } returns false")
+    void askSpoReturnsFalseWhenNoDataExists() {
+        assertFalse(executor.evaluateBoolean("""
+                ASK WHERE {
+                  <http://example.org/alice> <http://example.org/knows> <http://example.org/missing>
+                }
+                """));
+    }
+
+    @Test
+    @DisplayName("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } materializes next statements")
+    void constructSpoRunsEndToEnd() {
+        GraphQueryResult result = executor.evaluateGraph("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }");
+
+        List<Statement> statements = result.asList();
+        assertEquals(1, statements.size());
+        assertEquals(ALICE, statements.getFirst().getSubject().stringValue());
+        assertEquals(KNOWS, statements.getFirst().getPredicate().stringValue());
+        assertEquals(BOB, statements.getFirst().getObject().stringValue());
+    }
+
+    @Test
+    @DisplayName("CONSTRUCT templates with blank nodes fail explicitly")
+    void constructBlankNodeTemplateFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.evaluateGraph("""
+                        CONSTRUCT { _:b <http://example.org/knows> ?o }
+                        WHERE { ?s <http://example.org/knows> ?o }
+                        """));
+
+        assertTrue(error.getMessage().contains("Blank nodes in CONSTRUCT"));
+    }
+
+    @Test
+    @DisplayName("DESCRIBE ?s WHERE { ?s ?p ?o } follows the minimal outgoing/incoming strategy")
+    void describeSpoRunsEndToEnd() {
+        GraphQueryResult result = executor.evaluateGraph("DESCRIBE ?s WHERE { ?s ?p ?o }");
+
+        List<Statement> statements = result.asList();
+        assertEquals(1, statements.size());
+        assertEquals(ALICE, statements.getFirst().getSubject().stringValue());
+        assertEquals(KNOWS, statements.getFirst().getPredicate().stringValue());
+        assertEquals(BOB, statements.getFirst().getObject().stringValue());
+    }
+
+    @Test
+    @DisplayName("INSERT DATA writes through StorageManager")
+    void insertDataWritesThroughStorageManager() {
+        executor.executeUpdate("""
+                INSERT DATA {
+                  <http://example.org/bob> <http://example.org/knows> <http://example.org/alice>
+                }
+                """);
+
+        assertTrue(storage.getQueryOperations().exists(StatementPattern.of(iri(BOB), iri(KNOWS), iri(ALICE))));
+    }
+
+    @Test
+    @DisplayName("INSERT DATA with prefixed names fails explicitly")
+    void insertDataPrefixedNameFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("""
+                        PREFIX ex: <http://example.org/>
+                        INSERT DATA { ex:bob ex:knows ex:alice }
+                        """));
+
+        assertTrue(error.getMessage().contains("prefixed names are not resolved here"));
+    }
+
+    @Test
+    @DisplayName("INSERT DATA with relative IRIs fails explicitly")
+    void insertDataRelativeIriFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("""
+                        INSERT DATA {
+                          <bob> <http://example.org/knows> <http://example.org/alice>
+                        }
+                        """));
+
+        assertTrue(error.getMessage().contains("must be absolute"));
+    }
+
+    @Test
+    @DisplayName("INSERT DATA with prefixed literal datatype fails explicitly")
+    void insertDataPrefixedDatatypeFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("""
+                        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                        INSERT DATA {
+                          <http://example.org/bob> <http://example.org/age> "42"^^xsd:integer
+                        }
+                        """));
+
+        assertTrue(error.getMessage().contains("prefixed datatypes are not resolved here"));
+    }
+
+    @Test
+    @DisplayName("INSERT DATA with escaped string literal fails explicitly")
+    void insertDataEscapedLiteralFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("""
+                        INSERT DATA {
+                          <http://example.org/bob> <http://example.org/name> "Bo\\nb"
+                        }
+                        """));
+
+        assertTrue(error.getMessage().contains("Escaped string literals are not supported yet"));
+    }
+
+    @Test
+    @DisplayName("INSERT DATA with GRAPH blocks fails explicitly")
+    void insertDataGraphBlockFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("""
+                        INSERT DATA {
+                          GRAPH <http://example.org/g> {
+                            <http://example.org/bob> <http://example.org/knows> <http://example.org/alice>
+                          }
+                        }
+                        """));
+
+        assertTrue(error.getMessage().contains("GRAPH blocks"));
+    }
+
+    @Test
+    @DisplayName("DELETE DATA deletes through StorageManager")
+    void deleteDataDeletesThroughStorageManager() {
+        executor.executeUpdate("""
+                DELETE DATA {
+                  <http://example.org/alice> <http://example.org/knows> <http://example.org/bob>
+                }
+                """);
+
+        assertFalse(storage.getQueryOperations().exists(StatementPattern.of(iri(ALICE), iri(KNOWS), iri(BOB))));
+    }
+
+    @Test
+    @DisplayName("Unsupported update operations fail explicitly")
+    void unsupportedUpdateOperationFailsExplicitly() {
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> executor.executeUpdate("CLEAR DEFAULT"));
+
+        assertTrue(error.getMessage().contains("not supported yet"));
+    }
+
+    private void insert(Resource subject, IRI predicate, Value object) {
+        storage.getMutationOperations().insertStatement(valueFactory.createStatement(subject, predicate, object));
+    }
+
+    private IRI iri(String iri) {
+        return valueFactory.createIRI(iri);
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
@@ -84,6 +84,17 @@ class NextSparqlPipelineExecutorTest {
     }
 
     @Test
+    @DisplayName("CONSTRUCT skips template triples containing unbound variables")
+    void constructSkipsTemplateTripleWithUnboundVariable() {
+        GraphQueryResult result = executor.evaluateGraph("""
+                CONSTRUCT { ?s ?p ?missing }
+                WHERE { ?s ?p ?o }
+                """);
+
+        assertTrue(result.asList().isEmpty());
+    }
+
+    @Test
     @DisplayName("CONSTRUCT templates with blank nodes fail explicitly")
     void constructBlankNodeTemplateFailsExplicitly() {
         UnsupportedQueryFeatureException error = assertThrows(


### PR DESCRIPTION
## Summary

This PR adds the first autonomous end-to-end SPARQL execution path for the `next` query pipeline.

It proves that simple queries can now run through:

```text
SPARQL string -> next parser -> next AST -> next KGRAM -> StorageManagerProducer -> StorageManager
```

without using the legacy `QueryProcess`.

This PR is stacked on top of #472.

## Changes

- Configure ANTLR generated sources correctly for Gradle and IDEs.
- Add `UnsupportedQueryFeatureException` for clear unsupported-feature errors.
- Add next AST support for simple `INSERT DATA` and `DELETE DATA`.
- Add CONSTRUCT support in `CoreseAstQueryBuilder`.
- Add `NextSparqlPipelineExecutor` as an internal integration executor.
- Add end-to-end tests for SELECT, ASK, CONSTRUCT, DESCRIBE, INSERT DATA, and DELETE DATA.

## Scope

This is not the final public SPARQL API.

Unsupported SPARQL features fail explicitly.
