### PR TITLE
refactor(next): streamline AST execution bridges and eliminate query adapter layers (#576)

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/AstBackedExpr.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/AstBackedExpr.java
@@ -138,7 +138,7 @@ public final class AstBackedExpr implements Expr {
             SparqlTermResolver resolver = whereCompiler == null
                     ? new SparqlTermResolver(null)
                     : whereCompiler.termResolver();
-            return CoreseAstQueryBuilder.toNode(source, resolver).getDatatypeValue();
+            return resolver.toNode(source).getDatatypeValue();
         }
         return null;
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -3,8 +3,6 @@ package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
-import fr.inria.corese.core.next.query.impl.sparql.ast.path.PathAst;
-import fr.inria.corese.core.next.query.impl.sparql.ast.path.PredicatePathAst;
 import fr.inria.corese.core.next.query.impl.engine.model.ExpType.Type;
 import fr.inria.corese.core.next.query.impl.engine.model.Filter;
 import fr.inria.corese.core.next.query.impl.engine.model.Node;
@@ -170,22 +168,6 @@ public final class CoreseAstQueryBuilder {
     public Filter toNextFilter(ConstraintAst filterExpression) {
         Objects.requireNonNull(filterExpression, "filterExpression");
         return new AstBackedExpr(filterExpression, whereCompiler).getFilter();
-    }
-
-    /**
-     * Converts a query term used as subject, predicate, object, or variable reference
-     * into a runtime {@link Node}.
-     *
-     * <p>This helper is package-visible because both the query builder and the
-     * {@link WhereCompiler} need a single shared term-to-node conversion rule.</p>
-     */
-    static TermAst simplePredicate(PathAst path) {
-        if (path instanceof PredicatePathAst(TermAst predicate)) {
-            return predicate;
-        }
-        throw new UnsupportedQueryFeatureException(
-                "Property path bridge compilation is not supported yet by the next pipeline for: "
-                        + path.getClass().getSimpleName());
     }
 
     /**
@@ -521,7 +503,8 @@ public final class CoreseAstQueryBuilder {
         Exp bgp = Exp.create(Type.BGP);
         for (TriplePatternAst triple : template.triplePatternAsts()) {
             Node subject = constructNode(query, triple.subject(), compiler);
-            Node predicate = constructNode(query, simplePredicate(triple.predicate()), compiler);
+            Node predicate = constructNode(
+                    query, WhereCompiler.simplePredicate(triple.predicate()), compiler);
             Node object = constructNode(query, triple.object(), compiler);
             bgp.add(new AstBackedEdge(subject, predicate, object));
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -179,14 +179,6 @@ public final class CoreseAstQueryBuilder {
      * <p>This helper is package-visible because both the query builder and the
      * {@link WhereCompiler} need a single shared term-to-node conversion rule.</p>
      */
-    static Node toNode(TermAst term) {
-        return toNode(term, new SparqlTermResolver(null));
-    }
-
-    static Node toNode(TermAst term, SparqlTermResolver resolver) {
-        return resolver.toNode(term);
-    }
-
     static TermAst simplePredicate(PathAst path) {
         if (path instanceof PredicatePathAst(TermAst predicate)) {
             return predicate;
@@ -307,7 +299,7 @@ public final class CoreseAstQueryBuilder {
     private List<Node> toNodeList(Iterable<IriAst> iris, WhereCompiler compiler) {
         List<Node> nodes = new ArrayList<>();
         for (IriAst iri : iris) {
-            nodes.add(toNode(iri, compiler.termResolver()));
+            nodes.add(compiler.termResolver().toNode(iri));
         }
         return nodes;
     }
@@ -360,7 +352,7 @@ public final class CoreseAstQueryBuilder {
                 }
                 nodes.add(node);
             } else {
-                nodes.add(toNode(term, compiler.termResolver()));
+                nodes.add(compiler.termResolver().toNode(term));
             }
         }
         return nodes;
@@ -545,8 +537,8 @@ public final class CoreseAstQueryBuilder {
     private Node constructNode(Query query, TermAst term, WhereCompiler compiler) {
         if (term instanceof VarAst(String name)) {
             Node bound = visibleBodyNode(query, name);
-            return bound != null ? bound : toNode(term, compiler.termResolver());
+            return bound != null ? bound : compiler.termResolver().toNode(term);
         }
-        return toNode(term, compiler.termResolver());
+        return compiler.termResolver().toNode(term);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -184,18 +184,7 @@ public final class CoreseAstQueryBuilder {
     }
 
     static Node toNode(TermAst term, SparqlTermResolver resolver) {
-        return switch (term) {
-            case VarAst(String name) -> NodeImpl.forVariable(name);
-            case IriAst(String raw) when raw.startsWith("_:") -> NodeImpl.forBlank(raw.substring(2));
-            case IriAst(String raw) -> NodeImpl.forIRI(resolver.resolveIri(raw));
-            case LiteralAst(String lexical, String lang, String datatype) -> NodeImpl.forLiteral(
-                    resolver.unquoteLexical(lexical),
-                    resolver.normalizeDatatypeIri(datatype),
-                    lang);
-            default -> throw new IllegalArgumentException(
-                    "A query term must be a variable, IRI or literal, got: "
-                            + term.getClass().getSimpleName());
-        };
+        return resolver.toNode(term);
     }
 
     static TermAst simplePredicate(PathAst path) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeEvaluationContext.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeEvaluationContext.java
@@ -60,7 +60,7 @@ final class NativeEvaluationContext {
     }
 
     DatatypeValue constant(TermAst expression) {
-        return CoreseAstQueryBuilder.toNode(expression, termResolver()).getDatatypeValue();
+        return termResolver().toNode(expression).getDatatypeValue();
     }
 
     DatatypeValue required(TermAst expression) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NextFilterFromAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NextFilterFromAst.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.engine.model.Expr;
 import fr.inria.corese.core.next.query.impl.engine.model.Filter;
@@ -10,9 +9,7 @@ import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.Varia
 import java.util.List;
 import java.util.Optional;
 
-/**
- * {@link Filter} view exposing native AST metadata through the Corese-next {@link Expr} API.
- */
+/** Filter view exposing native AST metadata through the Corese-next expression API. */
 public final class NextFilterFromAst implements Filter {
 
     private final AstBackedExpr owner;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
@@ -5,10 +5,14 @@ import fr.inria.corese.core.next.data.api.vocabulary.RDF;
 import fr.inria.corese.core.next.data.impl.namespace.PrefixHandler;
 import fr.inria.corese.core.next.data.spi.io.IOConstants;
 import fr.inria.corese.core.next.data.spi.term.IRIUtils;
+import fr.inria.corese.core.next.query.impl.engine.model.Node;
+import fr.inria.corese.core.next.query.impl.engine.model.NodeImpl;
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.PrefixDeclarationAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryPrologueAst;
-
-import java.util.Objects;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 
 /** Resolves SPARQL terms against one immutable query-prologue snapshot. */
 public final class SparqlTermResolver {
@@ -43,6 +47,20 @@ public final class SparqlTermResolver {
             return raw;
         }
         return resolvePrefixedIri(raw);
+    }
+
+    public Node toNode(TermAst term) {
+        return switch (term) {
+            case VarAst(String name) -> NodeImpl.forVariable(name);
+            case IriAst(String raw) when raw.startsWith(IOConstants.BLANK_NODE_PREFIX) ->
+                    NodeImpl.forBlank(raw.substring(IOConstants.BLANK_NODE_PREFIX.length()));
+            case IriAst(String raw) -> NodeImpl.forIRI(resolveIri(raw));
+            case LiteralAst(String lexical, String lang, String datatype) -> NodeImpl.forLiteral(
+                    unquoteLexical(lexical), normalizeDatatypeIri(datatype), lang);
+            default -> throw new IllegalArgumentException(
+                    "A query term must be a variable, IRI or literal, got: "
+                            + term.getClass().getSimpleName());
+        };
     }
 
     public String normalizeDatatypeIri(String datatype) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
@@ -120,10 +120,10 @@ public final class WhereCompiler {
     }
 
     private Edge toEdge(TriplePatternAst triple) {
-        Node subject = CoreseAstQueryBuilder.toNode(triple.subject(), termResolver);
-        Node predicate = CoreseAstQueryBuilder.toNode(
-                CoreseAstQueryBuilder.simplePredicate(triple.predicate()), termResolver);
-        Node object = CoreseAstQueryBuilder.toNode(triple.object(), termResolver);
+        Node subject = termResolver.toNode(triple.subject());
+        Node predicate = termResolver.toNode(
+            CoreseAstQueryBuilder.simplePredicate(triple.predicate()));
+        Node object = termResolver.toNode(triple.object());
         return new AstBackedEdge(subject, predicate, object);
     }
 
@@ -165,7 +165,7 @@ public final class WhereCompiler {
      */
     private Exp compileBind(BindAst bind) {
         Filter filter = new AstBackedExpr(bind.expression(), this).getFilter();
-        Node variable = CoreseAstQueryBuilder.toNode(bind.variable(), termResolver);
+        Node variable = termResolver.toNode(bind.variable());
         Exp exp = Exp.create(Type.BIND);
         exp.setFilter(filter);
         exp.setFunctional(filter.isFunctional());
@@ -177,7 +177,7 @@ public final class WhereCompiler {
      * Compiles {@code SERVICE <endpoint> { ... }} into a KGRAM {@link Exp}.
      */
     private Exp compileService(ServiceAst service) {
-        Node endpoint = CoreseAstQueryBuilder.toNode(service.endpoint(), termResolver);
+        Node endpoint = termResolver.toNode(service.endpoint());
         Exp endpointNode = Exp.create(Type.NODE, endpoint);
         Query body = Query.create(compile(service.pattern()));
         body.setService(true);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
@@ -11,8 +11,11 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.OptionalAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.PatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryPrologueAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ServiceAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.UnionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.path.PathAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.path.PredicatePathAst;
 import fr.inria.corese.core.next.query.impl.engine.model.Edge;
 import fr.inria.corese.core.next.query.impl.engine.model.ExpType.Type;
 import fr.inria.corese.core.next.query.impl.engine.model.Filter;
@@ -122,9 +125,18 @@ public final class WhereCompiler {
     private Edge toEdge(TriplePatternAst triple) {
         Node subject = termResolver.toNode(triple.subject());
         Node predicate = termResolver.toNode(
-            CoreseAstQueryBuilder.simplePredicate(triple.predicate()));
+            simplePredicate(triple.predicate()));
         Node object = termResolver.toNode(triple.object());
         return new AstBackedEdge(subject, predicate, object);
+    }
+
+    static TermAst simplePredicate(PathAst path) {
+        if (path instanceof PredicatePathAst(TermAst predicate)) {
+            return predicate;
+        }
+        throw new UnsupportedQueryFeatureException(
+                "Property path bridge compilation is not supported yet by the next pipeline for: "
+                        + path.getClass().getSimpleName());
     }
 
     private Exp compileFilter(FilterAst filter) {

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/AstBackedExprTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/AstBackedExprTest.java
@@ -1,0 +1,80 @@
+package fr.inria.corese.core.next.query.impl.sparql.bridge;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.IriAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.LiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.PrefixDeclarationAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.QueryPrologueAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BoundAst;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("AstBackedExpr: AST wrapping, value resolution, and filter view")
+class AstBackedExprTest {
+
+    @Test
+    void resolvesConstantUsingCompilerPrologue() {
+        QueryPrologueAst prologue = new QueryPrologueAst(
+                List.of(new PrefixDeclarationAst("ex:", new IriAst("http://example.org/"))),
+                null);
+        WhereCompiler compiler = new WhereCompiler().withPrologue(prologue);
+        AstBackedExpr expression = new AstBackedExpr(new IriAst("ex:name"), compiler);
+
+        assertEquals("http://example.org/name", expression.getValue().stringValue());
+        assertTrue(expression.isConstant());
+        assertFalse(expression.isVariable());
+    }
+
+    @Test
+    void resolvesLiteralValue() {
+        WhereCompiler compiler = new WhereCompiler();
+        AstBackedExpr stringExpr = new AstBackedExpr(new LiteralAst("\"hello\"", null, null), compiler);
+        assertEquals("hello", stringExpr.getValue().stringValue());
+
+        AstBackedExpr intExpr = new AstBackedExpr(new LiteralAst("42", null, "http://www.w3.org/2001/XMLSchema#integer"), compiler);
+        assertEquals("42", intExpr.getValue().stringValue());
+    }
+
+    @Test
+    void variableExpressionMetadata() {
+        WhereCompiler compiler = new WhereCompiler();
+        AstBackedExpr varExpr = new AstBackedExpr(new VarAst("x"), compiler);
+
+        assertEquals("x", varExpr.getLabel());
+        assertTrue(varExpr.isVariable());
+        assertFalse(varExpr.isConstant());
+        assertTrue(varExpr.getExpList().isEmpty());
+        assertNull(varExpr.getArg());
+    }
+
+    @Test
+    void boundExpressionAndFilterView() {
+        WhereCompiler compiler = new WhereCompiler();
+        BoundAst boundAst = new BoundAst(List.of(new VarAst("y")));
+        AstBackedExpr boundExpr = new AstBackedExpr(boundAst, compiler);
+
+        assertTrue(boundExpr.isBound());
+        assertNotNull(boundExpr.getFilter());
+        assertTrue(boundExpr.getFilter().isBound());
+        assertEquals(List.of("y"), boundExpr.getFilter().getVariables());
+        assertEquals(boundAst, boundExpr.getFilter().getFilterExpression());
+    }
+
+    @Test
+    void immutableExpressionsThrowOnModification() {
+        WhereCompiler compiler = new WhereCompiler();
+        AstBackedExpr expr = new AstBackedExpr(new VarAst("z"), compiler);
+
+        assertThrows(UnsupportedOperationException.class, () -> expr.setExp(0, expr));
+        assertThrows(UnsupportedOperationException.class, () -> expr.setArg(expr));
+    }
+}


### PR DESCRIPTION
### Summary
Streamlines and simplifies the execution bridge layers in `fr.inria.corese.core.next.query.impl.sparql.bridge` to eliminate unnecessary intermediate translation wrappers between the Next SPARQL AST and the query execution pipeline.

Closes #576

### Changes
* **Centralize term resolution**: Moved term-to-node resolution directly into `SparqlTermResolver.toNode(TermAst)`, eliminating duplicated switch logic across bridge classes.
* **Eliminate builder indirection**: Replaced static indirections in `CoreseAstQueryBuilder` and `NativeEvaluationContext` with direct calls to `termResolver.toNode(term)`.
* **Relocate path predicate extraction**: Moved `simplePredicate(PathAst)` to `WhereCompiler` where query and construct graph patterns are resolved.
* **Clean up imports & formatting**: Removed redundant explicit imports and normalized EOF newlines across bridge classes.
* **Unit testing**: Added dedicated unit tests in `AstBackedExprTest` covering AST term resolution, literal parsing, filter views, variable bindings, and immutability contracts.

### Verification
* `./gradlew compileJava compileTestJava`: SUCCESS (0 errors, 0 warnings).
* `./gradlew test`: 2,628 tests executed, 2,628 passed, 0 failures.
* `./gradlew enforceW3cRegressions`: 2,327 stable passes, 0 regressions, 141 tests transitioned to passed.
* SonarLint LSP scan: 0 alerts across all modified files.