### PR TITLE
feat(query): implement scalar functions and XML Schema casts (#563)

### DIFF
--- a/src/main/antlr/SparqlParser.g4
+++ b/src/main/antlr/SparqlParser.g4
@@ -623,7 +623,7 @@ builtInCall
     | CEIL L_PAREN expression R_PAREN
     | FLOOR L_PAREN expression R_PAREN
     | ROUND L_PAREN expression R_PAREN
-    | CONCAT L_PAREN expression (COMMA expression)* R_PAREN
+    | CONCAT (NIL | L_PAREN expression (COMMA expression)* R_PAREN)
     | subStringExpression
     | strReplaceExpression
     | STRLEN L_PAREN expression R_PAREN
@@ -651,7 +651,7 @@ builtInCall
     | SHA256 L_PAREN expression R_PAREN
     | SHA384 L_PAREN expression R_PAREN
     | SHA512 L_PAREN expression R_PAREN
-    | COALESCE L_PAREN expression (COMMA expression)* R_PAREN
+    | COALESCE (NIL | L_PAREN expression (COMMA expression)* R_PAREN)
     | IF L_PAREN expression COMMA expression COMMA expression R_PAREN
     | STRLANG L_PAREN expression COMMA expression R_PAREN
     | STRDT L_PAREN expression COMMA expression R_PAREN

--- a/src/main/java/fr/inria/corese/core/next/query/api/exception/QueryTypeErrorException.java
+++ b/src/main/java/fr/inria/corese/core/next/query/api/exception/QueryTypeErrorException.java
@@ -1,0 +1,17 @@
+package fr.inria.corese.core.next.query.api.exception;
+
+/**
+ * A SPARQL expression error (unbound argument, incompatible RDF type or invalid
+ * value). FILTER, BIND, projection and the SPARQL error-handling functions may
+ * absorb this exception; infrastructure and programming failures must propagate.
+ */
+@SuppressWarnings("java:S110") // Retains the public query exception hierarchy and distinguishes SPARQL type errors.
+public final class QueryTypeErrorException extends QueryEvaluationException {
+    public QueryTypeErrorException(String message) {
+        super(message);
+    }
+
+    public QueryTypeErrorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/Eval.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/eval/Eval.java
@@ -22,7 +22,7 @@ import fr.inria.corese.core.next.query.impl.engine.spi.Plugin;
 import fr.inria.corese.core.next.query.impl.engine.spi.Producer;
 import fr.inria.corese.core.next.query.impl.engine.spi.Provider;
 import fr.inria.corese.core.next.query.impl.engine.spi.SPARQLEngine;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 
 import fr.inria.corese.core.next.data.Values;
 import fr.inria.corese.core.next.query.impl.engine.event.Event;
@@ -1247,7 +1247,7 @@ public final class Eval implements ExpType, Plugin {
         Node node;
         try {
             node = eval(graphNode, exp.getFilter(), env, p);
-        } catch (QueryEvaluationException error) {
+        } catch (QueryTypeErrorException error) {
             // SPARQL Extend keeps the input solution when its expression errors;
             // only the target variable is left unbound. Unsupported features and
             // programming failures deliberately still propagate.
@@ -1340,7 +1340,7 @@ public final class Eval implements ExpType, Plugin {
             env.setGraphNode(graphNode);
             DatatypeValue dt = eval(f, env, p);
             return isTrue(dt);
-        } catch (QueryEvaluationException error) {
+        } catch (QueryTypeErrorException error) {
             // A SPARQL filter expression error makes that solution fail; it is
             // not an engine failure and must not abort the whole query.
             return false;

--- a/src/main/java/fr/inria/corese/core/next/query/impl/engine/solution/Memory.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/engine/solution/Memory.java
@@ -1,5 +1,7 @@
 package fr.inria.corese.core.next.query.impl.engine.solution;
 
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
+
 import fr.inria.corese.core.next.query.impl.engine.eval.Eval;
 import fr.inria.corese.core.next.query.impl.engine.eval.PointerObject;
 import fr.inria.corese.core.next.query.impl.engine.eval.Stack;
@@ -423,7 +425,7 @@ public class Memory extends PointerObject implements Environment {
                         if (!e.isAggregate()) {
 
 
-                            node = (Node) kgram.eval(f, this, p);
+                            node = evaluateExpressionNode(f, p);
                             kgram.getVisitor().select(kgram, f.getExp(), node == null ? null : node.getDatatypeValue());
                             // bind fun(?x) as ?y
                             boolean success = push(e.getNode(), node);
@@ -530,11 +532,20 @@ public class Memory extends PointerObject implements Environment {
             if (nodes[n] == null) {
                 Filter f = e.getFilter();
                 if (f != null && !e.isAggregate()) {
-                    nodes[n] = (Node) kgram.eval(f, this, p);
+                    nodes[n] = evaluateExpressionNode(f, p);
                 }
 
             }
             n++;
+        }
+    }
+
+    private Node evaluateExpressionNode(Filter filter, Producer producer) {
+        try {
+            return producer.getNode(kgram.eval(filter, this, producer));
+        } catch (QueryTypeErrorException error) {
+            // A scalar type error leaves a projected value or sorting key unbound.
+            return null;
         }
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ASTConstants.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/ASTConstants.java
@@ -243,6 +243,7 @@ public class ASTConstants {
          * {@code isLiteral(term)}: returns {@code true} if {@code term} is a literal.
          */
         IS_LITERAL,
+        IS_NUMERIC,
 
         /**
          * {@code sameterm(termA, termB)}: Returns {@code true} if termA and termB are the same RDF term (including their lang and datatypes)

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsNumericAst.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/ast/constraint/IsNumericAst.java
@@ -1,0 +1,16 @@
+package fr.inria.corese.core.next.query.impl.sparql.ast.constraint;
+
+import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
+import java.util.List;
+
+/** Tests whether an RDF term is a valid numeric literal. */
+public final class IsNumericAst extends AbstractUnaryConstraintAst implements BooleanExpressionAst {
+    public IsNumericAst(List<TermAst> arguments) {
+        super(arguments);
+    }
+
+    @Override
+    public String getName() {
+        return "ISNUMERIC";
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/CoreseAstQueryBuilder.java
@@ -9,6 +9,7 @@ import fr.inria.corese.core.next.query.impl.engine.model.Node;
 import fr.inria.corese.core.next.query.impl.engine.pattern.Exp;
 import fr.inria.corese.core.next.query.impl.engine.pattern.Query;
 import fr.inria.corese.core.next.query.impl.engine.model.NodeImpl;
+import fr.inria.corese.core.next.query.impl.sparql.parser.semantic.support.VariableScopeAnalyzer;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -89,7 +90,7 @@ public final class CoreseAstQueryBuilder {
                 selectQueryAst.solutionModifier(),
                 selectQueryAst.valuesClause(),
                 compiler);
-        applyProjection(query, selectQueryAst.projection());
+        applyProjection(query, selectQueryAst.projection(), compiler);
         query.setDistinct(selectQueryAst.solutionModifier().distinct());
         applyOrderBy(query, selectQueryAst.solutionModifier(), compiler);
         query.setAST(selectQueryAst);
@@ -197,7 +198,6 @@ public final class CoreseAstQueryBuilder {
      *
      * <p>Planned roadmap items:
      * <ul>
-     *   <li>Issue #387: {@code SELECT} expressions and aliases need a runtime story and reuse in later clauses.</li>
      *   <li>Issue #387: {@code GROUP BY} / {@code HAVING} require aggregate semantics, not only AST field propagation.</li>
      *   <li>Issue #387: {@code REDUCED} support aligned with next-pipeline query-form policy.</li>
      * </ul>
@@ -205,9 +205,10 @@ public final class CoreseAstQueryBuilder {
      */
     private static void rejectUnsupportedSelectClauses(SelectQueryAst selectQueryAst) {
         ProjectionAst projection = selectQueryAst.projection();
-        if (!projection.expressionTerms().isEmpty() || !projection.expressionBoundVariables().isEmpty()) {
+        if (projection.expressionTerms().values().stream().anyMatch(
+                new VariableScopeAnalyzer()::containsAggregate)) {
             throw new UnsupportedQueryFeatureException(
-                    "SELECT expressions and aliases are not supported yet by the next pipeline");
+                    "Aggregate projection expressions are not supported yet by the next pipeline");
         }
         SolutionModifierAst solutionModifier = selectQueryAst.solutionModifier();
         if (solutionModifier.reduced()) {
@@ -288,13 +289,20 @@ public final class CoreseAstQueryBuilder {
      * query body. An explicit projection reuses these same runtime nodes and fails
      * fast when a projected variable is not visible in the body.</p>
      */
-    private void applyProjection(Query query, ProjectionAst projection) {
+    private void applyProjection(Query query, ProjectionAst projection, WhereCompiler compiler) {
         List<Exp> selectExpressions;
         if (projection.selectAll()) {
             selectExpressions = toNodeExpressions(query.selectNodesFromPattern());
         } else {
             selectExpressions = new ArrayList<>();
             for (VarAst variable : projection.variables()) {
+                TermAst expression = projection.expressionTerms().get(variable.name());
+                if (expression != null) {
+                    Exp selected = Exp.create(Type.NODE, compiler.termResolver().toNode(variable));
+                    selected.setFilter(new AstBackedExpr(expression, compiler).getFilter());
+                    selectExpressions.add(selected);
+                    continue;
+                }
                 Node node = visibleBodyNode(query, variable.name());
                 if (node == null) {
                     throw new IllegalArgumentException(

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeBooleanExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeBooleanExpressionEvaluator.java
@@ -1,7 +1,7 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.VarAst;
@@ -21,6 +21,7 @@ import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.InAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IsBlankAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IsIriAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IsLiteralAst;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IsNumericAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.LangMatchesAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.LowerOrEqualThanAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.LowerThanAst;
@@ -57,12 +58,13 @@ final class NativeBooleanExpressionEvaluator {
             case IsIriAst unary -> context.required(unary.argument()).isIRI();
             case IsBlankAst unary -> context.required(unary.argument()).isBNode();
             case IsLiteralAst unary -> context.required(unary.argument()).isLiteral();
+            case IsNumericAst unary -> NativeNumericExpressionEvaluator.isNumeric(context.required(unary.argument()));
             case StrStartsAst binary -> NativeStringExpressionEvaluator.startsWith(binary, context);
             case StrEndsAst binary -> NativeStringExpressionEvaluator.endsWith(binary, context);
             case ContainsAst binary -> NativeStringExpressionEvaluator.contains(binary, context);
             case LangMatchesAst binary -> languageMatches(
-                    context.stringLiteral(binary.getLeftArgument()).getLabel(),
-                    context.stringLiteral(binary.getRightArgument()).getLabel());
+                    context.simpleString(binary.getLeftArgument()).getLabel(),
+                    context.simpleString(binary.getRightArgument()).getLabel());
             case BinaryRegexAst regex -> NativeStringExpressionEvaluator.regex(regex, context);
             case TrinaryRegexAst regex -> NativeStringExpressionEvaluator.regex(regex, context);
             case InAst(var left, var candidates) -> in(context.required(left), candidates, context);
@@ -105,7 +107,7 @@ final class NativeBooleanExpressionEvaluator {
     private static BooleanResult booleanResult(TermAst expression, NativeEvaluationContext context) {
         try {
             return BooleanResult.value(context.effectiveBooleanValue(expression));
-        } catch (QueryEvaluationException failure) {
+        } catch (QueryTypeErrorException failure) {
             return BooleanResult.failure(failure);
         }
     }
@@ -114,14 +116,14 @@ final class NativeBooleanExpressionEvaluator {
             DatatypeValue left,
             List<TermAst> candidates,
             NativeEvaluationContext context) {
-        QueryEvaluationException failure = null;
+        QueryTypeErrorException failure = null;
         for (TermAst candidate : candidates) {
             try {
                 DatatypeValue right = context.required(candidate);
                 if (left.equalsWE(right)) {
                     return true;
                 }
-            } catch (QueryEvaluationException candidateFailure) {
+            } catch (QueryTypeErrorException candidateFailure) {
                 failure = candidateFailure;
             }
         }
@@ -158,13 +160,13 @@ final class NativeBooleanExpressionEvaluator {
                 "Boolean expression is not supported yet: " + expression.getClass().getSimpleName());
     }
 
-    private record BooleanResult(Boolean value, QueryEvaluationException failure) {
+    private record BooleanResult(Boolean value, QueryTypeErrorException failure) {
 
         static BooleanResult value(boolean value) {
             return new BooleanResult(value, null);
         }
 
-        static BooleanResult failure(QueryEvaluationException failure) {
+        static BooleanResult failure(QueryTypeErrorException failure) {
             return new BooleanResult(null, failure);
         }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeCastExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeCastExpressionEvaluator.java
@@ -1,0 +1,166 @@
+package fr.inria.corese.core.next.query.impl.sparql.bridge;
+
+import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
+import fr.inria.corese.core.next.data.api.model.DatatypeValue;
+import fr.inria.corese.core.next.data.api.term.Literal;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
+import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
+import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.FunctionCallAst;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Set;
+import javax.xml.datatype.DatatypeConstants;
+
+import static fr.inria.corese.core.next.query.impl.sparql.bridge.NativeNumericValues.DECIMAL;
+import static fr.inria.corese.core.next.query.impl.sparql.bridge.NativeNumericValues.INTEGER;
+import static fr.inria.corese.core.next.query.impl.sparql.bridge.NativeNumericValues.floatingLexical;
+import static fr.inria.corese.core.next.query.impl.sparql.bridge.NativeNumericValues.lexical;
+import static fr.inria.corese.core.next.query.impl.sparql.bridge.NativeNumericValues.whitespaceCollapsed;
+
+/** XML Schema constructors supported by SPARQL 1.1, without extension dispatch. */
+final class NativeCastExpressionEvaluator {
+    private static final String XSD = "http://www.w3.org/2001/XMLSchema#";
+    private static final String STRING = "string";
+    private static final Set<String> TARGETS = Set.of(STRING, "integer", "decimal", "double", "float", "boolean", "dateTime");
+
+    private NativeCastExpressionEvaluator() {}
+
+    static DatatypeValue evaluate(FunctionCallAst function, NativeEvaluationContext context) {
+        String iri = context.constant(function.functionName()).stringValue();
+        if (!iri.startsWith(XSD) || !TARGETS.contains(iri.substring(XSD.length()))) {
+            throw new UnsupportedQueryFeatureException("Extension function evaluation is not supported yet: " + iri);
+        }
+        if (function.arguments().size() != 1) {
+            throw new QueryTypeErrorException("An XML Schema constructor requires exactly one argument");
+        }
+        DatatypeValue value = context.required(function.arguments().getFirst());
+        String target = iri.substring(XSD.length());
+        if (target.equals(STRING) && value.isIRI()) {
+            return context.values().createLiteral(value.stringValue());
+        }
+        if (!(value instanceof Literal literal) || literal.getLanguage().isPresent()) {
+            throw new QueryTypeErrorException("XML Schema constructors require an untagged literal");
+        }
+        if (literal.isNumber()) literal = NativeNumericValues.normalized(literal);
+        return switch (target) {
+            case STRING -> context.values().createLiteral(stringValue(literal));
+            case "integer" -> context.values().createLiteral(integerValue(literal));
+            case "decimal" -> context.values().createLiteral(decimalValue(literal));
+            case "double" -> context.values().createLiteral(floatingValue(literal));
+            case "float" -> context.values().createLiteral((float) floatingValue(literal));
+            case "boolean" -> context.values().createLiteral(booleanValue(literal));
+            case "dateTime" -> dateTime(literal, context);
+            default -> throw new IllegalStateException("Unrecognized validated constructor: " + target);
+        };
+    }
+
+    @SuppressWarnings("java:S2111") // XPath casts truncate the exact binary value, not its decimal display string.
+    private static BigInteger integerValue(Literal value) {
+        if (value.getCoreDatatype() == XSDDatatype.STRING) {
+            return new BigInteger(lexical(value, INTEGER));
+        }
+        if (value.getCoreDatatype() == XSDDatatype.DOUBLE || value.getCoreDatatype() == XSDDatatype.FLOAT) {
+            double number = floatingValue(value);
+            if (!Double.isFinite(number)) {
+                throw new QueryTypeErrorException("NaN and infinity cannot be cast to integer");
+            }
+            // Truncate the binary value itself, not its rounded decimal display string.
+            return new BigDecimal(number).toBigInteger();
+        }
+        return decimalValue(value).toBigInteger();
+    }
+
+    private static BigDecimal decimalValue(Literal value) {
+        if (value.getCoreDatatype() == XSDDatatype.STRING) {
+            return new BigDecimal(lexical(value, DECIMAL));
+        }
+        if (value.getCoreDatatype() == XSDDatatype.BOOLEAN) {
+            return booleanValue(value) ? BigDecimal.ONE : BigDecimal.ZERO;
+        }
+        requireNumeric(value);
+        if (value.getCoreDatatype() == XSDDatatype.FLOAT || value.getCoreDatatype() == XSDDatatype.DOUBLE) {
+            double number = value.getCoreDatatype() == XSDDatatype.FLOAT ? value.floatValue() : value.doubleValue();
+            if (!Double.isFinite(number)) {
+                throw new QueryTypeErrorException("NaN and infinity cannot be cast to decimal or integer");
+            }
+            return BigDecimal.valueOf(number);
+        }
+        return value.decimalValue();
+    }
+
+    private static double floatingValue(Literal value) {
+        if (value.getCoreDatatype() == XSDDatatype.STRING) {
+            return switch (floatingLexical(value)) {
+                case "INF" -> Double.POSITIVE_INFINITY;
+                case "-INF" -> Double.NEGATIVE_INFINITY;
+                case "NaN" -> Double.NaN;
+                default -> Double.parseDouble(whitespaceCollapsed(value.getLabel()));
+            };
+        }
+        if (value.getCoreDatatype() == XSDDatatype.BOOLEAN) {
+            return booleanValue(value) ? 1.0 : 0.0;
+        }
+        requireNumeric(value);
+        return value.getCoreDatatype() == XSDDatatype.FLOAT ? value.floatValue() : value.doubleValue();
+    }
+
+    private static boolean booleanValue(Literal value) {
+        if (value.getCoreDatatype() == XSDDatatype.STRING || value.getCoreDatatype() == XSDDatatype.BOOLEAN) {
+            return switch (whitespaceCollapsed(value.getLabel())) {
+                case "true", "1" -> true;
+                case "false", "0" -> false;
+                default -> throw new QueryTypeErrorException("Invalid xsd:boolean lexical form");
+            };
+        }
+        requireNumeric(value);
+        return NativeNumericValues.booleanValue(value);
+    }
+
+    private static String stringValue(Literal value) {
+        if (value.getCoreDatatype() == XSDDatatype.BOOLEAN) {
+            return Boolean.toString(booleanValue(value));
+        }
+        if (value.isNumber()) {
+            NativeNumericValues.validate(value);
+            return numericString(value);
+        }
+        return value.getLabel();
+    }
+
+    private static String numericString(Literal value) {
+        if (value.getCoreDatatype() != XSDDatatype.FLOAT && value.getCoreDatatype() != XSDDatatype.DOUBLE) {
+            return value.decimalValue().stripTrailingZeros().toPlainString();
+        }
+        double number = value.getCoreDatatype() == XSDDatatype.FLOAT ? value.floatValue() : value.doubleValue();
+        if (Double.isNaN(number)) return "NaN";
+        if (Double.isInfinite(number)) return number < 0 ? "-INF" : "INF";
+        return floatingString(value, number);
+    }
+
+    private static String floatingString(Literal literal, double number) {
+        if (number == 0) return Double.doubleToRawLongBits(number) < 0 ? "-0" : "0";
+        BigDecimal decimal = new BigDecimal(literal.getCoreDatatype() == XSDDatatype.FLOAT
+                ? Float.toString((float) number) : Double.toString(number)).stripTrailingZeros();
+        double magnitude = Math.abs(number);
+        if (magnitude >= 0.000001 && magnitude < 1000000) return decimal.toPlainString();
+        int exponent = decimal.precision() - decimal.scale() - 1;
+        BigDecimal mantissa = decimal.movePointLeft(exponent);
+        if (mantissa.scale() < 1) mantissa = mantissa.setScale(1);
+        return mantissa.toPlainString() + "E" + exponent;
+    }
+
+    private static DatatypeValue dateTime(Literal value, NativeEvaluationContext context) {
+        if (value.getCoreDatatype() != XSDDatatype.STRING && value.getCoreDatatype() != XSDDatatype.DATETIME) {
+            throw new QueryTypeErrorException("Cannot cast this datatype to xsd:dateTime");
+        }
+        Literal result = context.values().createLiteral(whitespaceCollapsed(value.getLabel()), XSDDatatype.DATETIME.getIRI());
+        if (!DatatypeConstants.DATETIME.equals(result.calendarValue().getXMLSchemaType())) {
+            throw new QueryTypeErrorException("Invalid xsd:dateTime lexical form");
+        }
+        return result;
+    }
+
+    private static void requireNumeric(Literal value) {
+        NativeNumericValues.validate(value);
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeEvaluationContext.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeEvaluationContext.java
@@ -8,6 +8,10 @@ import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
+import fr.inria.corese.core.next.data.api.exception.IncorrectOperationException;
+import fr.inria.corese.core.next.data.api.exception.IncorrectFormatException;
+import fr.inria.corese.core.next.data.api.exception.InvalidDatatypeException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.engine.model.Node;
 import fr.inria.corese.core.next.query.impl.engine.spi.Environment;
@@ -45,8 +49,9 @@ final class NativeEvaluationContext {
             return NativeExpressionEvaluator.evaluateExpression(expression, this);
         } catch (QueryEvaluationException | UnsupportedQueryFeatureException failure) {
             throw failure;
-        } catch (RuntimeException failure) {
-            throw new QueryEvaluationException(
+        } catch (IllegalArgumentException | ArithmeticException | IncorrectOperationException
+                 | IncorrectFormatException | InvalidDatatypeException failure) {
+            throw new QueryTypeErrorException(
                     "Failed to evaluate SPARQL expression " + expression.getName(), failure);
         }
     }
@@ -69,7 +74,7 @@ final class NativeEvaluationContext {
 
     DatatypeValue required(DatatypeValue value) {
         if (value == null) {
-            throw new QueryEvaluationException("Expression references an unbound variable");
+            throw new QueryTypeErrorException("Expression references an unbound variable");
         }
         return value;
     }
@@ -79,7 +84,7 @@ final class NativeEvaluationContext {
         if (value instanceof Literal literal) {
             return literal;
         }
-        throw new QueryEvaluationException("Expected an RDF literal");
+        throw new QueryTypeErrorException("Expected an RDF literal");
     }
 
     Literal stringLiteral(TermAst expression) {
@@ -88,7 +93,15 @@ final class NativeEvaluationContext {
                 || literal.getCoreDatatype() == RDFDatatype.LANGSTRING) {
             return literal;
         }
-        throw new QueryEvaluationException("Expected a string RDF literal");
+        throw new QueryTypeErrorException("Expected a string RDF literal");
+    }
+
+    Literal simpleString(TermAst expression) {
+        Literal literal = stringLiteral(expression);
+        if (literal.getLanguage().isPresent()) {
+            throw new QueryTypeErrorException("Expected an untagged string literal");
+        }
+        return literal;
     }
 
     boolean effectiveBooleanValue(TermAst expression) {
@@ -98,20 +111,24 @@ final class NativeEvaluationContext {
     boolean effectiveBooleanValue(DatatypeValue value) {
         DatatypeValue boundValue = required(value);
         if (!(boundValue instanceof Literal literal)) {
-            throw new QueryEvaluationException("RDF term has no SPARQL effective boolean value");
+            throw new QueryTypeErrorException("RDF term has no SPARQL effective boolean value");
         }
         if (literal.getCoreDatatype() == XSDDatatype.BOOLEAN) {
-            return literal.booleanValue();
+            String lexical = NativeNumericValues.whitespaceCollapsed(literal.getLabel());
+            return lexical.equals("true") || lexical.equals("1");
         }
         if (literal.isNumber()) {
-            double number = literal.doubleValue();
-            return number != 0.0d && !Double.isNaN(number);
+            try {
+                return NativeNumericValues.booleanValue(literal);
+            } catch (QueryTypeErrorException invalidLexicalForm) {
+                return false;
+            }
         }
         if (literal.getCoreDatatype() == XSDDatatype.STRING
                 || literal.getCoreDatatype() == RDFDatatype.LANGSTRING) {
             return !literal.getLabel().isEmpty();
         }
-        throw new QueryEvaluationException("RDF literal has no SPARQL effective boolean value");
+        throw new QueryTypeErrorException("RDF literal has no SPARQL effective boolean value");
     }
 
     boolean exists(GroupGraphPatternAst pattern) {
@@ -124,6 +141,15 @@ final class NativeEvaluationContext {
         } catch (SparqlException exception) {
             throw new QueryEvaluationException("Failed to evaluate EXISTS graph pattern", exception);
         }
+    }
+
+    DatatypeValue blankNode(TermAst label) {
+        if (label == null) return values.createBNode();
+        String key = simpleString(label).getLabel();
+        if (environment == null || environment.getMap() == null) {
+            throw new QueryEvaluationException("BNODE(label) requires a solution evaluation context");
+        }
+        return environment.getMap().computeIfAbsent(key, ignored -> values.createBNode());
     }
 
     OffsetDateTime queryEvaluationTime() {

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeExpressionEvaluator.java
@@ -2,7 +2,7 @@ package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
 
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.engine.spi.Environment;
 import fr.inria.corese.core.next.query.impl.engine.spi.Evaluator;
@@ -65,11 +65,8 @@ final class NativeExpressionEvaluator {
             case CoalesceAst coalesce -> coalesce(coalesce.arguments(), context);
             case IfAst(var condition, var thenExpr, var elseExpr) -> context.evaluate(
                     context.effectiveBooleanValue(condition) ? thenExpr : elseExpr);
-            case BnodeAst bnode -> bnode.getLabel() == null
-                    ? context.values().createBNode()
-                    : context.values().createBNode(context.required(bnode.getLabel()).stringValue());
-            case FunctionCallAst function -> throw new UnsupportedQueryFeatureException(
-                    "Extension function evaluation is not supported yet: " + function.getName());
+            case BnodeAst bnode -> context.blankNode(bnode.getLabel());
+            case FunctionCallAst function -> NativeCastExpressionEvaluator.evaluate(function, context);
             default -> throw new UnsupportedQueryFeatureException(
                     "Expression is not supported yet by the native evaluator: "
                             + expression.getClass().getSimpleName());
@@ -79,18 +76,18 @@ final class NativeExpressionEvaluator {
     private static DatatypeValue coalesce(
             List<TermAst> arguments,
             NativeEvaluationContext context) {
-        QueryEvaluationException lastFailure = null;
+        QueryTypeErrorException lastFailure = null;
         for (TermAst argument : arguments) {
             try {
                 DatatypeValue value = context.evaluate(argument);
                 if (value != null) {
                     return value;
                 }
-            } catch (QueryEvaluationException failure) {
+            } catch (QueryTypeErrorException failure) {
                 lastFailure = failure;
             }
         }
-        throw new QueryEvaluationException(
+        throw new QueryTypeErrorException(
                 "COALESCE has no bound, successfully evaluated argument",
                 lastFailure);
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeIriExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeIriExpressionEvaluator.java
@@ -1,8 +1,10 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
+
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.DatatypeAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.IriExpressionAst;
@@ -20,9 +22,7 @@ final class NativeIriExpressionEvaluator {
     static DatatypeValue evaluate(IriExpressionAst expression, NativeEvaluationContext context) {
         return switch (expression) {
             case DatatypeAst datatype -> datatype(context.required(datatype.argument()), context);
-            case IriFunctionAst iri -> context.values().createIRI(
-                    context.termResolver().resolveIri(
-                            context.required(iri.argument()).stringValue()));
+            case IriFunctionAst iri -> iri(iri, context);
             case UuidAst ignored -> context.values().createIRI("urn:uuid:" + UUID.randomUUID());
             default -> throw new UnsupportedQueryFeatureException(
                     "IRI expression is not supported yet: "
@@ -30,11 +30,22 @@ final class NativeIriExpressionEvaluator {
         };
     }
 
+    private static DatatypeValue iri(IriFunctionAst expression, NativeEvaluationContext context) {
+        DatatypeValue value = context.required(expression.argument());
+        if (value.isIRI()) return value;
+        if (!(value instanceof Literal literal)
+                || literal.getCoreDatatype() != XSDDatatype.STRING) {
+            throw new QueryTypeErrorException("IRI expects an IRI or an untagged string literal");
+        }
+        String lexical = literal.getLabel();
+        return context.values().createIRI(context.termResolver().resolveRelativeIri(lexical));
+    }
+
     private static DatatypeValue datatype(
             DatatypeValue value,
             NativeEvaluationContext context) {
         if (!(value instanceof Literal literal)) {
-            throw new QueryEvaluationException("DATATYPE expects an RDF literal");
+            throw new QueryTypeErrorException("DATATYPE expects an RDF literal");
         }
         return context.values().createIRI(literal.getDatatype().stringValue());
     }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeNumericExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeNumericExpressionEvaluator.java
@@ -1,9 +1,13 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.data.api.exception.IncorrectOperationException;
+
+import java.math.BigInteger;
+
 import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AbsAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.AddAst;
@@ -60,18 +64,28 @@ final class NativeNumericExpressionEvaluator {
             case StrLenAst unary -> stringLength(unary, context);
             case RandAst ignored -> context.values().createLiteral(
                     ThreadLocalRandom.current().nextDouble());
-            case YearAst unary -> context.values().createLiteral(calendar(unary.argument(), context).getYear());
-            case MonthAst unary -> context.values().createLiteral(calendar(unary.argument(), context).getMonth());
-            case DayAst unary -> context.values().createLiteral(calendar(unary.argument(), context).getDay());
-            case HoursAst unary -> context.values().createLiteral(calendar(unary.argument(), context).getHour());
-            case MinutesAst unary -> context.values().createLiteral(calendar(unary.argument(), context).getMinute());
+            case YearAst unary -> context.values().createLiteral(BigInteger.valueOf(calendar(unary.argument(), context).getYear()));
+            case MonthAst unary -> context.values().createLiteral(BigInteger.valueOf(calendar(unary.argument(), context).getMonth()));
+            case DayAst unary -> context.values().createLiteral(BigInteger.valueOf(calendar(unary.argument(), context).getDay()));
+            case HoursAst unary -> context.values().createLiteral(BigInteger.valueOf(calendar(unary.argument(), context).getHour()));
+            case MinutesAst unary -> context.values().createLiteral(BigInteger.valueOf(calendar(unary.argument(), context).getMinute()));
             case SecondsAst unary -> seconds(calendar(unary.argument(), context), context);
             default -> throw unsupported(expression);
         };
     }
 
     static double numericDouble(DatatypeValue value) {
-        return numericLiteral(value).literal().doubleValue();
+        return numericLiteral(value).doubleValue();
+    }
+
+    static boolean isNumeric(DatatypeValue value) {
+        if (!value.isNumber()) return false;
+        try {
+            numericDouble(value);
+            return true;
+        } catch (QueryTypeErrorException | IllegalArgumentException | IncorrectOperationException failure) {
+            return false;
+        }
     }
 
     private static DatatypeValue arithmetic(
@@ -155,7 +169,7 @@ final class NativeNumericExpressionEvaluator {
 
     private static DatatypeValue stringLength(StrLenAst expression, NativeEvaluationContext context) {
         String text = context.stringLiteral(expression.argument()).getLabel();
-        return context.values().createLiteral(text.codePointCount(0, text.length()));
+        return context.values().createLiteral(BigInteger.valueOf(text.codePointCount(0, text.length())));
     }
 
     private static XMLGregorianCalendar calendar(
@@ -176,8 +190,9 @@ final class NativeNumericExpressionEvaluator {
 
     private static NumericLiteral numericLiteral(DatatypeValue value) {
         if (!(value instanceof Literal literal) || !literal.isNumber()) {
-            throw new QueryEvaluationException("Expected a numeric RDF literal");
+            throw new QueryTypeErrorException("Expected a numeric RDF literal");
         }
+        literal = NativeNumericValues.normalized(literal);
         return new NumericLiteral(literal, NumericKind.of(literal));
     }
 
@@ -201,7 +216,7 @@ final class NativeNumericExpressionEvaluator {
 
         static NumericKind of(Literal literal) {
             if (!(literal.getCoreDatatype() instanceof XSDDatatype datatype)) {
-                throw new QueryEvaluationException("Expected an XML Schema numeric datatype");
+                throw new QueryTypeErrorException("Expected an XML Schema numeric datatype");
             }
             return switch (datatype) {
                 case DOUBLE -> DOUBLE;
@@ -234,7 +249,7 @@ final class NativeNumericExpressionEvaluator {
         }
 
         double doubleValue() {
-            return literal.doubleValue();
+            return kind == NumericKind.FLOAT ? literal.floatValue() : literal.doubleValue();
         }
     }
 
@@ -264,7 +279,10 @@ final class NativeNumericExpressionEvaluator {
         NEAREST {
             @Override
             double apply(double value) {
-                return Math.floor(value + 0.5d);
+                if (!Double.isFinite(value) || value == 0) return value;
+                if (value >= -0.5d && value < 0) return -0.0d;
+                double floor = Math.floor(value);
+                return value - floor >= 0.5d ? floor + 1 : floor;
             }
 
             @Override

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeNumericValues.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeNumericValues.java
@@ -1,0 +1,103 @@
+package fr.inria.corese.core.next.query.impl.sparql.bridge;
+
+import fr.inria.corese.core.next.data.Values;
+
+import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
+import fr.inria.corese.core.next.data.api.term.Literal;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
+/** Validates numeric RDF literals before using their XML Schema values. */
+final class NativeNumericValues {
+    static final Pattern INTEGER = Pattern.compile("[+-]?\\d+");
+    static final Pattern DECIMAL = Pattern.compile("[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)");
+
+    private NativeNumericValues() {}
+
+    static String whitespaceCollapsed(String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && xmlWhitespace(value.charAt(start))) start++;
+        while (end > start && xmlWhitespace(value.charAt(end - 1))) end--;
+        return value.substring(start, end);
+    }
+
+    private static boolean xmlWhitespace(char value) {
+        return value == ' ' || value == '\t' || value == '\r' || value == '\n';
+    }
+
+    static String lexical(Literal literal, Pattern pattern) {
+        String text = whitespaceCollapsed(literal.getLabel());
+        if (!pattern.matcher(text).matches()) {
+            throw new QueryTypeErrorException("Invalid XML Schema numeric lexical form");
+        }
+        return text;
+    }
+
+    static void validate(Literal literal) {
+        if (!literal.isNumber() || !(literal.getCoreDatatype() instanceof XSDDatatype datatype)) {
+            throw new QueryTypeErrorException("Expected an XML Schema numeric literal");
+        }
+        switch (datatype) {
+            case FLOAT, DOUBLE -> floatingLexical(literal);
+            case DECIMAL -> lexical(literal, DECIMAL);
+            default -> validateInteger(new BigInteger(lexical(literal, INTEGER)), datatype);
+        }
+    }
+
+    static Literal normalized(Literal literal) {
+        validate(literal);
+        String lexical = whitespaceCollapsed(literal.getLabel());
+        return lexical.equals(literal.getLabel()) ? literal
+                : Values.factory().createLiteral(lexical, literal.getDatatype());
+    }
+
+    static String floatingLexical(Literal literal) {
+        String text = whitespaceCollapsed(literal.getLabel());
+        validateFloatingLexical(text);
+        return text;
+    }
+
+    private static void validateFloatingLexical(String text) {
+        if (text.equals("INF") || text.equals("-INF") || text.equals("NaN")) return;
+        int exponent = Math.max(text.indexOf('e'), text.indexOf('E'));
+        String mantissa = exponent < 0 ? text : text.substring(0, exponent);
+        boolean validExponent = exponent < 0 || INTEGER.matcher(text.substring(exponent + 1)).matches();
+        if (!validExponent || !DECIMAL.matcher(mantissa).matches()) {
+            throw new QueryTypeErrorException("Invalid XML Schema floating point lexical form");
+        }
+    }
+
+    private static void validateInteger(BigInteger value, XSDDatatype datatype) {
+        boolean valid = switch (datatype) {
+            case BYTE -> value.bitLength() < 8;
+            case SHORT -> value.bitLength() < 16;
+            case INT -> value.bitLength() < 32;
+            case LONG -> value.bitLength() < 64;
+            case UNSIGNED_BYTE -> unsigned(value, 8);
+            case UNSIGNED_SHORT -> unsigned(value, 16);
+            case UNSIGNED_INT -> unsigned(value, 32);
+            case UNSIGNED_LONG -> unsigned(value, 64);
+            case POSITIVE_INTEGER -> value.signum() > 0;
+            case NEGATIVE_INTEGER -> value.signum() < 0;
+            case NON_NEGATIVE_INTEGER -> value.signum() >= 0;
+            case NON_POSITIVE_INTEGER -> value.signum() <= 0;
+            default -> true;
+        };
+        if (!valid) throw new QueryTypeErrorException("Integer value is outside its datatype value space");
+    }
+
+    private static boolean unsigned(BigInteger value, int bits) {
+        return value.signum() >= 0 && value.bitLength() <= bits;
+    }
+
+    static boolean booleanValue(Literal literal) {
+        literal = normalized(literal);
+        if (literal.getCoreDatatype() == XSDDatatype.DOUBLE || literal.getCoreDatatype() == XSDDatatype.FLOAT) {
+            double value = literal.getCoreDatatype() == XSDDatatype.FLOAT ? literal.floatValue() : literal.doubleValue();
+            return value != 0 && !Double.isNaN(value);
+        }
+        return literal.decimalValue().signum() != 0;
+    }
+}

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeStringExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeStringExpressionEvaluator.java
@@ -3,6 +3,7 @@ package fr.inria.corese.core.next.query.impl.sparql.bridge;
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
 import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.BinaryConstraintAst;
@@ -49,8 +50,7 @@ final class NativeStringExpressionEvaluator {
             LiteralExpressionAst expression,
             NativeEvaluationContext context) {
         return switch (expression) {
-            case StrAst unary -> context.values().createLiteral(
-                    context.required(unary.argument()).stringValue());
+            case StrAst unary -> str(context.required(unary.argument()), context);
             case StrAfterAst binary -> after(binary, context);
             case StrBeforeAst binary -> before(binary, context);
             case StrLangAst binary -> stringWithLanguage(binary, context);
@@ -93,14 +93,14 @@ final class NativeStringExpressionEvaluator {
 
     static boolean regex(BinaryRegexAst expression, NativeEvaluationContext context) {
         String value = context.stringLiteral(expression.getString()).getLabel();
-        String pattern = context.stringLiteral(expression.getPattern()).getLabel();
+        String pattern = context.simpleString(expression.getPattern()).getLabel();
         return compilePattern(pattern, "").matcher(value).find();
     }
 
     static boolean regex(TrinaryRegexAst expression, NativeEvaluationContext context) {
         String value = context.stringLiteral(expression.getString()).getLabel();
-        String pattern = context.stringLiteral(expression.getPattern()).getLabel();
-        String flags = context.stringLiteral(expression.getFlags()).getLabel();
+        String pattern = context.simpleString(expression.getPattern()).getLabel();
+        String flags = context.simpleString(expression.getFlags()).getLabel();
         return compilePattern(pattern, flags).matcher(value).find();
     }
 
@@ -118,7 +118,8 @@ final class NativeStringExpressionEvaluator {
             NativeEvaluationContext context) {
         StringOperands operands = stringOperands(expression, context);
         int separator = operands.left().indexOf(operands.right());
-        String result = separator < 0 ? "" : operands.left().substring(0, separator);
+        if (separator < 0) return context.values().createLiteral("");
+        String result = operands.left().substring(0, separator);
         return stringLike(operands.source(), result, context);
     }
 
@@ -127,29 +128,35 @@ final class NativeStringExpressionEvaluator {
             NativeEvaluationContext context) {
         StringOperands operands = stringOperands(expression, context);
         int separator = operands.left().indexOf(operands.right());
-        String result = separator < 0
-                ? ""
-                : operands.left().substring(separator + operands.right().length());
+        if (separator < 0) return context.values().createLiteral("");
+        String result = operands.left().substring(separator + operands.right().length());
         return stringLike(operands.source(), result, context);
     }
 
     private static DatatypeValue stringWithLanguage(
             BinaryConstraintAst expression,
             NativeEvaluationContext context) {
-        String label = context.stringLiteral(expression.getLeftArgument()).getLabel();
-        String language = context.stringLiteral(expression.getRightArgument()).getLabel();
+        String label = context.simpleString(expression.getLeftArgument()).getLabel();
+        String language = context.simpleString(expression.getRightArgument()).getLabel();
         return context.values().createLiteral(label, language);
     }
 
     private static DatatypeValue stringWithDatatype(
             BinaryConstraintAst expression,
             NativeEvaluationContext context) {
-        String label = context.stringLiteral(expression.getLeftArgument()).getLabel();
+        String label = context.simpleString(expression.getLeftArgument()).getLabel();
         DatatypeValue datatype = context.required(expression.getRightArgument());
         if (!datatype.isIRI()) {
-            throw new QueryEvaluationException("STRDT expects an IRI as its second argument");
+            throw new QueryTypeErrorException("STRDT expects an IRI as its second argument");
         }
         return context.values().createLiteral(label, context.values().createIRI(datatype.stringValue()));
+    }
+
+    private static DatatypeValue str(DatatypeValue value, NativeEvaluationContext context) {
+        if (!value.isIRI() && !(value instanceof Literal)) {
+            throw new QueryTypeErrorException("STR expects an IRI or a literal");
+        }
+        return context.values().createLiteral(value.stringValue());
     }
 
     private static DatatypeValue language(TermAst expression, NativeEvaluationContext context) {
@@ -192,15 +199,21 @@ final class NativeStringExpressionEvaluator {
 
     private static DatatypeValue replace(ReplaceAst expression, NativeEvaluationContext context) {
         Literal source = context.stringLiteral(expression.getString());
-        String pattern = context.stringLiteral(expression.getPattern()).getLabel();
-        String replacement = context.stringLiteral(expression.getReplacement()).getLabel();
+        String pattern = context.simpleString(expression.getPattern()).getLabel();
+        String replacement = context.simpleString(expression.getReplacement()).getLabel();
         String flags = expression.hasFlags()
-                ? context.stringLiteral(expression.getFlags()).getLabel()
+                ? context.simpleString(expression.getFlags()).getLabel()
                 : "";
-        String result = compilePattern(pattern, flags)
-                .matcher(source.getLabel())
-                .replaceAll(replacement);
-        return stringLike(source, result, context);
+        Pattern compiled = compilePattern(pattern, flags);
+        if (compiled.matcher("").find()) {
+            throw new QueryTypeErrorException("REPLACE pattern must not match an empty string");
+        }
+        try {
+            String result = compiled.matcher(source.getLabel()).replaceAll(replacement);
+            return stringLike(source, result, context);
+        } catch (IndexOutOfBoundsException invalidGroup) {
+            throw new QueryTypeErrorException("Invalid replacement group", invalidGroup);
+        }
     }
 
     private static DatatypeValue substring(SubstrAst expression, NativeEvaluationContext context) {
@@ -216,48 +229,28 @@ final class NativeStringExpressionEvaluator {
     }
 
     private static String codePointSubstring(String value, double start, Double length) {
-        if (Double.isNaN(start) || start == Double.POSITIVE_INFINITY
-                || (length != null && Double.isNaN(length))) {
-            return "";
-        }
-        int codePointCount = value.codePointCount(0, value.length());
-        long roundedStart = xpathRound(start);
-        long firstPosition = Math.max(1L, roundedStart);
-        long endPosition = length == null
-                ? codePointCount + 1L
-                : saturatedAdd(roundedStart, xpathRound(length));
-        long exclusivePosition = Math.min(codePointCount + 1L, endPosition);
-        if (exclusivePosition <= firstPosition || firstPosition > codePointCount) {
-            return "";
-        }
-        int from = value.offsetByCodePoints(0, Math.toIntExact(firstPosition - 1L));
-        int to = value.offsetByCodePoints(0, Math.toIntExact(exclusivePosition - 1L));
+        double firstPosition = Math.max(1, xpathRound(start));
+        double endPosition = length == null ? Double.POSITIVE_INFINITY : xpathRound(start) + xpathRound(length);
+        if (Double.isNaN(firstPosition) || Double.isNaN(endPosition)) return "";
+        int count = value.codePointCount(0, value.length());
+        double exclusivePosition = Math.min(count + 1.0, endPosition);
+        if (exclusivePosition <= firstPosition || firstPosition > count) return "";
+        int from = value.offsetByCodePoints(0, (int) firstPosition - 1);
+        int to = value.offsetByCodePoints(0, (int) exclusivePosition - 1);
         return value.substring(from, to);
     }
 
-    private static long xpathRound(double value) {
-        if (value == Double.NEGATIVE_INFINITY) {
-            return Long.MIN_VALUE;
-        }
-        if (value == Double.POSITIVE_INFINITY) {
-            return Long.MAX_VALUE;
-        }
-        return (long) Math.floor(value + 0.5d);
-    }
-
-    private static long saturatedAdd(long left, long right) {
-        try {
-            return Math.addExact(left, right);
-        } catch (ArithmeticException overflow) {
-            return right < 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
-        }
+    private static double xpathRound(double value) {
+        if (!Double.isFinite(value) || value == 0) return value;
+        double floor = Math.floor(value);
+        return value - floor >= 0.5 ? floor + 1 : floor;
     }
 
     private static DatatypeValue digest(
             String algorithm,
             TermAst expression,
             NativeEvaluationContext context) {
-        String value = context.stringLiteral(expression).getLabel();
+        String value = context.simpleString(expression).getLabel();
         try {
             MessageDigest digest = MessageDigest.getInstance(algorithm);
             byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
@@ -268,10 +261,31 @@ final class NativeStringExpressionEvaluator {
     }
 
     private static Pattern compilePattern(String expression, String flags) {
-        return Pattern.compile(expression, regexOptions(flags));
+        int options = regexOptions(flags);
+        return Pattern.compile(flags.contains("x") ? removePatternWhitespace(expression) : expression, options);
+    }
+
+    private static String removePatternWhitespace(String expression) {
+        StringBuilder result = new StringBuilder();
+        boolean escaped = false;
+        int brackets = 0;
+        for (int index = 0; index < expression.length(); index++) {
+            char character = expression.charAt(index);
+            if (!escaped) {
+                if (character == '[') brackets++;
+                if (character == ']') brackets--;
+                if (brackets == 0 && " \t\r\n".indexOf(character) >= 0) continue;
+            }
+            result.append(character);
+            escaped = !escaped && character == '\\';
+        }
+        return result.toString();
     }
 
     private static int regexOptions(String flags) {
+        if (!flags.chars().allMatch(flag -> "imsx".indexOf(flag) >= 0)) {
+            throw new QueryTypeErrorException("Invalid regular expression flags");
+        }
         int options = 0;
         if (flags.contains("i")) {
             options |= Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
@@ -282,15 +296,13 @@ final class NativeStringExpressionEvaluator {
         if (flags.contains("s")) {
             options |= Pattern.DOTALL;
         }
-        if (flags.contains("x")) {
-            options |= Pattern.COMMENTS;
-        }
         return options;
     }
 
     private static String encodeForUri(String value) {
         return URLEncoder.encode(value, StandardCharsets.UTF_8)
                 .replace("+", "%20")
+                .replace("*", "%2A")
                 .replace("%7E", "~");
     }
 
@@ -309,7 +321,7 @@ final class NativeStringExpressionEvaluator {
         boolean compatible = rightLanguage == null
                 || leftLanguage != null && leftLanguage.equalsIgnoreCase(rightLanguage);
         if (!compatible) {
-            throw new QueryEvaluationException("String arguments have incompatible language tags");
+            throw new QueryTypeErrorException("String arguments have incompatible language tags");
         }
     }
 

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeTemporalExpressionEvaluator.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeTemporalExpressionEvaluator.java
@@ -1,9 +1,11 @@
 package fr.inria.corese.core.next.query.impl.sparql.bridge;
 
+import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
+
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
 import fr.inria.corese.core.next.data.api.vocabulary.XSD;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 import fr.inria.corese.core.next.query.api.exception.UnsupportedQueryFeatureException;
 import fr.inria.corese.core.next.query.impl.sparql.ast.TermAst;
 import fr.inria.corese.core.next.query.impl.sparql.ast.constraint.NowAst;
@@ -44,10 +46,11 @@ final class NativeTemporalExpressionEvaluator {
 
     static XMLGregorianCalendar calendar(TermAst expression, NativeEvaluationContext context) {
         DatatypeValue value = context.required(expression);
-        if (value instanceof Literal literal) {
+        if (value instanceof Literal literal
+                && literal.getCoreDatatype() == XSDDatatype.DATETIME) {
             return literal.calendarValue();
         }
-        throw new QueryEvaluationException("Date/time function expects a calendar literal");
+        throw new QueryTypeErrorException("Date/time function expects a calendar literal");
     }
 
     static String timezoneLabel(XMLGregorianCalendar calendar) {
@@ -70,17 +73,14 @@ final class NativeTemporalExpressionEvaluator {
             NativeEvaluationContext context) {
         int minutes = calendar.getTimezone();
         if (minutes == DatatypeConstants.FIELD_UNDEFINED) {
-            throw new QueryEvaluationException(
+            throw new QueryTypeErrorException(
                     "TIMEZONE expects a date/time value with a timezone");
         }
         int absoluteMinutes = Math.abs(minutes);
         String sign = minutes < 0 ? "-" : "";
-        String lexical = minutes == 0
-                ? "PT0S"
-                : "%sPT%dH%dM".formatted(
-                        sign,
-                        absoluteMinutes / 60,
-                        absoluteMinutes % 60);
+        String hours = absoluteMinutes >= 60 ? absoluteMinutes / 60 + "H" : "";
+        String remainder = absoluteMinutes % 60 != 0 ? absoluteMinutes % 60 + "M" : "";
+        String lexical = minutes == 0 ? "PT0S" : sign + "PT" + hours + remainder;
         return context.values().createLiteral(lexical, XSD.xsdDayTimeDuration.getIRI());
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeValueComparison.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeValueComparison.java
@@ -3,7 +3,7 @@ package fr.inria.corese.core.next.query.impl.sparql.bridge;
 import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
 import fr.inria.corese.core.next.data.api.model.DatatypeValue;
 import fr.inria.corese.core.next.data.api.term.Literal;
-import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.api.exception.QueryTypeErrorException;
 
 import javax.xml.datatype.DatatypeConstants;
 
@@ -48,7 +48,7 @@ final class NativeValueComparison {
 
     private static int compareFloatingPoint(double left, double right) {
         if (Double.isNaN(left) || Double.isNaN(right)) {
-            throw new QueryEvaluationException("NaN is not order-comparable");
+            throw new QueryTypeErrorException("NaN is not order-comparable");
         }
         if (left < right) {
             return -1;
@@ -71,8 +71,8 @@ final class NativeValueComparison {
         };
     }
 
-    private static QueryEvaluationException incomparable() {
-        return new QueryEvaluationException(
+    private static QueryTypeErrorException incomparable() {
+        return new QueryTypeErrorException(
                 "RDF values are not order-comparable in a SPARQL expression");
     }
 }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/bridge/SparqlTermResolver.java
@@ -139,7 +139,7 @@ public final class SparqlTermResolver {
         return namespace == null ? raw : namespace + unescapePName(raw.substring(colon + 1));
     }
 
-    private String resolveRelativeIri(String iri) {
+    String resolveRelativeIri(String iri) {
         if (IRIUtils.isAbsoluteIRI(baseIri) && !IRIUtils.isAbsoluteIRI(iri)) {
             return IRIUtils.resolveIRIAgainstBase(baseIri, iri);
         }

--- a/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlExpressionBuilder.java
+++ b/src/main/java/fr/inria/corese/core/next/query/impl/sparql/parser/SparqlExpressionBuilder.java
@@ -71,6 +71,7 @@ public final class SparqlExpressionBuilder {
             case IS_IRI -> new IsIriAst(args);
             case IS_BLANK -> new IsBlankAst(args);
             case IS_LITERAL -> new IsLiteralAst(args);
+            case IS_NUMERIC -> new IsNumericAst(args);
             case STR -> new StrAst(args);
             case UCASE -> new UcaseAst(args);
             case LCASE -> new LcaseAst(args);
@@ -506,6 +507,7 @@ public final class SparqlExpressionBuilder {
         if (ctx.IS_URI() != null || ctx.IS_IRI() != null) return createConstraint(ASTConstants.FUNCTION_CALL.IS_IRI, args);
         if (ctx.IS_BLANK() != null) return createConstraint(ASTConstants.FUNCTION_CALL.IS_BLANK, args);
         if (ctx.IS_LITERAL() != null) return createConstraint(ASTConstants.FUNCTION_CALL.IS_LITERAL, args);
+        if (ctx.IS_NUMERIC() != null) return createConstraint(ASTConstants.FUNCTION_CALL.IS_NUMERIC, args);
         if (ctx.MD5() != null) return new Md5Ast(args);
         if (ctx.SHA1() != null) return new Sha1Ast(args);
         if (ctx.SHA256() != null) return new Sha256Ast(args);

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeExpressionErrorTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/bridge/NativeExpressionErrorTest.java
@@ -1,0 +1,34 @@
+package fr.inria.corese.core.next.query.impl.sparql.bridge;
+
+import fr.inria.corese.core.next.query.api.exception.QueryEvaluationException;
+import fr.inria.corese.core.next.query.impl.engine.spi.Environment;
+import fr.inria.corese.core.next.query.impl.engine.spi.Evaluator;
+import fr.inria.corese.core.next.query.impl.sparql.ast.SelectQueryAst;
+import fr.inria.corese.core.next.query.impl.sparql.parser.SparqlParser;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NativeExpressionErrorTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"COALESCE(?x, 1)", "IF(true, ?x, 0)", "?x || true", "?x && false"})
+    void functionalFormsDoNotHideInfrastructureFailures(String expression) {
+        assertFailurePropagates(expression, new QueryEvaluationException("Storage unavailable"));
+        assertFailurePropagates(expression, new IllegalStateException("Invalid runtime state"));
+    }
+
+    private void assertFailurePropagates(String expression, RuntimeException failure) {
+        var environment = mock(Environment.class);
+        when(environment.getNode(anyString())).thenThrow(failure);
+        var query = (SelectQueryAst) new SparqlParser().parse("SELECT (" + expression + " AS ?result) WHERE {}");
+        var term = query.projection().expressionTerms().values().iterator().next();
+        RuntimeException actual = assertThrows(failure.getClass(), () -> NativeExpressionEvaluator.evaluate(
+                term, mock(Evaluator.class), environment, null, null));
+        assertSame(failure, actual);
+    }
+}

--- a/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/ScalarFunctionsTest.java
+++ b/src/test/java/fr/inria/corese/core/next/query/impl/sparql/execution/ScalarFunctionsTest.java
@@ -1,0 +1,151 @@
+package fr.inria.corese.core.next.query.impl.sparql.execution;
+
+import fr.inria.corese.core.next.data.api.literal.XSDDatatype;
+import fr.inria.corese.core.next.data.api.term.Literal;
+import fr.inria.corese.core.next.query.api.result.BindingSet;
+import fr.inria.corese.core.next.storage.impl.memory.MemoryStorageManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Scalar expressions exercised through parsing, evaluation and public result adaptation. */
+class ScalarFunctionsTest {
+    private static final String PREFIX = "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> ";
+
+    @ParameterizedTest
+    @CsvSource({"double,0E1,0", "double,1E0,1", "float,0E1,0", "float,1E0,1"})
+    void decimalCastDoesNotRewriteItsSourceTerm(String type, String lexical, int expected) {
+        var executor = new NextSparqlPipelineExecutor(MemoryStorageManager.builder().build());
+        try (var result = executor.evaluateTuple(PREFIX
+                + "SELECT ?v (xsd:decimal(?v) AS ?decimal) WHERE { VALUES ?v { '"
+                + lexical + "'^^xsd:" + type + " } }")) {
+            var row = result.next();
+            var source = (Literal) row.getValue("v");
+            var converted = (Literal) row.getValue("decimal");
+            assertEquals(lexical, source.getLabel());
+            assertEquals("http://www.w3.org/2001/XMLSchema#" + type, source.getDatatype().stringValue());
+            assertEquals(XSDDatatype.DECIMAL, converted.getCoreDatatype());
+            assertEquals(0, converted.decimalValue().compareTo(java.math.BigDecimal.valueOf(expected)));
+            assertFalse(result.hasNext());
+        }
+    }
+
+    private BindingSet evaluate(String expressions) {
+        var executor = new NextSparqlPipelineExecutor(MemoryStorageManager.builder().build());
+        try (var result = executor.evaluateTuple(PREFIX + "SELECT " + expressions + " WHERE {}")) {
+            assertTrue(result.hasNext());
+            var row = result.next();
+            assertFalse(result.hasNext());
+            return row;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "STRLEN('👪') = 1", "SUBSTR('a👪b', 2, 1) = '👪'",
+            "UCASE('abc') = 'ABC'", "LCASE('ABC') = 'abc'",
+            "STRSTARTS('abc', 'a')", "STRENDS('abc', 'c')", "CONTAINS('abc', 'b')",
+            "STRBEFORE('abc', 'b') = 'a'", "STRAFTER('abc', 'b') = 'c'",
+            "LANG(STRBEFORE('abc'@fr, 'z')) = ''", "LANG(STRAFTER('abc'@fr, 'z')) = ''",
+            "ENCODE_FOR_URI('* ~é') = '%2A%20~%C3%A9'", "CONCAT() = ''",
+            "LANG(CONCAT('a'@fr, 'b'@fr)) = 'fr'", "LANGMATCHES('fr-FR', 'fr')",
+            "REGEX('Abc', '^a', 'i')", "REPLACE('abc', 'b', 'Z') = 'aZc'",
+            "ABS(-2) = 2", "ROUND(-2.5) = -2", "CEIL(-2.5) = -2", "FLOOR(-2.5) = -3",
+            "RAND() >= 0 && RAND() < 1", "NOW() = NOW()",
+            "YEAR(xsd:dateTime('2020-03-04T05:06:07Z')) = 2020",
+            "MONTH(xsd:dateTime('2020-03-04T05:06:07Z')) = 3",
+            "DAY(xsd:dateTime('2020-03-04T05:06:07Z')) = 4",
+            "HOURS(xsd:dateTime('2020-03-04T05:06:07Z')) = 5",
+            "MINUTES(xsd:dateTime('2020-03-04T05:06:07Z')) = 6",
+            "SECONDS(xsd:dateTime('2020-03-04T05:06:07.125Z')) = 7.125",
+            "TZ(xsd:dateTime('2020-03-04T05:06:07')) = ''",
+            "STR(TIMEZONE(xsd:dateTime('2020-03-04T05:06:07-08:00'))) = '-PT8H'",
+            "MD5('abc') = '900150983cd24fb0d6963f7d28e17f72'",
+            "SHA1('abc') = 'a9993e364706816aba3e25717850c26c9cd0d89d'",
+            "STRLEN(SHA256('abc')) = 64", "STRLEN(SHA384('abc')) = 96", "STRLEN(SHA512('abc')) = 128",
+            "ISIRI(UUID())", "STRLEN(STRUUID()) = 36", "UUID() != UUID()", "STRUUID() != STRUUID()",
+            "ISBLANK(BNODE())", "BNODE() != BNODE()", "BNODE('x') = BNODE('x')",
+            "STRDT('1', xsd:integer) = 1", "LANG(STRLANG('abc', 'fr')) = 'fr'",
+            "ISNUMERIC(1)", "!ISNUMERIC('one')", "!ISNUMERIC('bad'^^xsd:integer)",
+            "IF(true, 1, 1/0) = 1", "IF(false, 1/0, 2) = 2", "COALESCE(1/0, ?missing, 3) = 3",
+            "xsd:integer('-2') = -2", "xsd:integer(-2.9) = -2", "xsd:decimal(true) = 1",
+            "xsd:double('1E2') = 100", "xsd:float(false) = 0", "xsd:boolean('false') = false",
+            "xsd:string(true) = 'true'", "xsd:string(1.20) = '1.2'",
+            "xsd:string(1.0E0) = '1'", "xsd:string(1.0E7) = '1.0E7'",
+            "xsd:string(-0.0E0) = '-0'", "xsd:string(ROUND(-0.4E0)) = '-0'",
+            "ROUND(4503599627370497.0E0) = 4503599627370497.0E0",
+            "xsd:boolean(0.000000000000000000000000000000000000000000000000000000000001)",
+            "!ISNUMERIC('128'^^xsd:byte)", "!ISNUMERIC('-1'^^xsd:unsignedInt)",
+            "!ISNUMERIC('0x1.0p1'^^xsd:double)", "!ISNUMERIC('1E2'^^xsd:decimal)",
+            "!('bad'^^xsd:integer)", "!('bad'^^xsd:boolean)",
+            "SUBSTR('abc', '-INF'^^xsd:double, 'INF'^^xsd:double) = ''",
+            "REGEX('#', '#', 'x')", "REGEX('ab', 'a b', 'x')",
+            "xsd:integer(' 12 ') = 12", "ABS(' 12 '^^xsd:integer) = 12",
+            "xsd:boolean(' true '^^xsd:boolean)", "xsd:string(' false '^^xsd:boolean) = 'false'",
+            "xsd:integer(1E23) = 99999999999999991611392"
+    })
+    void evaluatesScalar(String expression) {
+        var value = (Literal) evaluate("(" + expression + " AS ?actual)").getValue("actual");
+        assertNotNull(value, expression);
+        assertTrue(value.booleanValue(), expression);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"xsd:integer('1.5')", "xsd:decimal('1E2')", "xsd:boolean('yes')",
+            "xsd:double('0x1.0p1')", "xsd:dateTime('bad')", "xsd:integer('NaN'^^xsd:double)",
+            "STR(BNODE())", "STRDT('a'@fr, xsd:string)", "STRLANG('a'@fr, 'en')",
+            "STRDT('a', 'not an IRI')", "YEAR('2020-01-01'^^xsd:date)",
+            "TIMEZONE(xsd:dateTime('2020-01-01T00:00:00'))", "REGEX('abc', 'a', 'z')",
+            "CONTAINS('abc', 'a'@fr)", "COALESCE()", "MD5('abc'@en)",
+            "REGEX('abc', 'a'@en)", "REPLACE('abc', 'a*', 'x')", "BNODE(1)",
+            "IRI(1)", "IRI('a'@en)", "ABS('128'^^xsd:byte)"})
+    void typeErrorsLeaveOnlyAliasUnbound(String expression) {
+        var row = evaluate("(7 AS ?valid) (" + expression + " AS ?invalid)");
+        assertEquals(7, ((Literal) row.getValue("valid")).intValue());
+        assertFalse(row.hasBinding("invalid"), expression);
+        assertEquals(9, ((Literal) evaluate("(COALESCE(" + expression + ", 9) AS ?v)").getValue("v")).intValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"STRLEN('abc')", "YEAR(NOW())", "MONTH(NOW())", "DAY(NOW())", "HOURS(NOW())", "MINUTES(NOW())"})
+    void integerFunctionsReturnXsdInteger(String expression) {
+        assertEquals(XSDDatatype.INTEGER, ((Literal) evaluate("(" + expression + " AS ?v)").getValue("v")).getCoreDatatype());
+    }
+
+    @Test
+    void iriResolvesAgainstBaseWithoutExpandingPrefixes() {
+        var executor = new NextSparqlPipelineExecutor(MemoryStorageManager.builder().build());
+        try (var result = executor.evaluateTuple("BASE <http://example.org/> PREFIX ex: <http://other/> SELECT (IRI('relative') AS ?iri) (URI('ex:name') AS ?uri) WHERE {}")) {
+            var row = result.next();
+            assertEquals("http://example.org/relative", row.getValue("iri").stringValue());
+            assertEquals("ex:name", row.getValue("uri").stringValue());
+        }
+    }
+
+    @Test
+    void projectionAliasesJoinOrderAndDoNotLeakAcrossRows() {
+        var executor = new NextSparqlPipelineExecutor(MemoryStorageManager.builder().build());
+        try (var result = executor.evaluateTuple("SELECT (?x + 1 AS ?a) (?a + 1 AS ?b) WHERE { VALUES ?x { 2 1 } } ORDER BY ?a")) {
+            var rows = result.stream().toList();
+            assertEquals(2, rows.size());
+            assertEquals(2, ((Literal) rows.getFirst().getValue("a")).intValue());
+            assertEquals(3, ((Literal) rows.getFirst().getValue("b")).intValue());
+            assertEquals(4, ((Literal) rows.getLast().getValue("b")).intValue());
+        }
+    }
+
+    @Test
+    void labeledBlankNodesAreFreshForEachSolutionAndEvaluation() {
+        var executor = new NextSparqlPipelineExecutor(MemoryStorageManager.builder().build());
+        String query = "SELECT (BNODE('label') AS ?a) (BNODE('label') AS ?b) WHERE { VALUES ?x { 1 2 } }";
+        try (var first = executor.evaluateTuple(query); var second = executor.evaluateTuple(query)) {
+            var rows = first.stream().toList();
+            assertEquals(rows.getFirst().getValue("a"), rows.getFirst().getValue("b"));
+            assertNotEquals(rows.getFirst().getValue("a"), rows.getLast().getValue("a"));
+            assertNotEquals(rows.getFirst().getValue("a"), second.next().getValue("a"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #563 in the native `core.next.query` pipeline: SPARQL scalar built-ins, XML Schema constructors and SPARQL expression type-error handling.

- Enable scalar SELECT expressions through the existing AST/compiler and KGRAM projection machinery; aggregate projections remain explicitly unsupported.
- Implement the seven standard XML Schema casts and ISNUMERIC, validate numeric lexical forms/value spaces, preserve source RDF terms and handle exact integer truncation, signed zero and canonical numeric-to-string casts.
- Complete string/language, Unicode substring, URI, BNODE scoping, date/time, numeric and hash behavior. Accept empty CONCAT/COALESCE argument lists in the existing ANTLR grammar; no parser dependency is added.
- Distinguish absorbable SPARQL type errors from engine/infrastructure failures in FILTER, BIND, projection, IF, COALESCE and boolean expressions.
- Add 118 regression cases, including source-term preservation for all four disputed upstream cast-decimal bindings.

## Validation

- `./gradlew test`: **2,934 tests, zero failures/errors/skips**.
- SonarLint: **20/20 changed Java files analyzed, zero diagnostics**.
- Full sibling W3C run: all 73 harness unit tests pass; all active non-SPARQL suites pass. EARL parsing, 15 validation queries and JSON/EARL coverage checks pass.
- Same 978 official SPARQL test identifiers compared against the pre-#563 baseline: **644 → 738 passed (+94), zero regressions, no missing tests** with the companion harness fix. Core-only with the unchanged harness gives 730 passes.
- SPARQL 1.0: 398 → 415/483. SPARQL 1.1: 246 → 323/495.
- `functions`: **75/75 pass**. Cast evaluation: **5 pass + 1 indeterminate**; all seven cast syntax tests also pass.

The 239 remaining SPARQL failures are pre-existing cases outside this issue. The additional indeterminate case is not claimed as passing: upstream `cast-decimal.srx` rewrites four directly projected source literals. The companion harness PR continues executing it, recognizes only that exact discrepancy and preserves the original JUnit failure. No official fixture is changed and no core behavior is tailored to its erroneous expected source terms.

## Integration order

Merge this PR into **feature/corese-next first**, then merge **corese-stack/corese-w3c#27**. The harness uses the existing native parser only to identify computed numeric projections; numeric value comparison remains independent of Corese's numeric implementation. Its scoped comparison is justified by the [upstream discussion](https://github.com/w3c/rdf-tests/issues/58#issuecomment-493670079), without relaxing directly projected RDF-term identity.
