### PR TITLE
refactor(query): move Dataset into query API

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/api/Operation.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/Operation.java
@@ -2,7 +2,7 @@ package fr.inria.corese.core.next.query.api;
 
 import fr.inria.corese.core.next.data.api.Value;
 import fr.inria.corese.core.next.query.api.result.BindingSet;
-import fr.inria.corese.core.next.query.dataset.Dataset;
+import fr.inria.corese.core.next.query.api.dataset.Dataset;
 
 /**
  * A generic SPARQL operation (query or update) on a Corese repository.

--- a/src/main/java/fr/inria/corese/core/next/query/api/Operation.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/Operation.java
@@ -1,8 +1,8 @@
 package fr.inria.corese.core.next.query.api;
 
 import fr.inria.corese.core.next.data.api.Value;
-import fr.inria.corese.core.next.storagemanager.api.dataset.Dataset;
 import fr.inria.corese.core.next.query.api.result.BindingSet;
+import fr.inria.corese.core.next.query.dataset.Dataset;
 
 /**
  * A generic SPARQL operation (query or update) on a Corese repository.

--- a/src/main/java/fr/inria/corese/core/next/query/api/dataset/Dataset.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/dataset/Dataset.java
@@ -1,4 +1,4 @@
-package fr.inria.corese.core.next.query.dataset;
+package fr.inria.corese.core.next.query.api.dataset;
 
 import java.util.Set;
 

--- a/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
@@ -1,9 +1,9 @@
 package fr.inria.corese.core.next.query.api.repository;
 
 import fr.inria.corese.core.next.data.api.ValueFactory;
-import fr.inria.corese.core.next.storagemanager.api.dataset.Dataset;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.exception.RepositoryException;
+import fr.inria.corese.core.next.query.dataset.Dataset;
 import fr.inria.corese.core.next.query.api.*;
 
 /**

--- a/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
@@ -1,9 +1,9 @@
 package fr.inria.corese.core.next.query.api.repository;
 
 import fr.inria.corese.core.next.data.api.ValueFactory;
+import fr.inria.corese.core.next.query.api.dataset.Dataset;
 import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import fr.inria.corese.core.next.query.api.exception.RepositoryException;
-import fr.inria.corese.core.next.query.dataset.Dataset;
 import fr.inria.corese.core.next.query.api.*;
 
 /**

--- a/src/main/java/fr/inria/corese/core/next/query/dataset/Dataset.java
+++ b/src/main/java/fr/inria/corese/core/next/query/dataset/Dataset.java
@@ -1,4 +1,4 @@
-package fr.inria.corese.core.next.storagemanager.api.dataset;
+package fr.inria.corese.core.next.query.dataset;
 
 import java.util.Set;
 


### PR DESCRIPTION
Move the public SPARQL Dataset type from core.next.storagemanager.api.dataset to core.next.query.api.dataset. Dataset represents query configuration (FROM / FROM NAMED), not storage behavior. This changes the public package, so consumers must update their imports.