### PR TITLE
small PR to create an enum from constants

### DIFF
--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRight.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRight.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.sparql.triple.parser;
 
 import fr.inria.corese.core.kgram.api.core.Edge;
 import fr.inria.corese.core.sparql.api.IDatatype;
+import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessRights;
 
 /**
  * 
@@ -39,10 +40,7 @@ public class AccessRight {
         }
 
     }
-
-    public static final int GT_MODE  = 0;
-    public static final int EQ_MODE  = 1;
-    public static final int BI_MODE  = 2;
+    public enum AccessModes { GT_MODE, EQ_MODE, BI_MODE }
 
     public static final byte ZERO = 0b0000000;
     // available for access right:
@@ -59,7 +57,7 @@ public class AccessRight {
 
     public static final byte[] BINARY = {ZERO, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN};
 
-    public static final int DEFAULT_MODE = GT_MODE;
+    public static final AccessModes DEFAULT_MODE = AccessModes.GT_MODE;
     
     public static final String GT_ACCESS_MODE    = NSManager.EXT+"gt";
     public static final String EQ_ACCESS_MODE    = NSManager.EXT+"eq";
@@ -87,7 +85,7 @@ public class AccessRight {
     private AccessRights[] whereList = new AccessRights[0];
     private AccessRights where    = DEFAULT;
         
-    private static int mode = DEFAULT_MODE;
+    private static AccessModes mode = DEFAULT_MODE;
     
     private AccessRightDefinition insertRightDefinition;
     private AccessRightDefinition deleteRightDefinition;
@@ -338,24 +336,24 @@ public class AccessRight {
     }
     
    
-    public static int getMode() {
+    public static AccessModes getMode() {
         return mode;
     }
     
-    public static void setMode(int m) {
+    public static void setMode(AccessModes m) {
         mode = m;
     }
     
     public static void gtMode() {
-        setMode(GT_MODE);
+        setMode(AccessModes.GT_MODE);
     }
     
     public static void eqMode() {
-        setMode(EQ_MODE);
+        setMode(AccessModes.EQ_MODE);
     }
     
      public static void biMode() {
-        setMode(BI_MODE);
+        setMode(AccessModes.BI_MODE);
     }
     
 

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRight.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRight.java
@@ -2,7 +2,6 @@ package fr.inria.corese.core.sparql.triple.parser;
 
 import fr.inria.corese.core.kgram.api.core.Edge;
 import fr.inria.corese.core.sparql.api.IDatatype;
-import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessRights;
 
 /**
  * 
@@ -11,8 +10,6 @@ import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessRights;
 public class AccessRight {
     
     private static boolean active = false;
-    // @deprecated
-    private static boolean inheritDefault = false;
 
     public enum AccessRights {
         // NONE means no access right
@@ -40,7 +37,7 @@ public class AccessRight {
         }
 
     }
-    public enum AccessModes { GT_MODE, EQ_MODE, BI_MODE }
+    public enum AccessMode { GT, EQ, BINARY }
 
     public static final byte ZERO = 0b0000000;
     // available for access right:
@@ -57,7 +54,7 @@ public class AccessRight {
 
     public static final byte[] BINARY = {ZERO, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN};
 
-    public static final AccessModes DEFAULT_MODE = AccessModes.GT_MODE;
+    public static final AccessMode DEFAULT_MODE = AccessMode.GT;
     
     public static final String GT_ACCESS_MODE    = NSManager.EXT+"gt";
     public static final String EQ_ACCESS_MODE    = NSManager.EXT+"eq";
@@ -85,12 +82,10 @@ public class AccessRight {
     private AccessRights[] whereList = new AccessRights[0];
     private AccessRights where    = DEFAULT;
         
-    private static AccessModes mode = DEFAULT_MODE;
+    private static AccessMode mode = DEFAULT_MODE;
     
     private AccessRightDefinition insertRightDefinition;
     private AccessRightDefinition deleteRightDefinition;
-    
-    private boolean debug = false;
     
     
     
@@ -155,14 +150,11 @@ public class AccessRight {
     }
     
     public static boolean accept(AccessRights query, AccessRights target) {
-        switch (mode) {
-            case EQ_MODE:
-                return acceptEQ(query, target);
-            case BI_MODE:
-                return acceptBI(query, target);    
-            default:
-                return acceptGT(query, target);
-        }
+        return switch (mode) {
+            case EQ -> acceptEQ(query, target);
+            case BINARY -> acceptBI(query, target);
+            default -> acceptGT(query, target);
+        };
     }
     
     
@@ -336,24 +328,24 @@ public class AccessRight {
     }
     
    
-    public static AccessModes getMode() {
+    public static AccessMode getMode() {
         return mode;
     }
     
-    public static void setMode(AccessModes m) {
+    public static void setMode(AccessMode m) {
         mode = m;
     }
     
     public static void gtMode() {
-        setMode(AccessModes.GT_MODE);
+        setMode(AccessMode.GT);
     }
     
     public static void eqMode() {
-        setMode(AccessModes.EQ_MODE);
+        setMode(AccessMode.EQ);
     }
     
-     public static void biMode() {
-        setMode(AccessModes.BI_MODE);
+    public static void biMode() {
+        setMode(AccessMode.BINARY);
     }
     
 

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
@@ -3,7 +3,7 @@ package fr.inria.corese.core.sparql.triple.parser;
 import fr.inria.corese.core.kgram.api.core.Edge;
 import fr.inria.corese.core.kgram.api.core.Node;
 import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessRights;
-import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessModes;
+import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessMode;
 
 import java.util.HashMap;
 
@@ -152,13 +152,13 @@ public class AccessRightDefinition {
         return null;
     }
     
-    AccessModes getMode() {
+    AccessMode getMode() {
         return AccessRight.getMode();
     }
 
     
     AccessRights combine(AccessRights b1, AccessRights b2) {
-        if (getMode() == AccessModes.BI_MODE) {
+        if (getMode() == AccessMode.BINARY) {
             return combineBinary(b1, b2);
         }
         return moreRestricted(b1, b2);

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
@@ -2,6 +2,7 @@ package fr.inria.corese.core.sparql.triple.parser;
 
 import fr.inria.corese.core.kgram.api.core.Edge;
 import fr.inria.corese.core.kgram.api.core.Node;
+import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessRights;
 import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessModes;
 
 import java.util.HashMap;
@@ -31,7 +32,7 @@ public class AccessRightDefinition {
         setSingleton(new AccessRightDefinition());
     }
     
-    public class AccessMap extends HashMap<String, AccessRight.AccessRights> {
+    public class AccessMap extends HashMap<String, AccessRights> {
 
 
         /**
@@ -40,11 +41,11 @@ public class AccessRightDefinition {
          * otherwise return null
          * @return
          */
-        AccessRight.AccessRights getAccess(Node node) {
+        AccessRights getAccess(Node node) {
             if (isEmpty()) {
                 return null;
             }
-            AccessRight.AccessRights b = get(node.getLabel());
+            AccessRights b = get(node.getLabel());
             if (b != null) {
                 return b;
             }
@@ -111,22 +112,22 @@ public class AccessRightDefinition {
      * res is the URI|namespace access right granted for edge
      * @return
      */
-    AccessRight.AccessRights getAccess(Edge edge, AccessRight.AccessRights def) {
-        AccessRight.AccessRights res = getAccess(edge);
+    AccessRights getAccess(Edge edge, AccessRights def) {
+        AccessRights res = getAccess(edge);
         if (res == null) {
             return def;
         }
         return res;
     }
     
-    AccessRight.AccessRights getAccess(Edge edge) {
+    AccessRights getAccess(Edge edge) {
        return getAccessDirect(edge);
     }
     
     /**
      * URI of default may overload namespace of current (if current has no URI)
      */
-    AccessRight.AccessRights getAccessDirect(Edge edge) {
+    AccessRights getAccessDirect(Edge edge) {
         if (size() == 0) {
             return null;
         }
@@ -134,23 +135,23 @@ public class AccessRightDefinition {
     }  
 
 
-    AccessRight.AccessRights get(AccessRight.AccessRights current, AccessRight.AccessRights defaut) {
+    AccessRights get(AccessRights current, AccessRights defaut) {
         return (current == null) ? defaut : current;
     }
 
 
-    AccessRight.AccessRights getAccessOrDefault(Edge edge) {
-        AccessRight.AccessRights res = getAccessBasic(edge);
+    AccessRights getAccessOrDefault(Edge edge) {
+        AccessRights res = getAccessBasic(edge);
         if (res == null) {
             return getSingleton().getAccessBasic(edge);
         }
         return res;
     }
 
-    AccessRight.AccessRights getAccessBasic(Edge edge) {
+    AccessRights getAccessBasic(Edge edge) {
         if (size() > 0) {
-            AccessRight.AccessRights node   = combine(getSubject(edge),   getObject(edge));
-            AccessRight.AccessRights access = combine(getPredicate(edge), getGraph(edge));
+            AccessRights node   = combine(getSubject(edge),   getObject(edge));
+            AccessRights access = combine(getPredicate(edge), getGraph(edge));
             return combine(node, access);
         }
         return null;
@@ -161,14 +162,14 @@ public class AccessRightDefinition {
     }
 
     
-    AccessRight.AccessRights combine(AccessRight.AccessRights b1, AccessRight.AccessRights b2) {
+    AccessRights combine(AccessRights b1, AccessRights b2) {
         if (getMode() == AccessModes.BI_MODE) {
             return combineBinary(b1, b2);
         }
         return moreRestricted(b1, b2);
     }
 
-    AccessRight.AccessRights combineBinary(AccessRight.AccessRights b1, AccessRight.AccessRights b2) {
+    AccessRights combineBinary(AccessRights b1, AccessRights b2) {
         if (b1 == null) {
             return b2;
         }
@@ -179,7 +180,7 @@ public class AccessRightDefinition {
     }
 
 
-    AccessRight.AccessRights moreRestricted(AccessRight.AccessRights b1, AccessRight.AccessRights b2) {
+    AccessRights moreRestricted(AccessRights b1, AccessRights b2) {
         if (b1 == null) {
             return b2;
         }
@@ -192,22 +193,22 @@ public class AccessRightDefinition {
 
   
     // return null when there is no uri access right
-    AccessRight.AccessRights getPredicate(Edge edge) {
+    AccessRights getPredicate(Edge edge) {
         return getPredicate().getAccess(edge.getProperty());
     }
 
-    AccessRight.AccessRights getGraph(Edge edge) {
+    AccessRights getGraph(Edge edge) {
          if (edge.getGraph() == null) {
             return null;
         }
         return getGraph().getAccess(edge.getGraph());
     }
 
-    AccessRight.AccessRights getSubject(Edge edge) {
+    AccessRights getSubject(Edge edge) {
         return getNode().getAccess(edge.getNode(0));
     }
 
-    AccessRight.AccessRights getObject(Edge edge) {
+    AccessRights getObject(Edge edge) {
         return getNode().getAccess(edge.getNode(1));
     }
     

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
@@ -23,10 +23,6 @@ public class AccessRightDefinition {
     private AccessMap graphAccess;
     private AccessMap predicateAccess;
     
-    private boolean debug = false;
-    private boolean inheritDefault = false;
-    
-    
     
     static {
         setSingleton(new AccessRightDefinition());
@@ -92,7 +88,6 @@ public class AccessRightDefinition {
     
     public void inheritDefault() {
         inherit(getSingleton());
-        setInheritDefault(true);
     }
     
     
@@ -243,13 +238,6 @@ public class AccessRightDefinition {
 
 
     /**
-     * @param debug the debug to set
-     */
-    public void setDebug(boolean debug) {
-        this.debug = debug;
-    }
-
-    /**
      * @return the singleton
      */
     public static AccessRightDefinition getSingleton() {
@@ -304,18 +292,5 @@ public class AccessRightDefinition {
     public void setPredicateAccess(AccessMap predicateAccess) {
         this.predicateAccess = predicateAccess;
     }
-
-
-    /**
-     * @param inheritDefault the inheritDefault to set
-     */
-    public void setInheritDefault(boolean inheritDefault) {
-        this.inheritDefault = inheritDefault;
-    }
-    
-    
-    
-    
-    
     
 }

--- a/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
+++ b/src/main/java/fr/inria/corese/core/sparql/triple/parser/AccessRightDefinition.java
@@ -2,6 +2,8 @@ package fr.inria.corese.core.sparql.triple.parser;
 
 import fr.inria.corese.core.kgram.api.core.Edge;
 import fr.inria.corese.core.kgram.api.core.Node;
+import fr.inria.corese.core.sparql.triple.parser.AccessRight.AccessModes;
+
 import java.util.HashMap;
 
 /**
@@ -154,13 +156,13 @@ public class AccessRightDefinition {
         return null;
     }
     
-    int getMode() {
+    AccessModes getMode() {
         return AccessRight.getMode();
     }
 
     
     AccessRight.AccessRights combine(AccessRight.AccessRights b1, AccessRight.AccessRights b2) {
-        if (getMode() == AccessRight.BI_MODE) {
+        if (getMode() == AccessModes.BI_MODE) {
             return combineBinary(b1, b2);
         }
         return moreRestricted(b1, b2);


### PR DESCRIPTION
created an enum "AccessModes" in `core.sparql.triple.parser.AccessRight` from constants GT_MODE, EQ_MODE, BI_MODE
+ a little bit of refactoring/cleaning in `core.sparql.triple.parser.AccessRightDefinition`