### PR TITLE
Add unsupported query feature exception

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/exception/UnsupportedQueryFeatureException.java
@@ -1,0 +1,27 @@
+package fr.inria.corese.core.next.query.api.exception;
+
+/**
+ * Thrown when a syntactically valid query uses a feature not implemented by the current next pipeline.
+ */
+@SuppressWarnings("java:S110")
+public class UnsupportedQueryFeatureException extends QueryException {
+
+    /**
+     * Constructs an UnsupportedQueryFeatureException with a detail message.
+     *
+     * @param message the detail message explaining which query feature is not supported
+     */
+    public UnsupportedQueryFeatureException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an UnsupportedQueryFeatureException with a detail message and cause.
+     *
+     * @param message the detail message explaining which query feature is not supported
+     * @param cause   the underlying cause that exposed the unsupported feature
+     */
+    public UnsupportedQueryFeatureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PathAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PredicatePathAst;
@@ -191,20 +192,20 @@ public final class CoreseAstQueryBuilder {
         if (path instanceof PredicatePathAst(TermAst predicate)) {
             return predicate;
         }
-        throw new UnsupportedOperationException(
-                "Property path bridge compilation is not supported yet for: "
+        throw new UnsupportedQueryFeatureException(
+                "Property path bridge compilation is not supported yet by the next pipeline for: "
                         + path.getClass().getSimpleName());
     }
 
     private static void rejectUnsupportedAskClauses(AskQueryAst askQueryAst) {
         if (!askQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "Inline VALUES is not supported yet for ASK (values handling is a follow-up)");
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet by the next pipeline for ASK");
         }
         SolutionModifierAst mod = askQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for ASK");
+            throw new UnsupportedQueryFeatureException(
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for ASK");
         }
         // TODO(#388): inline VALUES needs a dedicated runtime mapping.
         // TODO(#388): GROUP BY / HAVING would require aggregate-aware ASK semantics, not just field copying.
@@ -213,22 +214,23 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedSelectClauses(SelectQueryAst selectQueryAst) {
         if (!selectQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException("VALUES is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet by the next pipeline for SELECT");
         }
         ProjectionAst projection = selectQueryAst.projection();
         if (!projection.expressionTerms().isEmpty() || !projection.expressionBoundVariables().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "SELECT expressions are not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException(
+                    "SELECT expressions and aliases are not supported yet by the next pipeline");
         }
         SolutionModifierAst solutionModifier = selectQueryAst.solutionModifier();
         if (solutionModifier.reduced()) {
-            throw new UnsupportedOperationException("REDUCED is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("REDUCED is not supported yet by the next pipeline for SELECT");
         }
         if (solutionModifier.hasGroupBy()) {
-            throw new UnsupportedOperationException("GROUP BY is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("GROUP BY is not supported yet by the next pipeline for SELECT");
         }
         if (solutionModifier.hasHaving()) {
-            throw new UnsupportedOperationException("HAVING is not supported yet when building a next Query");
+            throw new UnsupportedQueryFeatureException("HAVING is not supported yet by the next pipeline for SELECT");
         }
         // TODO(#387): inline VALUES needs a dedicated runtime mapping.
         // TODO(#387): SELECT expressions need a clear runtime story for aliases and reuse in later clauses.
@@ -238,13 +240,13 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedDescribeClauses(DescribeQueryAst describeQueryAst) {
         if (!describeQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "Inline VALUES is not supported yet for DESCRIBE (values handling is a follow-up)");
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet by the next pipeline for DESCRIBE");
         }
         SolutionModifierAst mod = describeQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for DESCRIBE");
+            throw new UnsupportedQueryFeatureException(
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for DESCRIBE");
         }
         // TODO(#390): inline VALUES needs a dedicated runtime mapping.
         // TODO(#390): GROUP BY / HAVING would require aggregate-aware DESCRIBE semantics, not just field copying.
@@ -465,13 +467,13 @@ public final class CoreseAstQueryBuilder {
 
     private static void rejectUnsupportedConstructClauses(ConstructQueryAst constructQueryAst) {
         if (!constructQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedOperationException(
-                    "Inline VALUES is not supported yet for CONSTRUCT (values handling is a follow-up)");
+            throw new UnsupportedQueryFeatureException(
+                    "Inline VALUES is not supported yet by the next pipeline for CONSTRUCT");
         }
         SolutionModifierAst mod = constructQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
-            throw new UnsupportedOperationException(
-                    "Solution modifiers (GROUP BY, HAVING, DISTINCT, REDUCED) are not supported for CONSTRUCT");
+            throw new UnsupportedQueryFeatureException(
+                    "GROUP BY, HAVING, DISTINCT and REDUCED are not supported yet by the next pipeline for CONSTRUCT");
         }
         // TODO(#389): inline VALUES needs a dedicated runtime mapping.
         // TODO(#389): GROUP BY / HAVING would require aggregate-aware CONSTRUCT semantics, not just field copying.

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpression.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 import fr.inria.corese.core.next.data.impl.io.common.IOConstants;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.*;
 import fr.inria.corese.core.next.query.kgram.api.core.Filter;
@@ -211,14 +212,15 @@ public final class SparqlAstToExpression {
             case Sha512Ast sha512Ast ->
                     functionTerm("sha512", convert(sha512Ast.argument()));
             case ExistsAst existsAst ->
-                    throw new UnsupportedOperationException(
-                            "EXISTS { ... } conversion requires GroupGraphPatternAst → Exp (see CoreseAstQueryBuilder)");
+                    throw new UnsupportedQueryFeatureException(
+                            "EXISTS filters are not supported yet by the next pipeline");
             case NotExistsAst notExistsAst ->
-                    throw new UnsupportedOperationException(
-                            "NOT EXISTS { ... } conversion requires GroupGraphPatternAst → Exp (see CoreseAstQueryBuilder)");
+                    throw new UnsupportedQueryFeatureException(
+                            "NOT EXISTS filters are not supported yet by the next pipeline");
             default ->
-                    throw new UnsupportedOperationException(
-                            "Unsupported constraint AST: " + constraint.getClass().getName());
+                    throw new UnsupportedQueryFeatureException(
+                            "Filter expression is not supported yet by the next pipeline: "
+                                    + constraint.getClass().getSimpleName());
         };
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
@@ -57,8 +58,9 @@ public final class WhereCompiler {
             case BindAst bind -> compileBind(bind);
             case ServiceAst service -> compileService(service);
             case GroupGraphPatternAst group -> compileGroup(group);
-            default -> throw new UnsupportedOperationException(
-                    "WHERE compilation not yet supported for: " + pattern.getClass().getSimpleName());
+            default -> throw new UnsupportedQueryFeatureException(
+                    "WHERE pattern is not supported yet by the next pipeline: "
+                            + pattern.getClass().getSimpleName());
         };
     }
 

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
@@ -112,14 +113,14 @@ class CoreseAstQueryBuilderAskTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet → UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("s"), new IriAst("http://example.org/x")))));
         AskQueryAst ask = new AskQueryAst(
                 DatasetClauseAst.none(), whereOneTriple(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(ask));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(ask));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
@@ -156,12 +157,12 @@ class CoreseAstQueryBuilderConstructTest extends AbstractSparqlParserFeatureTest
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet -> UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         ConstructQueryAst construct = new ConstructQueryAst(template(new TriplePatternAst(new VarAst("x"), new VarAst("p"), new VarAst("o"))), DatasetClauseAst.none(), whereSPO(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(construct));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(construct));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.kgram.api.core.Node;
@@ -160,25 +161,25 @@ class CoreseAstQueryBuilderDescribeTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet → UnsupportedOperationException")
+    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
     void rejectsValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         DescribeQueryAst describe = new DescribeQueryAst(
                 DatasetClauseAst.none(), List.of(new VarAst("x")), whereBindingX(), null, null, values);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(describe));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(describe));
     }
 
     @Test
-    @DisplayName("Unsupported solution modifier (e.g. DISTINCT) → UnsupportedOperationException")
+    @DisplayName("Unsupported solution modifier (e.g. DISTINCT) -> UnsupportedQueryFeatureException")
     void rejectsUnsupportedModifier() {
         SolutionModifierAst mod = SolutionModifierAst.withoutGroupBy(
                 true, false, List.of(), null, null);
         DescribeQueryAst describe = new DescribeQueryAst(
                 DatasetClauseAst.none(), List.of(new VarAst("x")), whereBindingX(), mod);
 
-        assertThrows(UnsupportedOperationException.class, () -> builder.toNextQuery(describe));
+        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(describe));
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpressionTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlAstToExpressionTest.java
@@ -1,22 +1,21 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-import fr.inria.corese.core.kgram.api.core.Edge;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.ExistsAst;
 import fr.inria.corese.core.sparql.triple.parser.Constant;
 import fr.inria.corese.core.sparql.triple.parser.Expression;
 import fr.inria.corese.core.sparql.triple.parser.Variable;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SparqlAstToExpressionTest {
-
-    @Test
-    void queryAstToQuery() {
-    }
+class SparqlAstToExpressionTest {
 
     @Test
     void iriAstToExpression() {
@@ -48,91 +47,14 @@ public class SparqlAstToExpressionTest {
         assertEquals("var1", varNode.getLabel());
     }
 
-//    @Test
-//    void triplePatternAstIriIriIriToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//
-//        TriplePatternAst iriiriiri = new TriplePatternAst(iri, iri, iri);
-//        Edge iriiriiriEdge = SparqlAstToExpression.convert(iriiriiri);
-//        assertNotNull(iriiriiriEdge);
-//        assertInstanceOf(Edge.class, iriiriiriEdge);
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, iriiriiriEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstIriIriLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst iriirilit = new TriplePatternAst(iri, iri, lit);
-//        Edge iriirilitEdge = SparqlAstToExpression.convert(iriirilit);
-//        assertNotNull(iriirilitEdge);
-//        assertInstanceOf(Edge.class, iriirilitEdge);
-//        assertInstanceOf(Constant.class, iriirilitEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, iriirilitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, iriirilitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarIriLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst varirilit = new TriplePatternAst(var, iri, lit);
-//        Edge varirilitEdge = SparqlAstToExpression.convert(varirilit);
-//        assertNotNull(varirilitEdge);
-//        assertInstanceOf(Edge.class, varirilitEdge);
-//        assertInstanceOf(Variable.class, varirilitEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, varirilitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, varirilitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstIriVarLitToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        LiteralAst lit = new LiteralAst("1234", "fr", null);
-//        VarAst var = new VarAst("var1");
-//
-//        TriplePatternAst irivarlit = new TriplePatternAst(iri, var, lit);
-//        Edge irivarlitEdge = SparqlAstToExpression.convert(irivarlit);
-//        assertNotNull(irivarlitEdge);
-//        assertInstanceOf(Edge.class, irivarlitEdge);
-//        assertInstanceOf(Constant.class, irivarlitEdge.getSubjectNode());
-//        assertInstanceOf(Variable.class, irivarlitEdge.getPropertyNode());
-//        assertInstanceOf(Constant.class, irivarlitEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarIriVarToEdge() {
-//        IriAst iri = new IriAst("<http://ns.inria.fr/test/iri>");
-//        VarAst var1 = new VarAst("var1");
-//        VarAst var2 = new VarAst("var2");
-//
-//        TriplePatternAst varirivar = new TriplePatternAst(var1, iri, var2);
-//        Edge varirivarEdge = SparqlAstToExpression.convert(varirivar);
-//        assertNotNull(varirivarEdge);
-//        assertInstanceOf(Edge.class, varirivarEdge);
-//        assertInstanceOf(Variable.class, varirivarEdge.getSubjectNode());
-//        assertInstanceOf(Constant.class, varirivarEdge.getPropertyNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getObjectNode());
-//    }
-//
-//    @Test
-//    void triplePatternAstVarVarVarToEdge() {
-//        VarAst var1 = new VarAst("var1");
-//        VarAst var2 = new VarAst("var2");
-//        VarAst var3 = new VarAst("var3");
-//
-//        TriplePatternAst varirivar = new TriplePatternAst(var1, var2, var3);
-//        Edge varirivarEdge = SparqlAstToExpression.convert(varirivar);
-//        assertNotNull(varirivarEdge);
-//        assertInstanceOf(Edge.class, varirivarEdge);
-//        assertInstanceOf(Variable.class, varirivarEdge.getSubjectNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getPropertyNode());
-//        assertInstanceOf(Variable.class, varirivarEdge.getObjectNode());
-//    }
+    @Test
+    void existsFilterFailsWithUnsupportedQueryFeatureException() {
+        ExistsAst exists = new ExistsAst(new GroupGraphPatternAst(List.of()));
+
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> SparqlAstToExpression.convert(exists));
+
+        assertTrue(error.getMessage().contains("EXISTS filters"));
+    }
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
@@ -1,5 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FunctionCallAst;
@@ -184,6 +185,18 @@ class WhereCompilerTest extends AbstractSparqlParserFeatureTest {
 
         assertTrue(bindExp.getFilter().isFunctional());
         assertTrue(bindExp.isFunctional(), "BIND exp should propagate functional flag");
+    }
+
+    @Test
+    @DisplayName("Unsupported WHERE pattern kinds fail with UnsupportedQueryFeatureException")
+    void unsupportedPatternFailsWithTypedException() {
+        SubQueryAst subQuery = new SubQueryAst(new SelectQueryAst(group(bgp("s", "p", "o"))));
+
+        UnsupportedQueryFeatureException error = assertThrows(
+                UnsupportedQueryFeatureException.class,
+                () -> compiler.compile(subQuery));
+
+        assertTrue(error.getMessage().contains("WHERE pattern"));
     }
 
     @Test


### PR DESCRIPTION
Closes #487.

This PR adds a dedicated exception for SPARQL features that are valid but not supported yet by the next pipeline.

It replaces a few bridge-level UnsupportedOperationException cases with UnsupportedQueryFeatureException and updates the related tests.