### PR TITLE
feat(query): support BIND and VALUES in the next SPARQL pipeline (#562)

### DIFF
--- a/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/repository/RepositoryConnection.java
@@ -197,6 +197,16 @@ public interface RepositoryConnection extends AutoCloseable {
             throws QuerySyntaxException, RepositoryException;
 
     /**
+     * Prepares a SELECT query using the source document's base IRI.
+     * An explicit SPARQL BASE declaration takes precedence.
+     *
+     * @param queryString query text, left unchanged
+     * @param baseIRI source base IRI, or {@code null} for the default
+     * @return the prepared query
+     */
+    TupleQuery prepareTupleQuery(String queryString, String baseIRI);
+
+    /**
      * Creates a prepared SPARQL CONSTRUCT or DESCRIBE query.
      *
      * @param queryString the textual query form
@@ -208,6 +218,15 @@ public interface RepositoryConnection extends AutoCloseable {
             throws QuerySyntaxException, RepositoryException;
 
     /**
+     * Prepares a CONSTRUCT or DESCRIBE query with a source document base IRI.
+     *
+     * @param queryString query text, left unchanged
+     * @param baseIRI source base IRI, overridden by an explicit BASE declaration
+     * @return the prepared query
+     */
+    GraphQuery prepareGraphQuery(String queryString, String baseIRI);
+
+    /**
      * Creates a prepared SPARQL ASK query.
      *
      * @param queryString the textual query form
@@ -217,6 +236,15 @@ public interface RepositoryConnection extends AutoCloseable {
      */
     BooleanQuery prepareBooleanQuery(String queryString)
             throws QuerySyntaxException, RepositoryException;
+
+    /**
+     * Prepares an ASK query with a source document base IRI.
+     *
+     * @param queryString query text, left unchanged
+     * @param baseIRI source base IRI, overridden by an explicit BASE declaration
+     * @return the prepared query
+     */
+    BooleanQuery prepareBooleanQuery(String queryString, String baseIRI);
 
     /**
      * Creates a prepared SPARQL update request.

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/Eval.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/Eval.java
@@ -22,6 +22,7 @@ import fr.inria.corese.core.next.query.impl.engine.spi.Plugin;
 import fr.inria.corese.core.next.query.impl.engine.spi.Producer;
 import fr.inria.corese.core.next.query.impl.engine.spi.Provider;
 import fr.inria.corese.core.next.query.impl.engine.spi.SPARQLEngine;
+import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
 
 import fr.inria.corese.core.next.data.Values;
 import fr.inria.corese.core.next.query.impl.engine.event.Event;
@@ -339,7 +340,7 @@ public final class Eval implements ExpType, Plugin {
                 }
                 if (valuesBinding(values.getNodeList(), m, -1)) {
                     eval(gNode, q, map);
-                    free(values.getNodeList());
+                    free(values.getNodeList(), m);
                 }
             }
             return;
@@ -933,7 +934,7 @@ public final class Eval implements ExpType, Plugin {
                         break;
 
                     case UNION:
-                        backtrack = union(p, graphNode, exp, map, n);
+                        backtrack = union(p, graphNode, exp, map, stack, n);
                         break;
 
                     case OPTIONAL:
@@ -1053,7 +1054,7 @@ public final class Eval implements ExpType, Plugin {
         return exp.isRecFederate();
     }
 
-    private int union(Producer p, Node graphNode, Exp exp, Mappings data, int n) throws SparqlException {
+    private int union(Producer p, Node graphNode, Exp exp, Mappings data, Stack stack, int n) throws SparqlException {
         int backtrack = n - 1;
         // join(A, union(B, C)) ; map = eval(A).distinct(inscopenodes())
 
@@ -1064,8 +1065,28 @@ public final class Eval implements ExpType, Plugin {
         Mappings map2 = unionBranch(p, graphNode, exp.rest(), exp, data);
 
         getVisitor().union(this, getGraphNode(graphNode), exp, map1, map2);
+        Mappings alternatives = new Mappings();
+        alternatives.add(map1);
+        alternatives.add(map2);
+        return evalUnionMappings(p, graphNode, stack, n, alternatives, backtrack);
+    }
 
-
+    /** Continues the enclosing query once for every solution of a UNION branch. */
+    private int evalUnionMappings(
+            Producer p, Node graphNode, Stack stack, int n, Mappings mappings, int backtrack) throws SparqlException {
+        Memory environment = getMemory();
+        for (Mapping mapping : mappings) {
+            if (stopped) {
+                return STOP;
+            }
+            if (environment.push(mapping, n, false)) {
+                backtrack = eval(p, graphNode, stack, n + 1);
+                environment.pop(mapping);
+                if (backtrack < n) {
+                    return backtrack;
+                }
+            }
+        }
         return backtrack;
     }
 
@@ -1223,7 +1244,16 @@ public final class Eval implements ExpType, Plugin {
 
         int backtrack = n - 1;
         Memory env = getMemory();
-        Node node = eval(graphNode, exp.getFilter(), env, p);
+        Node node;
+        try {
+            node = eval(graphNode, exp.getFilter(), env, p);
+        } catch (QueryEvaluationException error) {
+            // SPARQL Extend keeps the input solution when its expression errors;
+            // only the target variable is left unbound. Unsupported features and
+            // programming failures deliberately still propagate.
+            getVisitor().bind(this, getGraphNode(graphNode), exp, null);
+            return eval(p, graphNode, stack, map, n + 1);
+        }
 
         getVisitor().bind(this, getGraphNode(graphNode), exp, node == null ? null : node.getDatatypeValue());
 
@@ -1310,6 +1340,10 @@ public final class Eval implements ExpType, Plugin {
             env.setGraphNode(graphNode);
             DatatypeValue dt = eval(f, env, p);
             return isTrue(dt);
+        } catch (QueryEvaluationException error) {
+            // A SPARQL filter expression error makes that solution fail; it is
+            // not an engine failure and must not abort the whole query.
+            return false;
         } finally {
             env.setGraphNode(null);
         }
@@ -1474,7 +1508,7 @@ public final class Eval implements ExpType, Plugin {
             }
             if (valuesBinding(exp.getNodeList(), map, n)) {
                 backtrack = eval(p, graphNode, stack, n + 1);
-                free(exp.getNodeList());
+                free(exp.getNodeList(), map);
 
                 if (backtrack < n) {
                     return backtrack;
@@ -1504,23 +1538,20 @@ public final class Eval implements ExpType, Plugin {
     }
 
     void popBinding(List<Node> varList, Mapping map, int i) {
-        int j = 0;
-        for (Node qq : varList) {
-            Node mapNode = map.getNode(qq);
-            if (mapNode != null) {
-                if (j >= i) {
-                    return;
-                } else {
-                    j++;
-                }
-                getMemory().pop(qq);
+        for (int index = 0; index < i; index++) {
+            Node variable = varList.get(index);
+            if (map.getNode(variable) != null) {
+                getMemory().pop(variable);
             }
         }
     }
 
-    void free(List<Node> varList) {
+    /** Releases only bindings contributed by the current VALUES row. */
+    void free(List<Node> varList, Mapping map) {
         for (Node qNode : varList) {
-            getMemory().pop(qNode);
+            if (map.getNode(qNode) != null) {
+                getMemory().pop(qNode);
+            }
         }
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/EvalGraph.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/EvalGraph.java
@@ -40,8 +40,10 @@ public class EvalGraph {
 
         if (graph == null) {
             res = graphNodes(p, exp, data);
-        } else {
+        } else if (p.isProducer(graph) || isNamedGraph(p, graphNode, graph)) {
             res = graph(p, graph, exp, data);
+        } else {
+            return backtrack;
         }
 
         if (res == null) {
@@ -83,6 +85,16 @@ public class EvalGraph {
             return true;
         }
         environment.pop(mapping);
+        return false;
+    }
+
+    private boolean isNamedGraph(Producer producer, Node graphNode, Node graph) {
+        for (Node candidate : producer.getGraphNodes(
+                graphNode, engine.getQuery().getFrom(graphNode), engine.getMemory())) {
+            if (candidate.same(graph)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/model/NodeImpl.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/model/NodeImpl.java
@@ -11,13 +11,19 @@ public final class NodeImpl implements Node {
 
     private DatatypeValue value;
     private final String variableName;
+    private final boolean blankVariable;
     private int index = -1;
     private String key = INITKEY;
     private Object payload;
 
     private NodeImpl(DatatypeValue value, String variableName) {
+        this(value, variableName, false);
+    }
+
+    private NodeImpl(DatatypeValue value, String variableName, boolean blankVariable) {
         this.value = value;
         this.variableName = variableName;
+        this.blankVariable = blankVariable;
     }
 
     /** Creates a constant node carrying a Corese-next RDF value. */
@@ -56,6 +62,11 @@ public final class NodeImpl implements Node {
     /** Creates a variable node with the given name. */
     public static NodeImpl forVariable(String name) {
         return new NodeImpl(null, Objects.requireNonNull(name, "name"));
+    }
+
+    /** Creates an existential BGP variable, excluded from SELECT * projection. */
+    public static NodeImpl forBlankVariable(String label) {
+        return new NodeImpl(null, Objects.requireNonNull(label, "label"), true);
     }
 
     @Override
@@ -123,10 +134,10 @@ public final class NodeImpl implements Node {
         return variableName != null;
     }
 
-    /** Returns whether this constant node represents an RDF blank node. */
+    /** Returns whether this node is an RDF blank node or an existential variable. */
     @Override
     public boolean isBlank() {
-        return value != null && value.isBNode();
+        return blankVariable || (value != null && value.isBNode());
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/pattern/Exp.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/pattern/Exp.java
@@ -943,8 +943,11 @@ public class Exp extends PointerObject
                 break;
 
             case BIND:
-                // bind may not bind the variable (in case of error)
-                // hence variable cannot be considered as bound for filter
+                // A FILTER in the same group is evaluated after a preceding BIND
+                // when it references the BIND target. If the expression errors,
+                // the target remains unbound and the relocated filter rejects the
+                // solution, as required by SPARQL's error semantics.
+                share(getNode(), filterVar, expVar);
                 break;
 
             case EDGE, PATH:

--- a/src/main/java/fr/inria/corese/core/next/query/impl/repository/CoreseRepositoryConnection.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/repository/CoreseRepositoryConnection.java
@@ -220,14 +220,19 @@ public final class CoreseRepositoryConnection implements RepositoryConnection {
     @Override
     public TupleQuery prepareTupleQuery(String queryString)
             throws QuerySyntaxException, RepositoryException {
+        return prepareTupleQuery(queryString, null);
+    }
+
+    @Override
+    public TupleQuery prepareTupleQuery(String queryString, String baseIRI) {
         checkOpen();
         String source = requireSource(queryString, PARAM_QUERY_STRING);
-        QueryAst ast = parse(source);
+        QueryAst ast = parser.parse(source, baseIRI);
         if (!(ast instanceof SelectQueryAst)) {
             throw new QuerySyntaxException(
                     "Expected a SELECT query, got: " + ast.getClass().getSimpleName());
         }
-        CoreseTupleQuery q = new CoreseTupleQuery(source, executor, this::checkOpen);
+        CoreseTupleQuery q = new CoreseTupleQuery(source, executorFor(baseIRI), this::checkOpen);
         applyConnectionDataset(q);
         return q;
     }
@@ -235,14 +240,19 @@ public final class CoreseRepositoryConnection implements RepositoryConnection {
     @Override
     public GraphQuery prepareGraphQuery(String queryString)
             throws QuerySyntaxException, RepositoryException {
+        return prepareGraphQuery(queryString, null);
+    }
+
+    @Override
+    public GraphQuery prepareGraphQuery(String queryString, String baseIRI) {
         checkOpen();
         String source = requireSource(queryString, PARAM_QUERY_STRING);
-        QueryAst ast = parse(source);
+        QueryAst ast = parser.parse(source, baseIRI);
         if (!(ast instanceof ConstructQueryAst) && !(ast instanceof DescribeQueryAst)) {
             throw new QuerySyntaxException(
                     "Expected a CONSTRUCT or DESCRIBE query, got: " + ast.getClass().getSimpleName());
         }
-        CoreseGraphQuery q = new CoreseGraphQuery(source, executor, this::checkOpen);
+        CoreseGraphQuery q = new CoreseGraphQuery(source, executorFor(baseIRI), this::checkOpen);
         applyConnectionDataset(q);
         return q;
     }
@@ -250,14 +260,19 @@ public final class CoreseRepositoryConnection implements RepositoryConnection {
     @Override
     public BooleanQuery prepareBooleanQuery(String queryString)
             throws QuerySyntaxException, RepositoryException {
+        return prepareBooleanQuery(queryString, null);
+    }
+
+    @Override
+    public BooleanQuery prepareBooleanQuery(String queryString, String baseIRI) {
         checkOpen();
         String source = requireSource(queryString, PARAM_QUERY_STRING);
-        QueryAst ast = parse(source);
+        QueryAst ast = parser.parse(source, baseIRI);
         if (!(ast instanceof AskQueryAst)) {
             throw new QuerySyntaxException(
                     "Expected an ASK query, got: " + ast.getClass().getSimpleName());
         }
-        CoreseBooleanQuery q = new CoreseBooleanQuery(source, executor, this::checkOpen);
+        CoreseBooleanQuery q = new CoreseBooleanQuery(source, executorFor(baseIRI), this::checkOpen);
         applyConnectionDataset(q);
         return q;
     }
@@ -381,6 +396,10 @@ public final class CoreseRepositoryConnection implements RepositoryConnection {
      */
     private QueryAst parse(String queryString) throws QuerySyntaxException {
         return parser.parse(queryString);
+    }
+
+    private NextSparqlPipelineExecutor executorFor(String baseIRI) {
+        return baseIRI == null ? executor : new NextSparqlPipelineExecutor(storage, baseIRI);
     }
 
     private String requireSource(String source, String parameterName) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GraphAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/GraphAst.java
@@ -1,0 +1,13 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast;
+
+import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.AstVisitor;
+
+/** A named graph pattern, with an IRI or variable graph name. */
+public record GraphAst(TermAst name, GroupGraphPatternAst pattern) implements PatternAst {
+    @Override
+    public void accept(AstVisitor visitor) {
+        visitor.visit(this);
+        name.accept(visitor);
+        pattern.accept(visitor);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/PatternAst.java
@@ -6,6 +6,6 @@ import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.Visit
 /**
  * Element of a group graph pattern (BGP, optional, union, etc.).
  */
-public sealed interface PatternAst extends VisitableAst permits BgpAst, BindAst, FilterAst, GroupGraphPatternAst, MinusAst, OptionalAst, ServiceAst, UnionAst, SubQueryAst {
+public sealed interface PatternAst extends VisitableAst permits BgpAst, BindAst, FilterAst, GraphAst, GroupGraphPatternAst, MinusAst, OptionalAst, ServiceAst, UnionAst, SubQueryAst, ValuesAst {
     void accept(AstVisitor visitor);
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValueMappingAst.java
@@ -3,7 +3,8 @@ package fr.inria.corese.core.next.query.impl.sparql.ast;
 import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.AstVisitor;
 import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.VisitableAst;
 
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -13,9 +14,9 @@ import java.util.Map;
 public record ValueMappingAst(Map<VarAst, TermAst> values) implements VisitableAst {
 
     public ValueMappingAst {
-        if(values == null) {
-            values = new HashMap<>();
-        }
+        values = values == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(values));
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ValuesAst.java
@@ -1,25 +1,51 @@
 package fr.inria.corese.core.next.query.impl.sparql.ast;
 
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.AstVisitor;
-import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.VisitableAst;
 
 /**
- * VALUES clause. Cumulated mappings of all the VALUES clauses declared in a
- * query
+ * SPARQL {@code VALUES} table.
+ *
+ * <p>The same table representation is used for inline data in a group graph
+ * pattern and for the optional query-level values clause. {@link #variables()}
+ * retains the header of an empty table, which cannot be recovered from its
+ * mappings alone.</p>
  */
-public record ValuesAst(List<ValueMappingAst> mappings) implements VisitableAst {
+public record ValuesAst(List<VarAst> variables, List<ValueMappingAst> mappings, boolean present) implements PatternAst {
 
     public ValuesAst {
-        if (mappings == null) {
-            mappings = new ArrayList<>();
-        }
+        variables = variables == null ? inferVariables(mappings) : List.copyOf(variables);
+        mappings = mappings == null ? List.of() : List.copyOf(mappings);
+    }
+
+    public ValuesAst(List<ValueMappingAst> mappings) {
+        this(inferVariables(mappings), mappings, true);
+    }
+
+    public ValuesAst(List<VarAst> variables, List<ValueMappingAst> mappings) {
+        this(variables, mappings, true);
     }
 
     public static ValuesAst none() {
-        return new ValuesAst(new ArrayList<>());
+        return new ValuesAst(List.of(), List.of(), false);
+    }
+
+    private static List<VarAst> inferVariables(List<ValueMappingAst> mappings) {
+        if (mappings == null) {
+            return List.of();
+        }
+        Set<VarAst> variables = new LinkedHashSet<>();
+        for (ValueMappingAst mapping : mappings) {
+            for (VarAst variable : mapping.values().keySet()) {
+                if (variable != null) {
+                    variables.add(variable);
+                }
+            }
+        }
+        return List.copyOf(variables);
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -61,6 +61,7 @@ public final class CoreseAstQueryBuilder {
                 askQueryAst.whereClause(),
                 askQueryAst.datasetClause(),
                 askQueryAst.solutionModifier(),
+                askQueryAst.valuesClause(),
                 compiler);
         applyOrderBy(query, askQueryAst.solutionModifier(), compiler);
         query.setAsk(true);
@@ -86,6 +87,7 @@ public final class CoreseAstQueryBuilder {
                 selectQueryAst.whereClause(),
                 selectQueryAst.datasetClause(),
                 selectQueryAst.solutionModifier(),
+                selectQueryAst.valuesClause(),
                 compiler);
         applyProjection(query, selectQueryAst.projection());
         query.setDistinct(selectQueryAst.solutionModifier().distinct());
@@ -113,6 +115,7 @@ public final class CoreseAstQueryBuilder {
                 describeQueryAst.whereClause(),
                 describeQueryAst.datasetClause(),
                 describeQueryAst.solutionModifier(),
+                describeQueryAst.valuesClause(),
                 compiler);
         applyOrderBy(query, describeQueryAst.solutionModifier(), compiler);
         List<Node> describedNodes = describeNodes(query, describeQueryAst, compiler);
@@ -140,6 +143,7 @@ public final class CoreseAstQueryBuilder {
                 constructQueryAst.whereClause(),
                 constructQueryAst.datasetClause(),
                 constructQueryAst.solutionModifier(),
+                constructQueryAst.valuesClause(),
                 compiler);
         applyOrderBy(query, constructQueryAst.solutionModifier(), compiler);
         Exp template = compileConstructTemplate(query, constructQueryAst.constructTemplate(), compiler);
@@ -175,17 +179,12 @@ public final class CoreseAstQueryBuilder {
      *
      * <p>Planned roadmap items:
      * <ul>
-     *   <li>Issue #388: inline {@code VALUES} requires a dedicated runtime mapping.</li>
      *   <li>Issue #388: {@code GROUP BY} / {@code HAVING} requires aggregate-aware ASK semantics.</li>
      *   <li>Issue #388: {@code REDUCED} support aligned with next-pipeline query-form policy.</li>
      * </ul>
      * </p>
      */
     private static void rejectUnsupportedAskClauses(AskQueryAst askQueryAst) {
-        if (!askQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet by the next pipeline for ASK");
-        }
         SolutionModifierAst mod = askQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
@@ -198,7 +197,6 @@ public final class CoreseAstQueryBuilder {
      *
      * <p>Planned roadmap items:
      * <ul>
-     *   <li>Issue #387: inline {@code VALUES} requires a dedicated runtime mapping.</li>
      *   <li>Issue #387: {@code SELECT} expressions and aliases need a runtime story and reuse in later clauses.</li>
      *   <li>Issue #387: {@code GROUP BY} / {@code HAVING} require aggregate semantics, not only AST field propagation.</li>
      *   <li>Issue #387: {@code REDUCED} support aligned with next-pipeline query-form policy.</li>
@@ -206,10 +204,6 @@ public final class CoreseAstQueryBuilder {
      * </p>
      */
     private static void rejectUnsupportedSelectClauses(SelectQueryAst selectQueryAst) {
-        if (!selectQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet by the next pipeline for SELECT");
-        }
         ProjectionAst projection = selectQueryAst.projection();
         if (!projection.expressionTerms().isEmpty() || !projection.expressionBoundVariables().isEmpty()) {
             throw new UnsupportedQueryFeatureException(
@@ -232,17 +226,12 @@ public final class CoreseAstQueryBuilder {
      *
      * <p>Planned roadmap items:
      * <ul>
-     *   <li>Issue #390: inline {@code VALUES} requires a dedicated runtime mapping.</li>
      *   <li>Issue #390: {@code GROUP BY} / {@code HAVING} requires aggregate-aware DESCRIBE semantics.</li>
      *   <li>Issue #390: {@code REDUCED} support aligned with next-pipeline query-form policy.</li>
      * </ul>
      * </p>
      */
     private static void rejectUnsupportedDescribeClauses(DescribeQueryAst describeQueryAst) {
-        if (!describeQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet by the next pipeline for DESCRIBE");
-        }
         SolutionModifierAst mod = describeQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
@@ -261,8 +250,14 @@ public final class CoreseAstQueryBuilder {
             GroupGraphPatternAst whereClause,
             DatasetClauseAst datasetClause,
             SolutionModifierAst solutionModifier,
+            ValuesAst valuesClause,
             WhereCompiler compiler) {
-        Query query = Query.create(compiler.compile(whereClause));
+        Exp body = compiler.compile(whereClause);
+        if (valuesClause.present()) {
+            body = Exp.create(Type.JOIN,
+                    body, compiler.compileValues(valuesClause));
+        }
+        Query query = Query.create(body);
         // Collect visible nodes once so later clauses (projection, ORDER BY, DESCRIBE)
         // can resolve variables against the compiled runtime body.
         query.collect();
@@ -476,17 +471,12 @@ public final class CoreseAstQueryBuilder {
      *
      * <p>Planned roadmap items:
      * <ul>
-     *   <li>Issue #389: inline {@code VALUES} requires a dedicated runtime mapping.</li>
      *   <li>Issue #389: {@code GROUP BY} / {@code HAVING} requires aggregate-aware CONSTRUCT semantics.</li>
      *   <li>Issue #389: {@code DISTINCT} / {@code REDUCED} defensive guards.</li>
      * </ul>
      * </p>
      */
     private static void rejectUnsupportedConstructClauses(ConstructQueryAst constructQueryAst) {
-        if (!constructQueryAst.valuesClause().mappings().isEmpty()) {
-            throw new UnsupportedQueryFeatureException(
-                    "Inline VALUES is not supported yet by the next pipeline for CONSTRUCT");
-        }
         SolutionModifierAst mod = constructQueryAst.solutionModifier();
         if (mod.hasGroupBy() || mod.hasHaving() || mod.distinct() || mod.reduced()) {
             throw new UnsupportedQueryFeatureException(
@@ -520,7 +510,7 @@ public final class CoreseAstQueryBuilder {
     private Node constructNode(Query query, TermAst term, WhereCompiler compiler) {
         if (term instanceof VarAst(String name)) {
             Node bound = visibleBodyNode(query, name);
-            return bound != null ? bound : compiler.termResolver().toNode(term);
+            return bound != null ? bound : NodeImpl.forVariable(name);
         }
         return compiler.termResolver().toNode(term);
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
@@ -14,11 +14,15 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.QueryPrologueAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** Resolves SPARQL terms against one immutable query-prologue snapshot. */
 public final class SparqlTermResolver {
 
     private final PrefixHandler prefixes;
     private final String baseIri;
+    private final Map<String, Node> variables = new HashMap<>();
 
     public SparqlTermResolver(QueryPrologueAst prologue) {
         QueryPrologueAst effectivePrologue = prologue == null ? QueryPrologueAst.empty() : prologue;
@@ -51,7 +55,7 @@ public final class SparqlTermResolver {
 
     public Node toNode(TermAst term) {
         return switch (term) {
-            case VarAst(String name) -> NodeImpl.forVariable(name);
+            case VarAst(String name) -> variables.computeIfAbsent(name, NodeImpl::forVariable);
             case IriAst(String raw) when raw.startsWith(IOConstants.BLANK_NODE_PREFIX) ->
                     NodeImpl.forBlank(raw.substring(IOConstants.BLANK_NODE_PREFIX.length()));
             case IriAst(String raw) -> NodeImpl.forIRI(resolveIri(raw));
@@ -61,6 +65,18 @@ public final class SparqlTermResolver {
                     "A query term must be a variable, IRI or literal, got: "
                             + term.getClass().getSimpleName());
         };
+    }
+
+    /**
+     * Resolves a graph-pattern term. SPARQL blank-node labels in a basic graph
+     * pattern are existential variables, unlike blank nodes used as RDF values
+     * (for example in a CONSTRUCT template or a VALUES row).
+     */
+    public Node toPatternNode(TermAst term) {
+        if (term instanceof IriAst(String raw) && raw.startsWith(IOConstants.BLANK_NODE_PREFIX)) {
+            return variables.computeIfAbsent(raw, NodeImpl::forBlankVariable);
+        }
+        return toNode(term);
     }
 
     public String normalizeDatatypeIri(String datatype) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompiler.java
@@ -5,15 +5,21 @@ import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureExce
 import fr.inria.corese.core.next.query.impl.sparql.ast.BgpAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.BindAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.FilterAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.GraphAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.GroupGraphPatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.MinusAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.OptionalAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.PatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.QueryPrologueAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ServiceAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SubQueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TriplePatternAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.UnionAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ValueMappingAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.ValuesAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PathAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.path.PredicatePathAst;
 import fr.inria.corese.core.next.query.impl.engine.model.Edge;
@@ -22,7 +28,11 @@ import fr.inria.corese.core.next.query.impl.engine.model.Filter;
 import fr.inria.corese.core.next.query.impl.engine.model.Node;
 import fr.inria.corese.core.next.query.impl.engine.pattern.Exp;
 import fr.inria.corese.core.next.query.impl.engine.pattern.Query;
+import fr.inria.corese.core.next.query.impl.engine.solution.Mapping;
+import fr.inria.corese.core.next.query.impl.engine.solution.Mappings;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -79,7 +89,12 @@ public final class WhereCompiler {
             case OptionalAst optional -> compileOptional(optional);
             case MinusAst minus -> compileMinus(minus);
             case BindAst bind -> compileBind(bind);
+            case ValuesAst values -> compileValues(values);
             case ServiceAst service -> compileService(service);
+            case GraphAst(TermAst name, GroupGraphPatternAst graphPattern) -> Exp.create(Type.GRAPH,
+                    Exp.create(Type.GRAPHNODE, Exp.create(Type.NODE, termResolver.toNode(name))),
+                    compile(graphPattern));
+            case SubQueryAst subQuery -> compileSubQuery(subQuery);
             case GroupGraphPatternAst group -> compileGroup(group);
             default -> throw new UnsupportedQueryFeatureException(
                     "WHERE pattern is not supported yet by the next pipeline: "
@@ -108,6 +123,11 @@ public final class WhereCompiler {
                     body = Exp.create(Type.AND);
                     body.add(minusExp);
                 }
+                case GroupGraphPatternAst nested -> {
+                    Exp joined = Exp.create(Type.JOIN, body, compile(nested));
+                    body = Exp.create(Type.AND);
+                    body.add(joined);
+                }
                 default -> body.add(compile(element));
             }
         }
@@ -123,10 +143,10 @@ public final class WhereCompiler {
     }
 
     private Edge toEdge(TriplePatternAst triple) {
-        Node subject = termResolver.toNode(triple.subject());
-        Node predicate = termResolver.toNode(
+        Node subject = termResolver.toPatternNode(triple.subject());
+        Node predicate = termResolver.toPatternNode(
             simplePredicate(triple.predicate()));
-        Node object = termResolver.toNode(triple.object());
+        Node object = termResolver.toPatternNode(triple.object());
         return new AstBackedEdge(subject, predicate, object);
     }
 
@@ -185,6 +205,30 @@ public final class WhereCompiler {
         return exp;
     }
 
+    /** Lowers a SPARQL inline-data table to the runtime's native VALUES expression. */
+    Exp compileValues(ValuesAst values) {
+        List<Node> variables = new ArrayList<>();
+        for (VarAst variable : values.variables()) {
+            variables.add(termResolver.toNode(variable));
+        }
+
+        Mappings mappings = new Mappings();
+        for (ValueMappingAst row : values.mappings()) {
+            List<Node> rowVariables = new ArrayList<>();
+            List<Node> rowValues = new ArrayList<>();
+            for (int index = 0; index < values.variables().size(); index++) {
+                VarAst variable = values.variables().get(index);
+                TermAst value = row.values().get(variable);
+                if (value != null) {
+                    rowVariables.add(variables.get(index));
+                    rowValues.add(termResolver.toNode(value));
+                }
+            }
+            mappings.add(Mapping.create(rowVariables, rowValues));
+        }
+        return Exp.createValues(variables, mappings);
+    }
+
     /**
      * Compiles {@code SERVICE <endpoint> { ... }} into a KGRAM {@link Exp}.
      */
@@ -197,5 +241,10 @@ public final class WhereCompiler {
         Exp exp = Exp.create(Type.SERVICE, endpointNode, body);
         exp.setSilent(service.silent());
         return exp;
+    }
+
+    /** Compiles a nested SELECT into the runtime query expression used by KGRAM. */
+    private Exp compileSubQuery(SubQueryAst subQuery) {
+        return new CoreseAstQueryBuilder(this).toNextQuery((SelectQueryAst) subQuery.query());
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/CoreseBindingSet.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/CoreseBindingSet.java
@@ -1,7 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.execution;
 
 
-import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Value;
 import fr.inria.corese.core.next.query.api.result.Binding;
 import fr.inria.corese.core.next.query.api.result.BindingSet;
@@ -9,9 +8,9 @@ import fr.inria.corese.core.next.query.impl.engine.solution.Mapping;
 import fr.inria.corese.core.next.query.impl.result.CoreseBinding;
 
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Adapts a KGRAM {@link Mapping} to the {@link BindingSet} API.
@@ -19,39 +18,46 @@ import java.util.Set;
 public final class CoreseBindingSet implements BindingSet {
 
     private final Mapping mapping;
+    private final Set<String> visibleNames;
 
     public CoreseBindingSet(Mapping mapping) {
+        this(mapping, mapping.getVariableNames());
+    }
+
+    CoreseBindingSet(Mapping mapping, Set<String> visibleNames) {
         this.mapping = Objects.requireNonNull(mapping, "mapping");
+        this.visibleNames = visibleNames.stream()
+                .filter(name -> mapping.getValue(name) != null)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override
     public Set<String> getBindingNames() {
-        return this.mapping.getVariableNames();
+        return visibleNames;
     }
 
     @Override
     public boolean hasBinding(String name) {
-        return this.mapping.getValue(name) != null;
+        return visibleNames.contains(name) && this.mapping.getValue(name) != null;
     }
 
     @Override
     public Value getValue(String name) {
-        return this.mapping.getValue(name) instanceof Value value ? value : null;
+        return visibleNames.contains(name) && this.mapping.getValue(name) instanceof Value value ? value : null;
     }
 
     @Override
     public Iterator<Binding> iterator() {
-        return this.mapping.getMap().entrySet().stream()
-                .map(CoreseBindingSet::toBinding)
+        return visibleNames.stream()
+                .map(this::toBinding)
                 .iterator();
     }
 
-    private static Binding toBinding(
-            Map.Entry<String, DatatypeValue> entry) {
-        if (entry.getValue() instanceof Value value) {
-            return new CoreseBinding(entry.getKey(), value);
+    private Binding toBinding(String name) {
+        if (mapping.getValue(name) instanceof Value value) {
+            return new CoreseBinding(name, value);
         }
         throw new IllegalStateException(
-                "Query binding is not backed by an RDF value: " + entry.getKey());
+                "Query binding is not backed by an RDF value: " + name);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/CoreseTupleQueryResult.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/CoreseTupleQueryResult.java
@@ -9,6 +9,7 @@ import fr.inria.corese.core.next.query.impl.engine.solution.Mappings;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Adapts a KGRAM {@link Mappings} result to the {@link TupleQueryResult} API.
@@ -17,11 +18,13 @@ public final class CoreseTupleQueryResult implements TupleQueryResult {
 
     private final Mappings mappings;
     private final Iterator<Mapping> iterator;
+    private final Set<String> projectedNames;
     private boolean closed;
 
     public CoreseTupleQueryResult(Mappings mappings) {
         this.mappings = Objects.requireNonNull(mappings, "mappings");
         this.iterator = this.mappings.iterator();
+        this.projectedNames = Set.copyOf(this.mappings.getSelect().stream().map(Node::getLabel).toList());
     }
 
     @Override
@@ -38,7 +41,7 @@ public final class CoreseTupleQueryResult implements TupleQueryResult {
     @Override
     public BindingSet next() {
         checkOpen();
-        return new CoreseBindingSet(this.iterator.next());
+        return new CoreseBindingSet(this.iterator.next(), projectedNames);
     }
 
     @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutor.java
@@ -15,6 +15,7 @@ import fr.inria.corese.core.next.query.api.result.BindingSet;
 import fr.inria.corese.core.next.query.api.result.GraphQueryResult;
 import fr.inria.corese.core.next.query.api.result.TupleQueryResult;
 import fr.inria.corese.core.next.query.impl.sparql.parser.SparqlParser;
+import fr.inria.corese.core.next.query.impl.sparql.parser.SparqlParserOptions;
 import fr.inria.corese.core.next.query.impl.result.CoreseGraphQueryResult;
 import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.ConstructQueryAst;
@@ -71,6 +72,12 @@ public final class NextSparqlPipelineExecutor {
      */
     public NextSparqlPipelineExecutor(StorageManager storage) {
         this(storage, new SparqlParser(), new CoreseAstQueryBuilder());
+    }
+
+    /** Creates an executor with a query-scoped source base IRI. */
+    public NextSparqlPipelineExecutor(StorageManager storage, String baseIRI) {
+        this(storage, new SparqlParser(new SparqlParserOptions.Builder().baseIRI(baseIRI).build()),
+                new CoreseAstQueryBuilder());
     }
 
     /**

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlAntlrDispatcher.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlAntlrDispatcher.java
@@ -150,7 +150,12 @@ final class SparqlAntlrDispatcher extends SparqlParserBaseListener {
         for (var d : delegates) d.exitMinusGraphPattern(ctx);
     }
 
-    // ---------- SERVICE ----------
+    // ---------- GRAPH / SERVICE ----------
+
+    @Override
+    public void enterGraphGraphPattern(SparqlParser.GraphGraphPatternContext ctx) {
+        for (var delegate : delegates) delegate.enterGraphGraphPattern(ctx);
+    }
 
     @Override
     public void enterServiceGraphPattern(SparqlParser.ServiceGraphPatternContext ctx) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlAstBuilder.java
@@ -129,6 +129,14 @@ public abstract class SparqlAstBuilder {
      */
     protected final Deque<ServiceEntry> serviceStack = new ArrayDeque<>();
 
+    private record GraphEntry(int groupDepth, TermAst name) {}
+
+    private final Deque<GraphEntry> graphStack = new ArrayDeque<>();
+
+    public void enterGraph(TermAst name) {
+        graphStack.push(new GraphEntry(groupStack.size(), name));
+    }
+
     /*
      * having conditions
      */
@@ -367,7 +375,10 @@ public abstract class SparqlAstBuilder {
 
         List<PatternAst> popped = groupStack.pop();
         GroupGraphPatternAst group = new GroupGraphPatternAst(popped);
+        appendClosedGroup(group);
+    }
 
+    private void appendClosedGroup(GroupGraphPatternAst group) {
         if (!optionalGroupDepths.isEmpty() && groupStack.size() == optionalGroupDepths.peek()) {
             optionalGroupDepths.pop();
             currentGroup().add(new OptionalAst(group));
@@ -380,6 +391,9 @@ public abstract class SparqlAstBuilder {
         } else if (!serviceStack.isEmpty() && groupStack.size() == serviceStack.peek().groupDepth()) {
             ServiceEntry entry = serviceStack.pop();
             currentGroup().add(new ServiceAst(entry.endpoint(), entry.silent(), group));
+        } else if (!graphStack.isEmpty() && groupStack.size() == graphStack.peek().groupDepth()) {
+            GraphEntry entry = graphStack.pop();
+            currentGroup().add(new GraphAst(entry.name(), group));
         } else if (groupStack.isEmpty()) {
             if (hasCurrentSelect()) getCurrentSelectFrame().whereClause = group;
             else whereClause = group;
@@ -433,6 +447,17 @@ public abstract class SparqlAstBuilder {
         if (this.hasCurrentGroup()) {
             this.currentGroup().add(filter);
         }
+    }
+
+    /** Adds an inline {@code VALUES} table at its syntactic position in a group. */
+    public void addInlineValues(ValuesAst values) {
+        if (values == null) {
+            throw new IllegalArgumentException("values is null");
+        }
+        if (!hasCurrentGroup()) {
+            throw new IllegalStateException("addInlineValues() called outside of a group graph pattern");
+        }
+        currentGroup().add(values);
     }
 
     /**
@@ -838,5 +863,6 @@ public abstract class SparqlAstBuilder {
         protected GroupByAst groupBy = new GroupByAst(List.of());
         protected final List<OrderConditionAst> orderConditions = new ArrayList<>();
         protected final List<TermAst> havingConditions = new ArrayList<>();
+        protected ValuesAst valuesClause = ValuesAst.none();
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlQueryAstBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlQueryAstBuilder.java
@@ -38,15 +38,11 @@ public class SparqlQueryAstBuilder extends SparqlAstBuilder {
 
     // --- Internal stacks (scopes) ---
 
-    /**
-     * Final query AST result, set when the top-level SELECT finishes.
-     */
-    private QueryAst selectQueryResult;
+    /** Completed top-level SELECT, retained until its trailing VALUES clause is read. */
+    private SelectFrame completedTopLevelSelect;
 
-    /**
-     * VALUES clause (agglomerate all VALUES declarations in the query)
-     */
-    protected final List<ValueMappingAst> values = new ArrayList<>();
+    /** Query-level VALUES clause, distinct from VALUES tables inside WHERE. */
+    protected ValuesAst valuesClause = ValuesAst.none();
 
     /**
      * SELECT projection (* or explicit variables). Set by SelectQueryAstListener in enterSelectQuery.
@@ -131,41 +127,28 @@ public class SparqlQueryAstBuilder extends SparqlAstBuilder {
 
         // SELECT projection / ORDER BY scope: reported by SparqlQuerySemanticValidator (validate() collects all diagnostics).
 
-        /*
-         * Top-level SELECT keeps the dataset clause declared at query level.
-         * Nested SELECT subqueries use an empty dataset clause for now.
-         *
-         * Prologue is inherited from the enclosing query source context.
-         */
-        DatasetClauseAst datasetClauseAst = hasCurrentGroup()
-                ? DatasetClauseAst.none()
-                : new DatasetClauseAst(datasetDefaultGraphs, datasetNamedGraphs);
+        // The query-level VALUES clause is parsed after the top-level SELECT.
+        // Defer its AST construction until getResult() has all clauses.
+        if (!hasCurrentGroup()) {
+            completedTopLevelSelect = frame;
+            return;
+        }
 
         QueryPrologueAst prologueAst = new QueryPrologueAst(
                 List.copyOf(getPrefixDeclaration()),
                 new IriAst(getBaseUri())
         );
 
-        ValuesAst valuesClause = new ValuesAst(this.values);
-
         SelectQueryAst selectQueryAst = new SelectQueryAst(
                 frame.projection,
-                datasetClauseAst,
+                DatasetClauseAst.none(),
                 frame.whereClause,
                 buildSolutionModifier(frame),
                 prologueAst,
-                valuesClause
+                frame.valuesClause
         );
 
-        /*
-         * If we are still inside a parent group, this SELECT is a subquery.
-         * Otherwise it is the top-level SELECT result.
-         */
-        if (hasCurrentGroup()) {
-            currentGroup().add(new SubQueryAst(selectQueryAst));
-        } else {
-            selectQueryResult = selectQueryAst;
-        }
+        currentGroup().add(new SubQueryAst(selectQueryAst));
     }
 
     public void enterConstructQuery() {
@@ -272,8 +255,13 @@ public class SparqlQueryAstBuilder extends SparqlAstBuilder {
         else this.projection = newProjection;
     }
 
-    public void addValues(List<ValueMappingAst> mappings) {
-        this.values.addAll(mappings);
+    /** Adds the optional query-level {@code VALUES} clause to the active query. */
+    public void addValues(ValuesAst values) {
+        if (hasCurrentSelect()) {
+            getCurrentSelectFrame().valuesClause = values;
+        } else {
+            valuesClause = values;
+        }
     }
 
     /**
@@ -355,16 +343,16 @@ public class SparqlQueryAstBuilder extends SparqlAstBuilder {
      * @throws IllegalStateException    if no WHERE clause was set (exitGroup() not called for root) or unhandled query type
      */
     public QueryAst getResult() {
-        if (selectQueryResult != null) return selectQueryResult;
-        if (whereClause == null && this.queryType != ASTConstants.QUERY_TYPE.DESCRIBE) {
+        if (whereClause == null
+                && completedTopLevelSelect == null
+                && this.queryType != ASTConstants.QUERY_TYPE.DESCRIBE) {
             throw new IllegalStateException("No WHERE clause: did you call exitGroup() for the top-level GroupGraphPattern?");
         }
         DatasetClauseAst datasetClauseAst = new DatasetClauseAst(datasetDefaultGraphs, datasetNamedGraphs);
         QueryPrologueAst prologueAst = new QueryPrologueAst(List.copyOf(getPrefixDeclaration()), new IriAst(getBaseUri()));
-        ValuesAst valuesClause = new ValuesAst(this.values);
         return switch (this.queryType) {
             case ASK -> buildAskQueryAst(datasetClauseAst, prologueAst, valuesClause);
-            case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst,valuesClause);
+            case CONSTRUCT -> buildConstructQueryAst(datasetClauseAst, prologueAst, valuesClause);
             case DESCRIBE -> buildDescribeQueryAst(datasetClauseAst, prologueAst, valuesClause);
             case SELECT -> buildSelectQueryAst(datasetClauseAst, prologueAst, valuesClause);
             default -> throw new QueryEvaluationException("Could not determine the type of query during parsing");
@@ -384,6 +372,16 @@ public class SparqlQueryAstBuilder extends SparqlAstBuilder {
      * Builds the AST for SELECT operations.
      */
     private SelectQueryAst buildSelectQueryAst(DatasetClauseAst datasetClauseAst, QueryPrologueAst prologue, ValuesAst valuesClause) {
+        if (completedTopLevelSelect != null) {
+            SelectFrame frame = completedTopLevelSelect;
+            return new SelectQueryAst(
+                    frame.projection,
+                    datasetClauseAst,
+                    frame.whereClause,
+                    buildSolutionModifier(frame),
+                    prologue,
+                    valuesClause);
+        }
         if (hasCurrentSelect()) {
             SelectFrame frame = getCurrentSelectFrame();
             return new SelectQueryAst(

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlTermBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlTermBuilder.java
@@ -142,7 +142,7 @@ public final class SparqlTermBuilder {
 
     public TermAst termFromNumericLiteralUnsigned(SparqlParser.NumericLiteralUnsignedContext ctx) {
         if (ctx.INTEGER() != null) {
-            return literal(ctx.getText(), null, XSD.xsdUnsignedInt.getIRI().stringValue());
+            return literal(ctx.getText(), null, XSD.xsdInteger.getIRI().stringValue());
         } else if (ctx.DECIMAL() != null) {
             return literal(ctx.getText(), null, XSD.xsdDecimal.getIRI().stringValue());
         } else if (ctx.DOUBLE() != null) {
@@ -154,7 +154,7 @@ public final class SparqlTermBuilder {
 
     public TermAst termFromNumericLiteralPositive(SparqlParser.NumericLiteralPositiveContext ctx) {
         if (ctx.INTEGER_POSITIVE() != null) {
-            return literal(ctx.getText(), null, XSD.xsdPositiveInteger.getIRI().stringValue());
+            return literal(ctx.getText(), null, XSD.xsdInteger.getIRI().stringValue());
         } else if (ctx.DECIMAL_POSITIVE() != null) {
             return literal(ctx.getText(), null, XSD.xsdDecimal.getIRI().stringValue());
         } else if (ctx.DOUBLE_POSITIVE() != null) {
@@ -166,7 +166,7 @@ public final class SparqlTermBuilder {
 
     public TermAst termFromNumericLiteralNegative(SparqlParser.NumericLiteralNegativeContext ctx) {
         if (ctx.INTEGER_NEGATIVE() != null) {
-            return literal(ctx.getText(), null, XSD.xsdNegativeInteger.getIRI().stringValue());
+            return literal(ctx.getText(), null, XSD.xsdInteger.getIRI().stringValue());
         } else if (ctx.DECIMAL_NEGATIVE() != null) {
             return literal(ctx.getText(), null, XSD.xsdDecimal.getIRI().stringValue());
         } else if (ctx.DOUBLE_NEGATIVE() != null) {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/listener/BgpAstListener.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/listener/BgpAstListener.java
@@ -30,6 +30,11 @@ public class BgpAstListener extends AbstractSparqlAstListener {
     }
 
     @Override
+    public void enterGraphGraphPattern(SparqlParser.GraphGraphPatternContext ctx) {
+        builder().enterGraph(builder().termFromVarOrIriRef(ctx.varOrIri()));
+    }
+
+    @Override
     public void enterGroupGraphPattern(SparqlParser.GroupGraphPatternContext ctx) {
         builder().enterGroup();
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/listener/ValuesAstListener.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/listener/ValuesAstListener.java
@@ -19,42 +19,38 @@ public class ValuesAstListener extends AbstractSparqlQueryAstListener {
     @Override
     public void exitValuesClause(SparqlParser.ValuesClauseContext ctx) {
         if(ctx.dataBlock() != null) {
-            processDataBlock(ctx.dataBlock());
+            queryBuilder().addValues(processDataBlock(ctx.dataBlock()));
         }
     }
 
     @Override
     public void exitInlineData(SparqlParser.InlineDataContext ctx) {
         if(ctx.dataBlock() != null) {
-            processDataBlock(ctx.dataBlock());
+            builder().addInlineValues(processDataBlock(ctx.dataBlock()));
         }
     }
 
-    private void processDataBlock(SparqlParser.DataBlockContext ctx) {
+    private ValuesAst processDataBlock(SparqlParser.DataBlockContext ctx) {
         if(ctx.inlineDataOneVar() != null) {
-            processInlineDataOneVar(ctx.inlineDataOneVar());
-        } else if (ctx.inlineDataFull() != null) {
-            processInlineDataFull(ctx.inlineDataFull());
+            return processInlineDataOneVar(ctx.inlineDataOneVar());
         }
+        if (ctx.inlineDataFull() != null) {
+            return processInlineDataFull(ctx.inlineDataFull());
+        }
+        throw new QuerySyntaxException("Missing data block in VALUES clause");
     }
 
-    private void processInlineDataOneVar(SparqlParser.InlineDataOneVarContext ctx) {
-        if(ctx.var_() != null) {
-            VarAst varAst = (VarAst) this.builder().termFromVar(ctx.var_());
-            if(!Objects.equals(varAst.name(), "()")) {
-                List<ValueMappingAst> mappingAstList = new ArrayList<>();
-                if(ctx.dataBlockValue() != null) {
-                    ctx.dataBlockValue().forEach(dataBlockValueContext -> {
-                        Map<VarAst, TermAst> valueMap = termAstFromDataBlockValues(List.of(varAst), List.of(dataBlockValueContext));
-                        // Each dataBlockValue is a solution
-                        mappingAstList.add(new ValueMappingAst(valueMap));
-                    });
-                    this.queryBuilder().addValues(mappingAstList);
-                }
-            }
-        } else if(ctx.var_() == null && ctx.dataBlockValue() != null) {
+    private ValuesAst processInlineDataOneVar(SparqlParser.InlineDataOneVarContext ctx) {
+        if (ctx.var_() == null) {
             throw new QuerySyntaxException("Missing variable for solution mapping in VALUES clause");
         }
+        VarAst variable = (VarAst) builder().termFromVar(ctx.var_());
+        List<VarAst> header = List.of(variable);
+        List<ValueMappingAst> rows = new ArrayList<>();
+        for (var value : ctx.dataBlockValue()) {
+            rows.add(new ValueMappingAst(termAstFromDataBlockValues(header, List.of(value))));
+        }
+        return new ValuesAst(header, rows);
     }
 
     /**
@@ -65,7 +61,7 @@ public class ValuesAstListener extends AbstractSparqlQueryAstListener {
         if(variables.size() != dataBlockValueList.size()) {
             throw new QuerySyntaxException("VALUE solutions should have a value for every variable and at least a variable for a solution.");
         }
-        Map<VarAst, TermAst> valuesList = new HashMap<>();
+        Map<VarAst, TermAst> valuesList = new LinkedHashMap<>();
         for(int varNum = 0; varNum < variables.size(); varNum++) {
             VarAst variable = variables.get(varNum);
             SparqlParser.DataBlockValueContext dataBlockValueContext = dataBlockValueList.get(varNum);
@@ -81,32 +77,18 @@ public class ValuesAstListener extends AbstractSparqlQueryAstListener {
                 valuesList.put(variable, null);
             }
         }
-        dataBlockValueList.forEach(dataBlockValueContext -> {
-        });
         return valuesList;
     }
 
-    private void processInlineDataFull(SparqlParser.InlineDataFullContext ctx) {
+    private ValuesAst processInlineDataFull(SparqlParser.InlineDataFullContext ctx) {
         List<VarAst> varList = new ArrayList<>();
-        if(ctx.var_() != null) {
-            ctx.var_().forEach(varContext -> {
-                VarAst varAst = (VarAst) this.builder().termFromVar(varContext);
-                if(!Objects.equals(varAst.name(), "()")) {
-                    varList.add(varAst);
-                }
-            });
+        for (var variable : ctx.var_()) {
+            varList.add((VarAst) builder().termFromVar(variable));
         }
-        if(!varList.isEmpty()) {
-            List<ValueMappingAst> valuesList = new ArrayList<>();
-            if(ctx.dataBlockValues() != null) { // Each dataBlockValues is a solution
-                ctx.dataBlockValues().forEach(dataBlockValuesContext -> { // Each dataBlockValue is a value for a variable in a solution
-                    if(dataBlockValuesContext.dataBlockValue() != null) {
-                        Map<VarAst, TermAst> valueList = termAstFromDataBlockValues(varList, dataBlockValuesContext.dataBlockValue());
-                        valuesList.add(new ValueMappingAst(valueList));
-                    }
-                });
-            }
-            this.queryBuilder().addValues(valuesList);
+        List<ValueMappingAst> valuesList = new ArrayList<>();
+        for (var row : ctx.dataBlockValues()) {
+            valuesList.add(new ValueMappingAst(termAstFromDataBlockValues(varList, row.dataBlockValue())));
         }
+        return new ValuesAst(varList, valuesList);
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/AbstractAstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/AbstractAstVisitor.java
@@ -94,6 +94,11 @@ public abstract class AbstractAstVisitor implements AstVisitor {
     }
 
     @Override
+    public void visit(GraphAst ast) {
+        // Traversal is performed by GraphAst.accept.
+    }
+
+    @Override
     public void visit(ServiceAst ast) {
 
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/AstVisitor.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/AstVisitor.java
@@ -25,6 +25,7 @@ public interface AstVisitor {
     void visit(OrderConditionAst ast);
     void visit(PrefixDeclarationAst ast);
     void visit(ServiceAst ast);
+    void visit(GraphAst ast);
     void visit(GraphRefAst ast);
     void visit(PathAst ast);
     void visit(QuadsAst ast);

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/VariableScopeAnalyzer.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/semantic/support/VariableScopeAnalyzer.java
@@ -50,12 +50,7 @@ public final class VariableScopeAnalyzer {
             return visibleVariables;
         }
 
-        valuesClause.mappings().forEach(valueMappingAst ->
-                valueMappingAst.values().keySet().forEach(varAst -> {
-                    if (varAst != null) {
-                        visibleVariables.add(varAst.name());
-                    }
-                }));
+        valuesClause.variables().forEach(variable -> visibleVariables.add(variable.name()));
 
         return visibleVariables;
     }
@@ -201,6 +196,9 @@ public final class VariableScopeAnalyzer {
             case BindAst(TermAst expression, VarAst variable) ->
                 visibleVariables.add(variable.name());
 
+            case ValuesAst values ->
+                visibleVariables.addAll(collectVisibleVariables(values));
+
             case FilterAst ignored -> {
                 // FILTER does not make a variable visible by itself.
             }
@@ -211,12 +209,18 @@ public final class VariableScopeAnalyzer {
                 addIfVariable(endpoint, visibleVariables);
             }
 
+            case GraphAst(TermAst name, GroupGraphPatternAst graphPattern) -> {
+                collectVisibleVariables(graphPattern, visibleVariables);
+                addIfVariable(name, visibleVariables);
+            }
+
             case SubQueryAst(SelectQueryAst select) -> {
 
                 ProjectionAst proj = select.projection();
 
                 if (proj.selectAll()) {
                     collectVisibleVariables(select.whereClause(), visibleVariables);
+                    visibleVariables.addAll(collectVisibleVariables(select.valuesClause()));
                 } else {
                     for (VarAst v : proj.variables()) {
                         visibleVariables.add(v.name());

--- a/src/test/java/fr/inria/corese/core/next/query/impl/repository/CoreseRepositoryConnectionTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/repository/CoreseRepositoryConnectionTest.java
@@ -61,6 +61,53 @@ class CoreseRepositoryConnectionTest {
         repository.close();
     }
 
+    @Test
+    void documentBaseIsScopedToEachPreparedQuery() {
+        try (RepositoryConnection conn = repository.getConnection()) {
+            TupleQuery first = conn.prepareTupleQuery("SELECT ?x { VALUES ?x { <item> } }", "https://example.org/a/query.rq");
+            TupleQuery second = conn.prepareTupleQuery("SELECT ?x { VALUES ?x { <item> } }", "https://example.org/b/query.rq");
+            try (var secondResult = second.evaluate(); var firstResult = first.evaluate()) {
+                assertEquals("https://example.org/a/item", firstResult.next().getValue("x").stringValue());
+                assertEquals("https://example.org/b/item", secondResult.next().getValue("x").stringValue());
+            }
+        }
+    }
+
+    @Test
+    void explicitBaseOverridesDocumentBaseWithoutChangingLiterals() {
+        try (RepositoryConnection conn = repository.getConnection();
+             var result = conn.prepareTupleQuery("""
+                     # BASE <https://wrong.example/>
+                     BASE <https://other.example/>
+                     SELECT ?x ?text { VALUES (?x ?text) { (<item> "FROM <item>") } }
+                     """, "https://example.org/query.rq").evaluate()) {
+            var row = result.next();
+            assertEquals("https://other.example/item", row.getValue("x").stringValue());
+            assertEquals("FROM <item>", row.getValue("text").stringValue());
+        }
+    }
+
+    @Test
+    void documentBaseDoesNotLegalizeRelativeBaseDeclarations() {
+        try (RepositoryConnection conn = repository.getConnection()) {
+            assertThrows(QuerySyntaxException.class, () -> conn.prepareTupleQuery(
+                    "BASE <../data/> SELECT ?x { VALUES ?x { <item> } }", "https://example.org/tests/query.rq"));
+        }
+    }
+
+    @Test
+    void documentBaseAppliesToAskAndConstruct() {
+        try (RepositoryConnection conn = repository.getConnection()) {
+            assertTrue(conn.prepareBooleanQuery("ASK { <alice> <knows> <bob> }", "http://example.org/query.rq").evaluate());
+            try (var result = conn.prepareGraphQuery("CONSTRUCT { <alice> <knows> ?o } WHERE { VALUES ?o { <bob> } }",
+                    "http://example.org/query.rq").evaluate()) {
+                assertTrue(result.hasNext());
+                assertEquals(vf.createStatement(iri(ALICE), iri(KNOWS), iri(BOB)), result.next());
+                assertFalse(result.hasNext());
+            }
+        }
+    }
+
     // -------------------------------------------------------------------------
     // TupleQuery (SELECT)
     // -------------------------------------------------------------------------

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderAskTest.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.sparql.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.AskQueryAst;
@@ -117,14 +116,16 @@ class CoreseAstQueryBuilderAskTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
-    void rejectsValuesClause() {
+    @DisplayName("Query-level VALUES is compiled as a runtime table")
+    void compilesValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("s"), new IriAst("http://example.org/x")))));
         AskQueryAst ask = new AskQueryAst(
                 DatasetClauseAst.none(), whereOneTriple(), null, null, values);
 
-        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(ask));
+        Query query = builder.toNextQuery(ask);
+        assertTrue(query.getBody().isJoin());
+        assertTrue(query.getBody().rest().isValues());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderConstructTest.java
@@ -1,6 +1,5 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
-import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.sparql.parser.SparqlParser;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
@@ -161,12 +160,14 @@ class CoreseAstQueryBuilderConstructTest extends AbstractSparqlParserFeatureTest
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
-    void rejectsValuesClause() {
+    @DisplayName("Query-level VALUES is compiled as a runtime table")
+    void compilesValuesClause() {
         ValuesAst values = new ValuesAst(List.of(new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         ConstructQueryAst construct = new ConstructQueryAst(template(new TriplePatternAst(new VarAst("x"), new VarAst("p"), new VarAst("o"))), DatasetClauseAst.none(), whereSPO(), null, null, values);
 
-        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(construct));
+        Query query = builder.toNextQuery(construct);
+        assertTrue(query.getBody().isJoin());
+        assertTrue(query.getBody().rest().isValues());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilderDescribeTest.java
@@ -220,14 +220,16 @@ class CoreseAstQueryBuilderDescribeTest {
     }
 
     @Test
-    @DisplayName("Inline VALUES is not supported yet -> UnsupportedQueryFeatureException")
-    void rejectsValuesClause() {
+    @DisplayName("Query-level VALUES is compiled as a runtime table")
+    void compilesValuesClause() {
         ValuesAst values = new ValuesAst(List.of(
                 new ValueMappingAst(Map.of(new VarAst("x"), new IriAst("http://example.org/v")))));
         DescribeQueryAst describe = new DescribeQueryAst(
                 DatasetClauseAst.none(), List.of(new VarAst("x")), whereBindingX(), null, null, values);
 
-        assertThrows(UnsupportedQueryFeatureException.class, () -> builder.toNextQuery(describe));
+        Query query = builder.toNextQuery(describe);
+        assertTrue(query.getBody().isJoin());
+        assertTrue(query.getBody().rest().isValues());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/WhereCompilerTest.java
@@ -1,7 +1,6 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 
-import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.parser.AbstractSparqlParserFeatureTest;
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FunctionCallAst;
@@ -189,15 +188,14 @@ class WhereCompilerTest extends AbstractSparqlParserFeatureTest {
     }
 
     @Test
-    @DisplayName("Unsupported WHERE pattern kinds fail with UnsupportedQueryFeatureException")
-    void unsupportedPatternFailsWithTypedException() {
+    @DisplayName("Subqueries compile to runtime queries")
+    void subqueryCompilesToRuntimeQuery() {
         SubQueryAst subQuery = new SubQueryAst(new SelectQueryAst(group(bgp("s", "p", "o"))));
 
-        UnsupportedQueryFeatureException error = assertThrows(
-                UnsupportedQueryFeatureException.class,
-                () -> compiler.compile(subQuery));
+        Exp exp = compiler.compile(subQuery);
 
-        assertTrue(error.getMessage().contains("WHERE pattern"));
+        assertTrue(exp.isQuery());
+        assertNotNull(exp.getQuery());
     }
 
     @Test

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/NextSparqlPipelineExecutorTest.java
@@ -130,6 +130,24 @@ class NextSparqlPipelineExecutorTest {
     }
 
     @Test
+    @DisplayName("BIND in a UNION branch leaves references outside its group unbound")
+    void bindInUnionBranchDoesNotReceiveOuterBindings() {
+        String age = "http://example.org/age";
+        insert(iri(ALICE), iri(age), valueFactory.createLiteral(1));
+
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?nextAge WHERE {
+                  ?person <http://example.org/age> ?age .
+                  { BIND(?age + 1 AS ?nextAge) } UNION { BIND(?age + 2 AS ?nextAge) }
+                }
+                """);
+
+        var rows = result.stream().toList();
+        assertEquals(2, rows.size());
+        assertTrue(rows.stream().noneMatch(binding -> binding.hasBinding("nextAge")));
+    }
+
+    @Test
     @DisplayName("ORDER BY uses numeric value order rather than lexical order")
     void orderByUsesNativeRdfValueOrder() {
         String rank = "http://example.org/rank";
@@ -225,6 +243,148 @@ class NextSparqlPipelineExecutorTest {
         assertTrue(executor.evaluateTuple("""
                 SELECT ?s WHERE { ?s ?p ?o . FILTER((1 / 0) || true) }
                 """).hasNext());
+    }
+
+    @Test
+    @DisplayName("Inline VALUES preserves row order, duplicates, and UNDEF bindings")
+    void inlineValuesPreservesBagSemanticsAndUndef() {
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?person ?rank WHERE {
+                  VALUES (?person ?rank) {
+                    (<http://example.org/alice> 1)
+                    (<http://example.org/alice> 1)
+                    (<http://example.org/bob> UNDEF)
+                  }
+                }
+                """);
+
+        assertEquals(List.of("person", "rank"), result.getBindingNames());
+        var first = result.next();
+        assertEquals(ALICE, first.getValue("person").stringValue());
+        assertEquals(1, ((Literal) first.getValue("rank")).intValue());
+        var duplicate = result.next();
+        assertEquals(ALICE, duplicate.getValue("person").stringValue());
+        assertEquals(1, ((Literal) duplicate.getValue("rank")).intValue());
+        var unbound = result.next();
+        assertEquals(BOB, unbound.getValue("person").stringValue());
+        assertFalse(unbound.hasBinding("rank"));
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("VALUES joins graph patterns at its position and rejects incompatible mappings")
+    void inlineValuesJoinsGraphPatterns() {
+        insert(iri(BOB), iri(KNOWS), iri(ALICE));
+
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?person ?friend WHERE {
+                  VALUES ?person { <http://example.org/alice> <http://example.org/missing> }
+                  ?person <http://example.org/knows> ?friend .
+                }
+                """);
+
+        assertTrue(result.hasNext());
+        var binding = result.next();
+        assertEquals(ALICE, binding.getValue("person").stringValue());
+        assertEquals(BOB, binding.getValue("friend").stringValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("Query-level VALUES constrains the completed WHERE result")
+    void queryLevelValuesConstrainWhereResults() {
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?person ?friend WHERE {
+                  ?person <http://example.org/knows> ?friend .
+                }
+                VALUES ?person { <http://example.org/alice> }
+                """);
+
+        assertTrue(result.hasNext());
+        assertEquals(ALICE, result.next().getValue("person").stringValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("Query-level VALUES constrains a semicolon-expanded basic graph pattern")
+    void queryLevelValuesConstrainSemicolonExpandedPattern() {
+        String title = "http://purl.org/dc/elements/1.1/title";
+        String price = "http://example.org/ns#price";
+        String secondBook = "http://example.org/book/book2";
+        insert(iri(ALICE), iri(title), valueFactory.createLiteral("first"));
+        insert(iri(ALICE), iri(price), valueFactory.createLiteral(1));
+        insert(iri(secondBook), iri(title), valueFactory.createLiteral("second"));
+        insert(iri(secondBook), iri(price), valueFactory.createLiteral(2));
+
+        TupleQueryResult result = executor.evaluateTuple("""
+                PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                PREFIX : <http://example.org/book/>
+                PREFIX ns: <http://example.org/ns#>
+                SELECT ?book ?title ?price {
+                  ?book dc:title ?title ; ns:price ?price .
+                }
+                VALUES ?book { <http://example.org/alice> }
+                """);
+
+        assertTrue(result.hasNext());
+        assertEquals(ALICE, result.next().getValue("book").stringValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("BIND chains after VALUES and remains visible to following graph patterns")
+    void bindAfterValuesIsVisibleToFollowingPatterns() {
+        String rank = "http://example.org/rank";
+        insert(iri(ALICE), iri(rank), valueFactory.createLiteral(2));
+
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?person ?nextRank WHERE {
+                  VALUES ?person { <http://example.org/alice> }
+                  ?person <http://example.org/rank> ?rank .
+                  BIND(?rank + 1 AS ?nextRank)
+                  VALUES ?nextRank { 3 }
+                }
+                """);
+
+        assertTrue(result.hasNext());
+        assertEquals(3, ((Literal) result.next().getValue("nextRank")).intValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("VALUES UNDEF leaves an incoming binding available to following operations")
+    void valuesUndefDoesNotClearIncomingBinding() {
+        String rank = "http://example.org/rank";
+        insert(iri(ALICE), iri(rank), valueFactory.createLiteral(2));
+
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?nextRank WHERE {
+                  ?person <http://example.org/rank> ?rank .
+                  VALUES (?person ?rank) { (<http://example.org/alice> UNDEF) }
+                  BIND(?rank + 1 AS ?nextRank)
+                }
+                """);
+
+        assertTrue(result.hasNext());
+        assertEquals(3, ((Literal) result.next().getValue("nextRank")).intValue());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    @DisplayName("BIND expression errors keep the input solution with an unbound target")
+    void bindExpressionErrorLeavesTargetUnbound() {
+        TupleQueryResult result = executor.evaluateTuple("""
+                SELECT ?person ?value WHERE {
+                  VALUES ?person { <http://example.org/alice> }
+                  BIND(1 / 0 AS ?value)
+                }
+                """);
+
+        assertTrue(result.hasNext());
+        var binding = result.next();
+        assertEquals(ALICE, binding.getValue("person").stringValue());
+        assertFalse(binding.hasBinding("value"));
+        assertFalse(result.hasNext());
     }
 
     @Test
@@ -558,4 +718,114 @@ class NextSparqlPipelineExecutorTest {
             @Override public Iterator<Binding> iterator()               { return List.of(b).iterator(); }
         };
     }
+    @Test
+    void valuesInsideGraphPreservesUnboundGraphRows() {
+        insertInGraph(iri(ALICE), iri(KNOWS), iri(BOB), iri("http://example.org/g1"));
+        insertInGraph(iri(ALICE), iri(KNOWS), iri(BOB), iri("http://example.org/g2"));
+        try (var result = executor.evaluateTuple("""
+                SELECT ?g ?t WHERE {
+                  GRAPH ?g {
+                    VALUES (?g ?t) { (UNDEF "foo") (<http://example.org/g1> "bar") }
+                  }
+                }
+                """)) {
+            assertEquals(List.of("http://example.org/g1:bar", "http://example.org/g1:foo", "http://example.org/g2:foo"),
+                    result.stream().map(row -> row.getValue("g").stringValue() + ":" + row.getValue("t").stringValue())
+                            .sorted().toList());
+        }
+    }
+
+    @Test
+    void trailingValuesDoesNotSupplyBindingsToWhere() {
+        try (var result = executor.evaluateTuple("SELECT ?x ?y { BIND(?x AS ?y) } VALUES ?x { 1 }")) {
+            assertTrue(result.hasNext());
+            var row = result.next();
+            assertEquals("1", row.getValue("x").stringValue());
+            assertFalse(row.hasBinding("y"));
+            assertEquals(Set.of("x"), row.getBindingNames());
+            var bindings = row.iterator();
+            assertTrue(bindings.hasNext());
+            assertEquals("x", bindings.next().name());
+            assertFalse(bindings.hasNext());
+            assertFalse(result.hasNext());
+        }
+    }
+
+    @Test
+    void unionPreservesRightBranchWhenLeftIsEmpty() {
+        try (var result = executor.evaluateTuple("SELECT ?x { { VALUES ?x {} } UNION { VALUES ?x { 1 1 } } }")) {
+            assertEquals(2, result.stream().count());
+        }
+    }
+
+    @Test
+    void selectStarDoesNotExposeExistentialBlankNodeVariables() {
+        try (var result = executor.evaluateTuple("SELECT * { [] <http://example.org/knows> ?friend }")) {
+            assertEquals(List.of("friend"), result.getBindingNames());
+            assertTrue(result.hasNext());
+            assertEquals(Set.of("friend"), result.next().getBindingNames());
+        }
+    }
+
+    @Test
+    void incompatibleValuesRowAfterUndefDoesNotPopIncomingBindings() {
+        try (var result = executor.evaluateTuple("""
+                SELECT ?x ?y ?z {
+                  VALUES (?x ?y ?z) { (1 2 3) }
+                  VALUES (?x ?y ?z) { (UNDEF 2 4) (UNDEF 2 3) }
+                }
+                """)) {
+            assertTrue(result.hasNext());
+            var row = result.next();
+            assertEquals("1", row.getValue("x").stringValue());
+            assertEquals("2", row.getValue("y").stringValue());
+            assertEquals("3", row.getValue("z").stringValue());
+            assertFalse(result.hasNext());
+        }
+    }
+
+    @Test
+    void graphNameIsNotAnInputBindingForItsInnerBind() {
+        insertInGraph(iri(ALICE), iri(KNOWS), iri(BOB), iri("http://example.org/g1"));
+        try (var result = executor.evaluateTuple("SELECT ?g ?copy { GRAPH ?g { BIND(?g AS ?copy) } }")) {
+            assertTrue(result.hasNext());
+            var row = result.next();
+            assertEquals("http://example.org/g1", row.getValue("g").stringValue());
+            assertFalse(row.hasBinding("copy"));
+            assertFalse(result.hasNext());
+        }
+    }
+
+    @Test
+    void nestedGroupFilterDoesNotSeeOuterBind() {
+        try (var result = executor.evaluateTuple("SELECT ?x { BIND(1 AS ?x) { FILTER(?x = 1) } }")) {
+            assertFalse(result.hasNext());
+        }
+    }
+
+    @Test
+    void graphWithValuesRequiresAnExistingNamedGraph() {
+        insertInGraph(iri(ALICE), iri(KNOWS), iri(BOB), iri("http://example.org/g1"));
+        assertTrue(executor.evaluateBoolean("ASK { GRAPH <http://example.org/g1> { VALUES ?x { 1 } } }"));
+        assertFalse(executor.evaluateBoolean("ASK { GRAPH <http://example.org/missing> { VALUES ?x { 1 } } }"));
+        assertFalse(executor.evaluateBoolean("""
+                ASK FROM NAMED <http://example.org/other>
+                { GRAPH <http://example.org/g1> { VALUES ?x { 1 } } }
+                """));
+    }
+
+    @Test
+    void valuesDistinguishesEmptyTableFromEmptySolution() {
+        assertFalse(executor.evaluateBoolean("ASK {} VALUES ?x {}"));
+        assertFalse(executor.evaluateBoolean("ASK { VALUES () {} }"));
+        assertTrue(executor.evaluateBoolean("ASK { VALUES () { () } }"));
+        try (var result = executor.evaluateTuple("SELECT * {} VALUES ?x {}")) {
+            assertEquals(List.of("x"), result.getBindingNames());
+            assertFalse(result.hasNext());
+        }
+        try (var result = executor.evaluateTuple("SELECT * { VALUES () { () () } }")) {
+            assertEquals(2, result.stream().count());
+        }
+    }
+
 }

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlParserValidationTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlParserValidationTest.java
@@ -158,6 +158,22 @@ class SparqlParserValidationTest extends AbstractSparqlParserFeatureTest {
 
             assertEquals(BIND_SCOPE_MESSAGE, exception.getMessage());
         }
+
+        @Test
+        @DisplayName("Should reject BIND when its target is already introduced by inline VALUES")
+        void shouldRejectBindVariableAlreadyVisibleFromInlineValues() {
+            var parser = newParserDefault();
+            QueryValidationException exception = assertThrows(
+                    QueryValidationException.class,
+                    () -> parser.parse("""
+                            SELECT * WHERE {
+                              VALUES ?x { 1 }
+                              BIND(2 AS ?x)
+                            }
+                            """));
+
+            assertEquals(BIND_SCOPE_MESSAGE, exception.getMessage());
+        }
     }
 
     @Nested

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlParserValuesTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlParserValuesTest.java
@@ -1,6 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.parser;
 
 import fr.inria.corese.core.next.query.impl.sparql.ast.*;
+import fr.inria.corese.core.next.query.api.exception.QuerySyntaxException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +18,7 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                 """;
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
+        ValuesAst valuesAst = inlineValues(ast);
         assertNotNull(valuesAst);
         assertEquals(2, valuesAst.mappings().size());
         assertEquals(1, valuesAst.mappings().getFirst().values().keySet().size());
@@ -42,7 +43,7 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                 """;
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
+        ValuesAst valuesAst = inlineValues(ast);
         assertNotNull(valuesAst);
         assertEquals(2, valuesAst.mappings().size());
         assertEquals(2, valuesAst.mappings().getFirst().values().keySet().size());
@@ -84,24 +85,24 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                """;
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
-        assertNotNull(valuesAst);
-        assertEquals(2, valuesAst.mappings().size());
+        ValuesAst valuesAst = inlineValues(ast);
+        assertEquals(1, valuesAst.mappings().size());
         assertEquals(1, valuesAst.mappings().getFirst().values().keySet().size());
-        assertEquals(2, valuesAst.mappings().getLast().values().keySet().size());
         VarAst var1Key = new VarAst("var1");
         VarAst var2Key = new VarAst("var2");
         VarAst var3Key = new VarAst("var3");
         assertTrue(valuesAst.mappings().getFirst().values().containsKey(var1Key));
-        assertTrue(valuesAst.mappings().getLast().values().containsKey(var2Key));
-        assertTrue(valuesAst.mappings().getLast().values().containsKey(var3Key));
+        ValuesAst queryValues = ast.valuesClause();
+        assertEquals(1, queryValues.mappings().size());
+        assertTrue(queryValues.mappings().getFirst().values().containsKey(var2Key));
+        assertTrue(queryValues.mappings().getFirst().values().containsKey(var3Key));
 
         ValueMappingAst valueMappingAst1 = valuesAst.mappings().getFirst();
         assertInstanceOf(LiteralAst.class, valueMappingAst1.values().get(var1Key));
         LiteralAst literalAst1 = (LiteralAst) valueMappingAst1.values().get(var1Key);
         assertEquals("\"test1\"", literalAst1.lexical());
 
-        ValueMappingAst valueMappingAst2 = valuesAst.mappings().getLast();
+        ValueMappingAst valueMappingAst2 = queryValues.mappings().getFirst();
         assertInstanceOf(LiteralAst.class, valueMappingAst2.values().get(var2Key));
         LiteralAst literalAst2 = (LiteralAst) valueMappingAst2.values().get(var2Key);
         assertEquals("\"test2\"", literalAst2.lexical());
@@ -120,7 +121,7 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                 """;
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
+        ValuesAst valuesAst = inlineValues(ast);
         assertNotNull(valuesAst);
         assertEquals(2, valuesAst.mappings().size());
         assertEquals(1, valuesAst.mappings().getFirst().values().keySet().size());
@@ -144,9 +145,10 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                 """;
         SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
         assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
+        ValuesAst valuesAst = inlineValues(ast);
         assertNotNull(valuesAst);
-        assertEquals(0, valuesAst.mappings().size());
+        assertEquals(1, valuesAst.mappings().size());
+        assertTrue(valuesAst.mappings().getFirst().values().isEmpty());
     }
 
     @Test
@@ -158,10 +160,11 @@ class SparqlParserValuesTest extends AbstractSparqlParserFeatureTest {
                     VALUES () { ( "test" ) }
                 }
                 """;
-        SparqlQueryAst ast = (SparqlQueryAst) parser.parse(inlineValueTest);
-        assertNotNull(ast);
-        ValuesAst valuesAst = ast.valuesClause();
-        assertNotNull(valuesAst);
-        assertEquals(0, valuesAst.mappings().size());
+        assertThrows(QuerySyntaxException.class, () -> parser.parse(inlineValueTest));
+    }
+
+    private ValuesAst inlineValues(SparqlQueryAst query) {
+        SelectQueryAst select = assertInstanceOf(SelectQueryAst.class, query);
+        return assertInstanceOf(ValuesAst.class, select.whereClause().patterns().getLast());
     }
 }


### PR DESCRIPTION
Closes #562

### Summary
Support SPARQL 1.1 inline data (`VALUES` / `Table`) and variable assignment (`BIND` / `Extend`) in `core.next.query`.

### Key Changes
- **VALUES Clause**:
  - Preserve `VALUES` headers, `UNDEF` and bag semantics.
  - Compile trailing `VALUES` as a join in `WhereCompiler`.
  - Support both inline data in WHERE graph patterns and trailing query-level `VALUES`.
- **BIND Clause**:
  - Implement `Extend(mu, var, expr)` evaluation to assign computed values to variables.
  - Correctly enforce scope across basic graph patterns, `UNION`, `GRAPH`, and subqueries.
- **Repository API & Base IRIs**:
  - Expose query-document base IRI prepare overloads on `RepositoryConnection` and `CoreseRepositoryConnection`.
- **Quality & Verification**:
  - All 2,816 local unit tests passing.
  - Headless SonarLint scan reports 0 issues across all changed Java files.
  - Strict modular boundaries verified by `NextModuleBoundaryTest`.