### PR TITLE
add canonicalMap API for W3C RDFC-1.0 blank node mapping evaluation

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/data/RdfCanonicalization.java
+++ b/src/main/java/fr/inria/corese/core/next/data/RdfCanonicalization.java
@@ -7,6 +7,7 @@ import fr.inria.corese.core.next.data.impl.io.serializer.rdfc10.RDFC10Serializer
 import fr.inria.corese.core.next.data.impl.io.serializer.rdfc10.StatementUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /** Public entry point for RDF Dataset Canonicalization 1.0 operations. */
@@ -19,6 +20,43 @@ public final class RdfCanonicalization {
     }
 
     private RdfCanonicalization() {
+    }
+
+    /**
+     * Computes the canonical blank node mapping for a model with standard RDFC 1.0 configuration.
+     *
+     * @param model model to map
+     * @return map from original blank node IDs to canonical identifiers
+     */
+    public static Map<String, String> canonicalMap(Model model) {
+        return canonicalMap(model, RDFC10SerializerOptions.defaultConfig());
+    }
+
+    /**
+     * Computes the canonical blank node mapping for a model with a specified hash algorithm.
+     *
+     * @param model model to map
+     * @param hashAlgorithm hash algorithm to use (SHA-256 or SHA-384)
+     * @return map from original blank node IDs to canonical identifiers
+     */
+    public static Map<String, String> canonicalMap(Model model, HashAlgorithm hashAlgorithm) {
+        Objects.requireNonNull(hashAlgorithm, "hashAlgorithm");
+        RDFC10SerializerOptions.HashAlgorithm internalAlgorithm = switch (hashAlgorithm) {
+            case SHA_256 -> RDFC10SerializerOptions.HashAlgorithm.SHA_256;
+            case SHA_384 -> RDFC10SerializerOptions.HashAlgorithm.SHA_384;
+        };
+        return canonicalMap(model, RDFC10SerializerOptions.builder().hashAlgorithm(internalAlgorithm).build());
+    }
+
+    private static Map<String, String> canonicalMap(Model model, RDFC10SerializerOptions options) {
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(options, "options");
+        return new RDFC10Canonicalizer(
+                options.getHashAlgorithm(),
+                options.getPermutationLimit(),
+                options.getDepthFactor(),
+                Values.factory()
+        ).canonicalMap(model);
     }
 
     /**

--- a/src/main/java/fr/inria/corese/core/next/data/impl/io/serializer/rdfc10/RDFC10Canonicalizer.java
+++ b/src/main/java/fr/inria/corese/core/next/data/impl/io/serializer/rdfc10/RDFC10Canonicalizer.java
@@ -71,6 +71,23 @@ public class RDFC10Canonicalizer {
     }
 
     /**
+     * Computes the canonical blank node replacement map for a {@link Model} according to W3C RDFC-1.0.
+     *
+     * @param model The model whose blank nodes will be mapped. Must not be null.
+     * @return An unmodifiable map from original blank node identifiers to their canonical identifiers (e.g. c14n0).
+     */
+    public Map<String, String> canonicalMap(Model model) {
+        Objects.requireNonNull(model, "Model cannot be null");
+        List<Statement> stmtList = model.stream().toList();
+        callsHashNDegreeQuads = 0;
+        Map<String, List<Statement>> blankNodeToQuads = createBNodeToQuadsMap(stmtList);
+        if (blankNodeToQuads.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(createCanonicalMap(blankNodeToQuads));
+    }
+
+    /**
      * Canonicalizes an RDF {@link Model} according to the W3C RDFC-1.0 specification.
      *
      * @param model The model to canonicalize. Must not be null.


### PR DESCRIPTION
### Summary
Adds the `canonicalMap(Model, HashAlgorithm)` API to expose the deterministic blank node identifier mapping (`Map<String, String>`) computed during RDFC-1.0 canonicalization.

### Changes
- Expose `canonicalMap(Model)` and `canonicalMap(Model, HashAlgorithm)` in `RdfCanonicalization`.
- Implement mapping retrieval in `RDFC10Canonicalizer`.

### Testing
- Tested and verified against the official W3C RDFC-1.0 `Rdfc10MapTest` suite in `corese-w3c`.